### PR TITLE
feat(gateway): Telegram sticker cache with vision analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "axum",
+ "base64",
  "chrono",
  "ed25519-dalek",
  "futures-util",

--- a/crates/genesis-gateway/Cargo.toml
+++ b/crates/genesis-gateway/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [dependencies]
 async-stream.workspace = true
 axum.workspace = true
+base64.workspace = true
 chrono.workspace = true
 genesis-config = { path = "../genesis-config" }
 genesis-core = { path = "../genesis-core" }

--- a/crates/genesis-gateway/src/platforms/telegram.rs
+++ b/crates/genesis-gateway/src/platforms/telegram.rs
@@ -10,16 +10,18 @@
 //! 4. Register the webhook URL: `POST https://api.telegram.org/bot<TOKEN>/setWebhook`
 //!    with `{"url": "https://your-server/telegram/webhook"}`
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
+use base64::Engine;
 use genesis_core::execution::{SessionExecutionService, SessionTurnInput};
-use genesis_storage::SessionStore;
+use genesis_storage::{SessionStore, StickerCacheStore};
 use genesis_types::DeliveryPlatform;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info, info_span, warn, Instrument};
+use tracing::{debug, error, info, info_span, warn, Instrument};
 
 use crate::verify::verify_telegram_webhook_secret;
 use crate::AppState;
@@ -53,6 +55,8 @@ pub struct TelegramMessage {
     pub audio: Option<TelegramAudio>,
     /// Photo attachments (array of sizes, largest last).
     pub photo: Option<Vec<TelegramPhoto>>,
+    /// Sticker message.
+    pub sticker: Option<TelegramSticker>,
     /// Caption for photo/audio/voice messages.
     pub caption: Option<String>,
 }
@@ -75,6 +79,18 @@ pub struct TelegramPhoto {
     pub file_id: String,
     pub width: i64,
     pub height: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TelegramSticker {
+    pub file_id: String,
+    pub file_unique_id: String,
+    #[serde(default)]
+    pub is_animated: bool,
+    #[serde(default)]
+    pub is_video: bool,
+    pub emoji: Option<String>,
+    pub set_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -223,6 +239,185 @@ async fn transcribe_telegram_audio(client: &reqwest::Client, token: &str, file_i
     Ok(result.text)
 }
 
+// --- Sticker analysis helpers ---
+
+/// Build a context string for a sticker message.
+///
+/// For static (non-animated, non-video) stickers, downloads the image and
+/// analyzes it with a vision LLM, caching the result. For animated/video
+/// stickers, returns emoji-based context only since they can't be analyzed
+/// as static images.
+async fn resolve_sticker_prompt(
+    sticker: &TelegramSticker,
+    client: &reqwest::Client,
+    token: &str,
+    config: &genesis_config::GenesisConfig,
+) -> String {
+    let emoji = sticker.emoji.as_deref().unwrap_or("");
+    let set_name = sticker.set_name.as_deref().unwrap_or("unknown");
+
+    // Animated and video stickers can't be analyzed as static images.
+    if sticker.is_animated || sticker.is_video {
+        return format!(
+            "[The user sent an animated sticker {emoji} from \"{set_name}\". \
+             Animated stickers cannot be visually analyzed.]"
+        );
+    }
+
+    // Check the cache first.
+    let cache = StickerCacheStore::new(&config.storage.database_path);
+    match cache.get(&sticker.file_unique_id) {
+        Ok(Some(cached)) => {
+            debug!(
+                file_unique_id = sticker.file_unique_id.as_str(),
+                "sticker cache hit"
+            );
+            return format_sticker_context(&cached.emoji, &cached.sticker_set, &cached.description);
+        }
+        Ok(None) => {}
+        Err(e) => {
+            warn!(error = %e, "sticker cache lookup failed, proceeding with analysis");
+        }
+    }
+
+    // Download and analyze the sticker via vision LLM.
+    match analyze_sticker_image(client, token, &sticker.file_id, config).await {
+        Ok(description) => {
+            info!(
+                file_unique_id = sticker.file_unique_id.as_str(),
+                "sticker analyzed via vision"
+            );
+            // Cache the result.
+            if let Err(e) = cache.set(&sticker.file_unique_id, &description, emoji, set_name) {
+                warn!(error = %e, "failed to cache sticker description");
+            }
+            format_sticker_context(emoji, set_name, &description)
+        }
+        Err(e) => {
+            warn!(error = %e, "sticker vision analysis failed, using emoji fallback");
+            format!(
+                "[The user sent a sticker {emoji} from \"{set_name}\". \
+                 Vision analysis failed: {e}]"
+            )
+        }
+    }
+}
+
+/// Format a sticker context string for the agent prompt.
+fn format_sticker_context(emoji: &str, set_name: &str, description: &str) -> String {
+    format!(
+        "[The user sent a sticker {emoji} from \"{set_name}\". It shows: \"{description}\"]"
+    )
+}
+
+/// Download a sticker image from Telegram and analyze it with a vision LLM.
+async fn analyze_sticker_image(
+    client: &reqwest::Client,
+    token: &str,
+    file_id: &str,
+    config: &genesis_config::GenesisConfig,
+) -> Result<String, String> {
+    // Step 1: Get the file path from Telegram.
+    let get_file_url = format!("https://api.telegram.org/bot{token}/getFile");
+    let resp = client
+        .post(&get_file_url)
+        .json(&serde_json::json!({ "file_id": file_id }))
+        .send()
+        .await
+        .map_err(|e| format!("getFile request failed: {e}"))?;
+
+    let file_resp: GetFileResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("failed to parse getFile response: {e}"))?;
+
+    if !file_resp.ok {
+        return Err("Telegram getFile returned not ok".to_owned());
+    }
+
+    let file_path = file_resp
+        .result
+        .and_then(|r| r.file_path)
+        .ok_or_else(|| "no file_path in getFile response".to_owned())?;
+
+    // Step 2: Download the sticker image.
+    let download_url = format!("https://api.telegram.org/file/bot{token}/{file_path}");
+    let image_bytes = client
+        .get(&download_url)
+        .send()
+        .await
+        .map_err(|e| format!("sticker download failed: {e}"))?
+        .bytes()
+        .await
+        .map_err(|e| format!("failed to read sticker bytes: {e}"))?;
+
+    if image_bytes.is_empty() {
+        return Err("downloaded sticker file is empty".to_owned());
+    }
+
+    // Determine MIME type from file extension.
+    let ext = file_path.rsplit('.').next().unwrap_or("webp");
+    let mime = match ext {
+        "webp" => "image/webp",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        _ => "image/webp", // Telegram stickers are typically WebP
+    };
+
+    // Step 3: Encode as base64 data URI.
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&image_bytes);
+    let data_uri = format!("data:{mime};base64,{b64}");
+
+    // Step 4: Call the vision LLM.
+    let env: BTreeMap<String, String> = std::env::vars().collect();
+    let provider = genesis_provider::resolve(
+        &config.provider.backend,
+        &config.provider.model,
+        config.provider.base_url.as_deref(),
+        config.provider.api_key_env.as_deref(),
+        &env,
+    );
+
+    let vision_client = genesis_provider::ChatClient::new(&provider)
+        .map_err(|e| format!("failed to create vision client: {e}"))?;
+
+    let request = genesis_provider::ChatCompletionRequest {
+        model: String::new(), // ChatClient fills this from its config
+        messages: vec![genesis_provider::ChatMessage::user_with_images(
+            "Describe this sticker in 1-2 sentences. Focus on what it depicts — \
+             character, action, emotion, and any text visible in the image.",
+            vec![genesis_provider::ImageUrl {
+                url: data_uri,
+                detail: Some("low".to_owned()),
+            }],
+        )],
+        tools: Vec::new(),
+        temperature: Some(0.2),
+        max_tokens: Some(150),
+        stream: None,
+        stream_options: None,
+        response_format: None,
+        tool_choice: None,
+        thinking: None,
+        extra_body: config.provider.extra_body.clone(),
+    };
+
+    let response = vision_client
+        .complete(request)
+        .await
+        .map_err(|e| format!("vision LLM call failed: {e}"))?;
+
+    let description = response
+        .choices
+        .first()
+        .and_then(|c| c.message.content.as_ref())
+        .and_then(|c| c.text())
+        .map(|t| t.trim().to_owned())
+        .ok_or_else(|| "vision LLM returned empty response".to_owned())?;
+
+    Ok(description)
+}
+
 // --- Handler ---
 
 /// Webhook handler for Telegram updates.
@@ -266,10 +461,13 @@ pub async fn webhook_handler(
         Text(String),
         Voice { file_id: String, duration: i64 },
         Audio { file_id: String, duration: i64, file_name: String },
+        Sticker(TelegramSticker),
     }
 
     let input = if let Some(t) = message.text.filter(|t| !t.is_empty()) {
         MessageInput::Text(t)
+    } else if let Some(sticker) = message.sticker {
+        MessageInput::Sticker(sticker)
     } else if let Some(photos) = &message.photo {
         let best = photos.last();
         let caption = message.caption.as_deref().unwrap_or("");
@@ -429,6 +627,15 @@ pub async fn webhook_handler(
                             )
                         }
                     }
+                }
+                MessageInput::Sticker(sticker) => {
+                    resolve_sticker_prompt(
+                        &sticker,
+                        &state.http_client,
+                        &token,
+                        &state.loaded.config,
+                    )
+                    .await
                 }
             };
 
@@ -732,5 +939,137 @@ mod tests {
         let json = r#"{"text": "Hello world, this is a test."}"#;
         let resp: WhisperResponse = serde_json::from_str(json).expect("should parse");
         assert_eq!(resp.text, "Hello world, this is a test.");
+    }
+
+    #[test]
+    fn telegram_sticker_message_deserializes() {
+        let json = r#"{
+            "update_id": 200,
+            "message": {
+                "message_id": 10,
+                "chat": {"id": 42, "type": "private"},
+                "from": {"id": 100, "first_name": "Cole"},
+                "sticker": {
+                    "file_id": "CAACAgIAAxkBAAIBe2abc",
+                    "file_unique_id": "AgADuQAD1234",
+                    "is_animated": false,
+                    "is_video": false,
+                    "emoji": "😀",
+                    "set_name": "TestPack"
+                }
+            }
+        }"#;
+        let update: TelegramUpdate = serde_json::from_str(json).expect("should parse");
+        let msg = update.message.expect("should have message");
+        let sticker = msg.sticker.expect("should have sticker");
+        assert_eq!(sticker.file_id, "CAACAgIAAxkBAAIBe2abc");
+        assert_eq!(sticker.file_unique_id, "AgADuQAD1234");
+        assert!(!sticker.is_animated);
+        assert!(!sticker.is_video);
+        assert_eq!(sticker.emoji.as_deref(), Some("😀"));
+        assert_eq!(sticker.set_name.as_deref(), Some("TestPack"));
+    }
+
+    #[test]
+    fn telegram_animated_sticker_deserializes() {
+        let json = r#"{
+            "update_id": 201,
+            "message": {
+                "message_id": 11,
+                "chat": {"id": 42, "type": "private"},
+                "sticker": {
+                    "file_id": "CAACAgIAAxkBAAIBe2xyz",
+                    "file_unique_id": "AgADuQAD5678",
+                    "is_animated": true,
+                    "is_video": false,
+                    "emoji": "🎉",
+                    "set_name": "AnimatedPack"
+                }
+            }
+        }"#;
+        let update: TelegramUpdate = serde_json::from_str(json).expect("should parse");
+        let msg = update.message.expect("should have message");
+        let sticker = msg.sticker.expect("should have sticker");
+        assert!(sticker.is_animated);
+        assert_eq!(sticker.set_name.as_deref(), Some("AnimatedPack"));
+    }
+
+    #[test]
+    fn telegram_video_sticker_deserializes() {
+        let json = r#"{
+            "update_id": 202,
+            "message": {
+                "message_id": 12,
+                "chat": {"id": 42, "type": "private"},
+                "sticker": {
+                    "file_id": "CAACAgIvideo",
+                    "file_unique_id": "AgADvideo",
+                    "is_animated": false,
+                    "is_video": true
+                }
+            }
+        }"#;
+        let update: TelegramUpdate = serde_json::from_str(json).expect("should parse");
+        let msg = update.message.expect("should have message");
+        let sticker = msg.sticker.expect("should have sticker");
+        assert!(sticker.is_video);
+        assert!(sticker.emoji.is_none());
+        assert!(sticker.set_name.is_none());
+    }
+
+    #[test]
+    fn sticker_fields_extracted() {
+        let sticker = TelegramSticker {
+            file_id: "CAACAgIAAxkBAAIBe2abc".to_owned(),
+            file_unique_id: "AgADuQAD1234".to_owned(),
+            is_animated: false,
+            is_video: false,
+            emoji: Some("😺".to_owned()),
+            set_name: Some("CatPack".to_owned()),
+        };
+        assert_eq!(sticker.file_id, "CAACAgIAAxkBAAIBe2abc");
+        assert_eq!(sticker.file_unique_id, "AgADuQAD1234");
+        assert!(!sticker.is_animated);
+        assert!(!sticker.is_video);
+        assert_eq!(sticker.emoji.as_deref(), Some("😺"));
+        assert_eq!(sticker.set_name.as_deref(), Some("CatPack"));
+    }
+
+    #[test]
+    fn format_sticker_context_produces_expected_output() {
+        let result = format_sticker_context("😀", "MyPack", "A cat waving");
+        assert_eq!(
+            result,
+            "[The user sent a sticker 😀 from \"MyPack\". It shows: \"A cat waving\"]"
+        );
+    }
+
+    #[test]
+    fn format_sticker_context_handles_empty_emoji() {
+        let result = format_sticker_context("", "StickerSet", "A dog sleeping");
+        assert_eq!(
+            result,
+            "[The user sent a sticker  from \"StickerSet\". It shows: \"A dog sleeping\"]"
+        );
+    }
+
+    #[test]
+    fn sticker_cache_integration_with_format() {
+        // Test that cached sticker data produces the right context string.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        genesis_storage::bootstrap(&db_path).expect("bootstrap");
+
+        let cache = StickerCacheStore::new(&db_path);
+        cache
+            .set("unique-123", "A happy frog jumping", "🐸", "FrogPack")
+            .expect("cache set");
+
+        let cached = cache.get("unique-123").unwrap().unwrap();
+        let context = format_sticker_context(&cached.emoji, &cached.sticker_set, &cached.description);
+        assert_eq!(
+            context,
+            "[The user sent a sticker 🐸 from \"FrogPack\". It shows: \"A happy frog jumping\"]"
+        );
     }
 }

--- a/crates/genesis-storage/src/lib.rs
+++ b/crates/genesis-storage/src/lib.rs
@@ -5,7 +5,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-pub const SCHEMA_VERSION: i64 = 7;
+pub const SCHEMA_VERSION: i64 = 8;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StorageBootstrap {
@@ -497,6 +497,13 @@ pub fn bootstrap(database_path: &Path) -> Result<StorageBootstrap, StorageError>
                 ON audit_log(event_type);
             CREATE INDEX IF NOT EXISTS idx_audit_log_created_at
                 ON audit_log(created_at);
+            CREATE TABLE IF NOT EXISTS sticker_cache (
+                file_unique_id TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                emoji TEXT NOT NULL DEFAULT '',
+                sticker_set TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
             ",
         )
         .map_err(|source| StorageError::Sqlite {
@@ -4151,6 +4158,193 @@ impl ResponseCacheStore {
                 source,
             })?;
         Ok((entries, hits))
+    }
+}
+
+/// Cached sticker description from vision analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedSticker {
+    pub file_unique_id: String,
+    pub description: String,
+    pub emoji: String,
+    pub sticker_set: String,
+    pub created_at: String,
+}
+
+/// Persistent cache for Telegram sticker descriptions.
+///
+/// Keyed by `file_unique_id` (stable across messages, unlike `file_id`).
+/// Stores vision-analyzed descriptions to avoid re-analyzing the same sticker.
+pub struct StickerCacheStore {
+    database_path: PathBuf,
+}
+
+impl StickerCacheStore {
+    pub fn new(database_path: &Path) -> Self {
+        Self {
+            database_path: database_path.to_path_buf(),
+        }
+    }
+
+    /// Look up a cached sticker description by its unique file ID.
+    pub fn get(&self, file_unique_id: &str) -> Result<Option<CachedSticker>, StorageError> {
+        let connection = open(&self.database_path)?;
+        connection
+            .query_row(
+                "SELECT file_unique_id, description, emoji, sticker_set, created_at
+                 FROM sticker_cache WHERE file_unique_id = ?1",
+                params![file_unique_id],
+                |row| {
+                    Ok(CachedSticker {
+                        file_unique_id: row.get(0)?,
+                        description: row.get(1)?,
+                        emoji: row.get(2)?,
+                        sticker_set: row.get(3)?,
+                        created_at: row.get(4)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })
+    }
+
+    /// Store a sticker description in the cache.
+    pub fn set(
+        &self,
+        file_unique_id: &str,
+        description: &str,
+        emoji: &str,
+        sticker_set: &str,
+    ) -> Result<(), StorageError> {
+        let connection = open(&self.database_path)?;
+        connection
+            .execute(
+                "INSERT OR REPLACE INTO sticker_cache
+                 (file_unique_id, description, emoji, sticker_set, created_at)
+                 VALUES (?1, ?2, ?3, ?4, datetime('now'))",
+                params![file_unique_id, description, emoji, sticker_set],
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+        Ok(())
+    }
+
+    /// Delete a cached sticker entry.
+    pub fn delete(&self, file_unique_id: &str) -> Result<bool, StorageError> {
+        let connection = open(&self.database_path)?;
+        let deleted = connection
+            .execute(
+                "DELETE FROM sticker_cache WHERE file_unique_id = ?1",
+                params![file_unique_id],
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+        Ok(deleted > 0)
+    }
+
+    /// Return the total number of cached sticker entries.
+    pub fn count(&self) -> Result<u64, StorageError> {
+        let connection = open(&self.database_path)?;
+        let count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM sticker_cache", [], |row| row.get(0))
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+        Ok(count as u64)
+    }
+}
+
+#[cfg(test)]
+mod sticker_cache_tests {
+    use super::{bootstrap, StickerCacheStore};
+    use tempfile::tempdir;
+
+    #[test]
+    fn sticker_cache_stores_and_retrieves_description() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).unwrap();
+
+        let store = StickerCacheStore::new(&db_path);
+        store
+            .set("unique-abc", "A cat waving hello", "😺", "CatPack")
+            .expect("set should succeed");
+
+        let entry = store
+            .get("unique-abc")
+            .expect("get should succeed")
+            .expect("entry should exist");
+
+        assert_eq!(entry.file_unique_id, "unique-abc");
+        assert_eq!(entry.description, "A cat waving hello");
+        assert_eq!(entry.emoji, "😺");
+        assert_eq!(entry.sticker_set, "CatPack");
+        assert!(!entry.created_at.is_empty());
+    }
+
+    #[test]
+    fn sticker_cache_returns_none_for_missing_entry() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).unwrap();
+
+        let store = StickerCacheStore::new(&db_path);
+        let entry = store.get("nonexistent").expect("get should succeed");
+        assert!(entry.is_none());
+    }
+
+    #[test]
+    fn sticker_cache_upserts_on_conflict() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).unwrap();
+
+        let store = StickerCacheStore::new(&db_path);
+        store
+            .set("unique-1", "A dog barking", "🐕", "DogPack")
+            .expect("first set");
+        store
+            .set("unique-1", "A dog sleeping", "🐕", "DogPack")
+            .expect("second set (upsert)");
+
+        let entry = store.get("unique-1").unwrap().unwrap();
+        assert_eq!(entry.description, "A dog sleeping");
+    }
+
+    #[test]
+    fn sticker_cache_delete_removes_entry() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).unwrap();
+
+        let store = StickerCacheStore::new(&db_path);
+        store.set("del-1", "A bird flying", "🐦", "BirdPack").unwrap();
+
+        assert!(store.delete("del-1").unwrap());
+        assert!(store.get("del-1").unwrap().is_none());
+        assert!(!store.delete("del-1").unwrap()); // already deleted
+    }
+
+    #[test]
+    fn sticker_cache_count_tracks_entries() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).unwrap();
+
+        let store = StickerCacheStore::new(&db_path);
+        assert_eq!(store.count().unwrap(), 0);
+
+        store.set("c-1", "Sticker 1", "😀", "Pack1").unwrap();
+        store.set("c-2", "Sticker 2", "😎", "Pack2").unwrap();
+        assert_eq!(store.count().unwrap(), 2);
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds persistent SQLite cache for Telegram sticker descriptions, keyed by `file_unique_id` (stable across messages)
- Static stickers are downloaded, encoded as base64, and analyzed via the configured vision LLM with the prompt: *"Describe this sticker in 1-2 sentences. Focus on what it depicts — character, action, emotion, and any text visible in the image."*
- Cached descriptions are reused on subsequent encounters to avoid redundant LLM calls
- Animated/video stickers fall back to emoji-based context since they cannot be analyzed as static images
- Sticker context is injected into the agent prompt like: `[The user sent a sticker 😀 from "MyPack". It shows: "A cat waving"]`

### Changes
- **genesis-storage**: `StickerCacheStore` (get/set/delete/count), `CachedSticker` struct, `sticker_cache` table in schema bootstrap (v7 → v8)
- **genesis-gateway**: `TelegramSticker` type, `Sticker` variant in `MessageInput`, `resolve_sticker_prompt()` / `analyze_sticker_image()` / `format_sticker_context()` helpers, `base64` dependency added
- **12 new tests**: 5 in genesis-storage (CRUD, upsert, count), 7 in genesis-gateway (deserialization, format output, cache integration)

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (1600 tests, 0 failures)
- [ ] Manual test: send a static sticker to the Telegram bot, verify vision analysis and caching
- [ ] Manual test: send an animated sticker, verify emoji-only fallback
- [ ] Manual test: re-send the same sticker, verify cache hit (no LLM call)

Closes #18