### PR TITLE
fix: resolve medium-severity audit findings

### DIFF
--- a/crates/genesis-mcp/src/client.rs
+++ b/crates/genesis-mcp/src/client.rs
@@ -272,12 +272,16 @@ impl McpClient {
         &self.tools
     }
 
-    /// Convert MCP tools to Genesis ToolDefinitions, prefixed with `mcp_{server_name}_`.
+    /// Convert MCP tools to Genesis ToolDefinitions, prefixed with `mcp_{server_name}__`.
+    ///
+    /// Uses a double-underscore separator between the server name and tool name
+    /// so that server names containing underscores (e.g. `my_server`) can be
+    /// unambiguously parsed back from the prefixed form.
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
         self.tools
             .iter()
             .map(|t| ToolDefinition {
-                name: format!("mcp_{}_{}", self.name, t.name),
+                name: format!("mcp_{}__{}", self.name, t.name),
                 description: t
                     .description
                     .clone()
@@ -452,14 +456,14 @@ mod tests {
         let defs: Vec<ToolDefinition> = tools
             .iter()
             .map(|t| ToolDefinition {
-                name: format!("mcp_{server_name}_{}", t.name),
+                name: format!("mcp_{server_name}__{}", t.name),
                 description: t.description.clone().unwrap_or_default(),
                 parameters: t.input_schema.clone(),
             })
             .collect();
 
         assert_eq!(defs.len(), 1);
-        assert_eq!(defs[0].name, "mcp_filesystem_read_file");
+        assert_eq!(defs[0].name, "mcp_filesystem__read_file");
         assert_eq!(defs[0].description, "Read a file");
         assert!(defs[0].parameters.is_some());
     }

--- a/crates/genesis-mcp/src/lib.rs
+++ b/crates/genesis-mcp/src/lib.rs
@@ -127,7 +127,7 @@ impl McpManager {
 
     /// Returns all tool definitions from all connected servers.
     ///
-    /// Tools are prefixed with `mcp_{server_name}_` to avoid naming collisions.
+    /// Tools are prefixed with `mcp_{server_name}__` to avoid naming collisions.
     pub async fn tool_definitions(&self) -> Vec<ToolDefinition> {
         let clients = self.clients.read().await;
         clients
@@ -136,7 +136,7 @@ impl McpManager {
             .collect()
     }
 
-    /// Call a tool by its prefixed name (e.g., `mcp_filesystem_read_file`).
+    /// Call a tool by its prefixed name (e.g., `mcp_filesystem__read_file`).
     ///
     /// Parses the prefix to route to the correct server. If the call fails
     /// with a transport error, attempts to reconnect and retry once.
@@ -323,19 +323,23 @@ impl McpManager {
     }
 }
 
-/// Parse a prefixed tool name like `mcp_filesystem_read_file` into
+/// Parse a prefixed tool name like `mcp_filesystem__read_file` into
 /// `("filesystem", "read_file")`.
+///
+/// Uses a double-underscore (`__`) separator between the server name and
+/// tool name so that server names containing underscores (e.g. `my_server`)
+/// are parsed unambiguously.
 fn parse_mcp_tool_name(prefixed: &str) -> Result<(&str, &str), McpError> {
     let rest = prefixed
         .strip_prefix("mcp_")
         .ok_or_else(|| McpError::UnknownTool(prefixed.to_owned()))?;
 
-    let underscore_pos = rest
-        .find('_')
+    let sep_pos = rest
+        .find("__")
         .ok_or_else(|| McpError::UnknownTool(prefixed.to_owned()))?;
 
-    let server_name = &rest[..underscore_pos];
-    let tool_name = &rest[underscore_pos + 1..];
+    let server_name = &rest[..sep_pos];
+    let tool_name = &rest[sep_pos + 2..];
 
     if server_name.is_empty() || tool_name.is_empty() {
         return Err(McpError::UnknownTool(prefixed.to_owned()));
@@ -387,16 +391,23 @@ mod tests {
 
     #[test]
     fn parse_tool_name_valid() {
-        let (server, tool) = parse_mcp_tool_name("mcp_filesystem_read_file").unwrap();
+        let (server, tool) = parse_mcp_tool_name("mcp_filesystem__read_file").unwrap();
         assert_eq!(server, "filesystem");
         assert_eq!(tool, "read_file");
     }
 
     #[test]
     fn parse_tool_name_with_underscores_in_tool() {
-        let (server, tool) = parse_mcp_tool_name("mcp_github_create_pull_request").unwrap();
+        let (server, tool) = parse_mcp_tool_name("mcp_github__create_pull_request").unwrap();
         assert_eq!(server, "github");
         assert_eq!(tool, "create_pull_request");
+    }
+
+    #[test]
+    fn parse_tool_name_with_underscores_in_server() {
+        let (server, tool) = parse_mcp_tool_name("mcp_my_server__read_file").unwrap();
+        assert_eq!(server, "my_server");
+        assert_eq!(tool, "read_file");
     }
 
     #[test]
@@ -405,9 +416,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_tool_name_no_double_underscore() {
+        // Single underscore should fail now
+        assert!(parse_mcp_tool_name("mcp_filesystem_read_file").is_err());
+    }
+
+    #[test]
     fn parse_tool_name_empty_parts() {
         assert!(parse_mcp_tool_name("mcp_").is_err());
-        assert!(parse_mcp_tool_name("mcp__tool").is_err());
+        assert!(parse_mcp_tool_name("mcp___tool").is_err()); // empty server name
+        assert!(parse_mcp_tool_name("mcp_server__").is_err()); // empty tool name
     }
 
     #[test]
@@ -511,7 +529,7 @@ mod tests {
     #[tokio::test]
     async fn manager_call_unknown_tool_errors() {
         let manager = McpManager::connect_all(vec![]).await;
-        let result = manager.call_tool("mcp_nonexistent_tool", None).await;
+        let result = manager.call_tool("mcp_nonexistent__tool", None).await;
         assert!(result.is_err());
     }
 

--- a/crates/genesis-storage/src/lib.rs
+++ b/crates/genesis-storage/src/lib.rs
@@ -516,6 +516,9 @@ pub fn bootstrap(database_path: &Path) -> Result<StorageBootstrap, StorageError>
     migrate_to_v3(&connection, database_path)?;
     migrate_to_v4(&connection, database_path)?;
     migrate_to_v5(&connection, database_path)?;
+    migrate_to_v6(&connection, database_path)?;
+    migrate_to_v7(&connection, database_path)?;
+    migrate_to_v8(&connection, database_path)?;
 
     connection
         .execute(
@@ -618,6 +621,85 @@ fn migrate_to_v5(connection: &Connection, database_path: &Path) -> Result<(), St
         .execute_batch(
             "ALTER TABLE messages ADD COLUMN mirror INTEGER NOT NULL DEFAULT 0;
              ALTER TABLE messages ADD COLUMN mirror_source TEXT;",
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: database_path.to_path_buf(),
+            source,
+        })?;
+
+    Ok(())
+}
+
+/// Migrate v5 → v6: add response_cache and audit_log tables.
+fn migrate_to_v6(connection: &Connection, database_path: &Path) -> Result<(), StorageError> {
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS response_cache (
+                cache_key TEXT PRIMARY KEY,
+                model TEXT NOT NULL,
+                response TEXT NOT NULL,
+                tool_calls_json TEXT,
+                input_tokens INTEGER NOT NULL DEFAULT 0,
+                output_tokens INTEGER NOT NULL DEFAULT 0,
+                hit_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                expires_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                event_type TEXT NOT NULL,
+                details TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_log_session
+                ON audit_log(session_id);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_event_type
+                ON audit_log(event_type);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_created_at
+                ON audit_log(created_at);",
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: database_path.to_path_buf(),
+            source,
+        })?;
+
+    Ok(())
+}
+
+/// Migrate v6 → v7: add channels table for platform channel caching.
+fn migrate_to_v7(connection: &Connection, database_path: &Path) -> Result<(), StorageError> {
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS channels (
+                platform TEXT NOT NULL,
+                channel_id TEXT NOT NULL,
+                channel_name TEXT NOT NULL,
+                channel_type TEXT NOT NULL DEFAULT 'channel',
+                is_member INTEGER NOT NULL DEFAULT 0,
+                cached_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (platform, channel_id)
+            );",
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: database_path.to_path_buf(),
+            source,
+        })?;
+
+    Ok(())
+}
+
+/// Migrate v7 → v8: add sticker_cache table for Telegram sticker descriptions.
+fn migrate_to_v8(connection: &Connection, database_path: &Path) -> Result<(), StorageError> {
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS sticker_cache (
+                file_unique_id TEXT PRIMARY KEY,
+                description TEXT NOT NULL,
+                emoji TEXT NOT NULL DEFAULT '',
+                sticker_set TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );",
         )
         .map_err(|source| StorageError::Sqlite {
             path: database_path.to_path_buf(),
@@ -4351,8 +4433,9 @@ mod sticker_cache_tests {
 #[cfg(test)]
 mod tests {
     use super::{
-        bootstrap, discover_legacy_source, inspect, latest_import_run, record_import_run,
-        ImportStatus, LegacyImportSource, SessionStore, SCHEMA_VERSION,
+        bootstrap, discover_legacy_source, inspect, latest_import_run, migrate_to_v6,
+        migrate_to_v7, migrate_to_v8, open, record_import_run, ImportStatus, LegacyImportSource,
+        SessionStore, SCHEMA_VERSION,
     };
     use std::fs;
     use tempfile::tempdir;
@@ -5655,5 +5738,88 @@ mod tests {
         assert_eq!(analytics[0].call_count, 2);
         assert_eq!(analytics[0].total_input_tokens, 300);
         assert_eq!(analytics[0].total_output_tokens, 130);
+    }
+
+    #[test]
+    fn migrations_v6_v7_v8_are_idempotent() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+
+        // First bootstrap creates all tables
+        bootstrap(&database_path).expect("bootstrap should succeed");
+
+        // Running bootstrap again (which re-runs all migrations) should not fail
+        // because all migrations use CREATE TABLE IF NOT EXISTS
+        bootstrap(&database_path).expect("second bootstrap should succeed");
+
+        let health = inspect(&database_path).expect("inspect should succeed");
+        assert_eq!(health.schema_version, Some(SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn v6_migration_creates_response_cache_and_audit_log() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+        let connection = open(&database_path).expect("open should work");
+
+        // Create minimal schema without response_cache/audit_log
+        connection
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);",
+            )
+            .unwrap();
+
+        // Run v6 migration
+        migrate_to_v6(&connection, &database_path).expect("v6 migration should succeed");
+
+        // Verify tables exist by querying them
+        connection
+            .execute(
+                "INSERT INTO response_cache (cache_key, model, response, expires_at) VALUES ('k', 'm', 'r', '2099-01-01')",
+                [],
+            )
+            .expect("response_cache should exist");
+        connection
+            .execute(
+                "INSERT INTO audit_log (event_type) VALUES ('test')",
+                [],
+            )
+            .expect("audit_log should exist");
+    }
+
+    #[test]
+    fn v7_migration_creates_channels_table() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+        let connection = open(&database_path).expect("open should work");
+
+        // Run v7 migration
+        migrate_to_v7(&connection, &database_path).expect("v7 migration should succeed");
+
+        // Verify table exists
+        connection
+            .execute(
+                "INSERT INTO channels (platform, channel_id, channel_name) VALUES ('slack', 'C1', 'general')",
+                [],
+            )
+            .expect("channels table should exist");
+    }
+
+    #[test]
+    fn v8_migration_creates_sticker_cache_table() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+        let connection = open(&database_path).expect("open should work");
+
+        // Run v8 migration
+        migrate_to_v8(&connection, &database_path).expect("v8 migration should succeed");
+
+        // Verify table exists
+        connection
+            .execute(
+                "INSERT INTO sticker_cache (file_unique_id, description) VALUES ('abc', 'a cat')",
+                [],
+            )
+            .expect("sticker_cache table should exist");
     }
 }

--- a/crates/genesis-tools/src/builtins/todo.rs
+++ b/crates/genesis-tools/src/builtins/todo.rs
@@ -1,14 +1,18 @@
-use std::collections::BTreeMap;
-use std::sync::Mutex;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{LazyLock, Mutex};
 
 use crate::{ToolCall, ToolContext, ToolError, ToolHandler, ToolOutput};
 
-/// In-memory task list for agent planning.
+/// In-memory task list for agent planning, keyed by session ID.
 ///
 /// Unlike persistent storage tools, the todo list lives only for the duration
 /// of the current process. It helps the agent decompose complex tasks,
 /// track progress, and report completion status.
-static TODO_LIST: Mutex<Vec<TodoItem>> = Mutex::new(Vec::new());
+///
+/// Each session gets its own isolated todo list so that concurrent sessions
+/// (e.g. via the gateway) do not leak state to each other.
+static TODO_LISTS: LazyLock<Mutex<HashMap<String, Vec<TodoItem>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Clone)]
 struct TodoItem {
@@ -46,7 +50,7 @@ fn parse_status(s: &str) -> Result<TodoStatus, String> {
 pub struct TodoTool;
 
 impl ToolHandler for TodoTool {
-    fn run(&self, call: &ToolCall, _context: &ToolContext) -> Result<ToolOutput, ToolError> {
+    fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
         let action = call
             .arguments
             .get("action")
@@ -54,6 +58,8 @@ impl ToolHandler for TodoTool {
                 tool: call.name.clone(),
                 argument: "action",
             })?;
+
+        let session_id = &context.session_id;
 
         match action.as_str() {
             "add" => {
@@ -65,7 +71,8 @@ impl ToolHandler for TodoTool {
                         argument: "text",
                     })?;
 
-                let mut list = TODO_LIST.lock().unwrap();
+                let mut lists = TODO_LISTS.lock().unwrap();
+                let list = lists.entry(session_id.clone()).or_default();
                 let id = list.len() + 1;
                 list.push(TodoItem {
                     id,
@@ -105,7 +112,8 @@ impl ToolHandler for TodoTool {
                     reason: e,
                 })?;
 
-                let mut list = TODO_LIST.lock().unwrap();
+                let mut lists = TODO_LISTS.lock().unwrap();
+                let list = lists.entry(session_id.clone()).or_default();
                 let item = list.iter_mut().find(|item| item.id == id).ok_or_else(|| {
                     ToolError::ExecutionFailed {
                         tool: call.name.clone(),
@@ -123,7 +131,9 @@ impl ToolHandler for TodoTool {
                 })
             }
             "list" => {
-                let list = TODO_LIST.lock().unwrap();
+                let lists = TODO_LISTS.lock().unwrap();
+                let empty = Vec::new();
+                let list = lists.get(session_id).unwrap_or(&empty);
                 if list.is_empty() {
                     return Ok(ToolOutput {
                         content: "(no todos)".to_owned(),
@@ -158,7 +168,8 @@ impl ToolHandler for TodoTool {
                 })
             }
             "clear" => {
-                let mut list = TODO_LIST.lock().unwrap();
+                let mut lists = TODO_LISTS.lock().unwrap();
+                let list = lists.entry(session_id.clone()).or_default();
                 let count = list.len();
                 list.clear();
 
@@ -193,13 +204,25 @@ mod tests {
         }
     }
 
-    fn clear_todos() {
-        TODO_LIST.lock().unwrap().clear();
+    fn ctx_with_session(session_id: &str) -> ToolContext {
+        ToolContext {
+            session_id: session_id.to_owned(),
+            profile: "test".to_owned(),
+            data_dir: "/tmp".to_owned(),
+            allow_destructive_tools: true,
+            terminal_backend: None,
+            default_working_dir: None,
+        }
+    }
+
+    fn clear_todos(session_id: &str) {
+        let mut lists = TODO_LISTS.lock().unwrap();
+        lists.remove(session_id);
     }
 
     #[test]
     fn todo_add_and_list() {
-        clear_todos();
+        clear_todos("test");
         let tool = TodoTool;
 
         // Add
@@ -225,7 +248,7 @@ mod tests {
 
     #[test]
     fn todo_update_status() {
-        clear_todos();
+        clear_todos("test");
         let tool = TodoTool;
 
         // Add
@@ -276,7 +299,7 @@ mod tests {
 
     #[test]
     fn todo_clear() {
-        clear_todos();
+        clear_todos("test");
         let tool = TodoTool;
 
         let call = ToolCall {
@@ -305,7 +328,7 @@ mod tests {
 
     #[test]
     fn todo_empty_list() {
-        clear_todos();
+        clear_todos("test");
         let tool = TodoTool;
 
         let call = ToolCall {
@@ -330,5 +353,60 @@ mod tests {
             }
             _ => panic!("expected ExecutionFailed"),
         }
+    }
+
+    #[test]
+    fn todo_sessions_are_isolated() {
+        clear_todos("session-a");
+        clear_todos("session-b");
+        let tool = TodoTool;
+
+        // Add to session A
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "add".to_owned()),
+                ("text".to_owned(), "task for A".to_owned()),
+            ]),
+        };
+        tool.run(&call, &ctx_with_session("session-a")).unwrap();
+
+        // Add to session B
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "add".to_owned()),
+                ("text".to_owned(), "task for B".to_owned()),
+            ]),
+        };
+        tool.run(&call, &ctx_with_session("session-b")).unwrap();
+
+        // Session A should only see its own todo
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "list".to_owned())]),
+        };
+        let output_a = tool.run(&call, &ctx_with_session("session-a")).unwrap();
+        assert!(output_a.content.contains("task for A"));
+        assert!(!output_a.content.contains("task for B"));
+
+        // Session B should only see its own todo
+        let output_b = tool.run(&call, &ctx_with_session("session-b")).unwrap();
+        assert!(output_b.content.contains("task for B"));
+        assert!(!output_b.content.contains("task for A"));
+
+        // Clearing session A should not affect session B
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "clear".to_owned())]),
+        };
+        tool.run(&call, &ctx_with_session("session-a")).unwrap();
+
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "list".to_owned())]),
+        };
+        let output_b = tool.run(&call, &ctx_with_session("session-b")).unwrap();
+        assert!(output_b.content.contains("task for B"));
     }
 }


### PR DESCRIPTION
## Summary

Addresses three medium-severity findings from the security/correctness audit:

- **Todo tool session isolation**: The global static `TODO_LIST` was shared across all concurrent sessions, causing state leakage in the gateway context. Changed to a `HashMap<String, Vec<TodoItem>>` keyed by `session_id` from `ToolContext`, so each session gets its own isolated todo list.

- **Schema migration gap**: `SCHEMA_VERSION` is 8 but only migrations up to v5 existed. Databases bootstrapped at v5 would never get the `response_cache`, `audit_log`, `channels`, or `sticker_cache` tables. Added idempotent `migrate_to_v6`, `migrate_to_v7`, and `migrate_to_v8` functions using `CREATE TABLE IF NOT EXISTS`.

- **MCP tool name parsing ambiguity**: `parse_mcp_tool_name` split on the first underscore after `mcp_`, so a server named `my_server` with tool `read_file` (`mcp_my_server_read_file`) was incorrectly parsed as server=`my`, tool=`server_read_file`. Changed to use a double-underscore (`__`) separator (`mcp_my_server__read_file`) for unambiguous parsing.

## Test plan

- [x] All ~1664 existing tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] New test: `todo_sessions_are_isolated` verifies cross-session isolation
- [x] New test: `parse_tool_name_with_underscores_in_server` verifies correct parsing
- [x] New test: `parse_tool_name_no_double_underscore` verifies old format is rejected
- [x] New tests: `v6_migration_creates_response_cache_and_audit_log`, `v7_migration_creates_channels_table`, `v8_migration_creates_sticker_cache_table` verify each migration independently
- [x] New test: `migrations_v6_v7_v8_are_idempotent` verifies double-bootstrap safety