### PR TITLE
refactor(storage): cleanup duplicates, optimize purge, consistency fixes

### DIFF
--- a/crates/genesis-cli/src/lib.rs
+++ b/crates/genesis-cli/src/lib.rs
@@ -6568,7 +6568,7 @@ fn run_info(config_path: Option<PathBuf>, json: bool) -> Result<String, CliError
     let tool_count = genesis_core::default_tool_count();
 
     let session_count = SessionStore::new(db_path)
-        .count_sessions()
+        .session_count()
         .unwrap_or(0);
 
     let skill_count = SkillStore::new(db_path)

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -378,7 +378,7 @@ fn check_tool_registry() -> DoctorCheck {
 
 /// Gather storage statistics: session, skill, and schedule counts.
 fn check_storage_stats(db_path: &Path) -> DoctorCheck {
-    let sessions = SessionStore::new(db_path).count_sessions().unwrap_or(0);
+    let sessions = SessionStore::new(db_path).session_count().unwrap_or(0);
 
     // Use direct COUNT(*) queries to avoid loading full rows
     let (skills, schedules) = match rusqlite::Connection::open(db_path) {

--- a/crates/genesis-storage/src/lib.rs
+++ b/crates/genesis-storage/src/lib.rs
@@ -1434,38 +1434,52 @@ impl SessionStore {
     pub fn purge_older_than(&self, days: u32) -> Result<u64, StorageError> {
         let connection = open(&self.database_path)?;
         let cutoff = format!("-{days} days");
-        // Gather session IDs to purge
-        let mut stmt = connection
-            .prepare("SELECT id FROM sessions WHERE created_at < datetime('now', ?1)")
+
+        // Enable foreign keys so ON DELETE CASCADE removes messages automatically.
+        connection
+            .execute_batch("PRAGMA foreign_keys = ON")
             .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
             })?;
-        let ids: Vec<String> = stmt
-            .query_map(params![cutoff], |row| row.get(0))
+
+        let tx = connection
+            .unchecked_transaction()
             .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?
-            .filter_map(|r| r.ok())
-            .collect();
+            })?;
 
-        for id in &ids {
-            let _ = connection.execute(
-                "DELETE FROM session_search WHERE session_id = ?1",
-                params![id],
-            );
-            let _ = connection.execute(
-                "DELETE FROM messages WHERE session_id = ?1",
-                params![id],
-            );
-            let _ = connection.execute(
-                "DELETE FROM sessions WHERE id = ?1",
-                params![id],
-            );
-        }
+        // Remove FTS entries (virtual table, no FK support).
+        tx.execute(
+            "DELETE FROM session_search WHERE session_id IN (
+                 SELECT id FROM sessions WHERE created_at < datetime('now', ?1)
+             )",
+            params![cutoff],
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: self.database_path.clone(),
+            source,
+        })?;
 
-        Ok(ids.len() as u64)
+        // Delete sessions; ON DELETE CASCADE handles messages.
+        tx.execute(
+            "DELETE FROM sessions WHERE created_at < datetime('now', ?1)",
+            params![cutoff],
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: self.database_path.clone(),
+            source,
+        })?;
+
+        let deleted = tx.changes() as u64;
+
+        tx.commit().map_err(|source| StorageError::Sqlite {
+            path: self.database_path.clone(),
+            source,
+        })?;
+
+        Ok(deleted)
     }
 
     /// Load all messages for a session in chronological order.
@@ -1751,17 +1765,6 @@ impl SessionStore {
             })?;
 
         Ok(sessions)
-    }
-
-    pub fn count_sessions(&self) -> Result<u64, StorageError> {
-        let connection = open(&self.database_path)?;
-        let count: i64 = connection
-            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
-            .map_err(|source| StorageError::Sqlite {
-                path: self.database_path.clone(),
-                source,
-            })?;
-        Ok(count as u64)
     }
 
     /// Aggregate token usage across all sessions.
@@ -2387,6 +2390,26 @@ impl SkillStore {
         }
     }
 
+    fn row_to_skill(row: &rusqlite::Row) -> Result<StoredSkill, rusqlite::Error> {
+        let tags_str: String = row.get(4)?;
+        let tags = if tags_str.is_empty() {
+            Vec::new()
+        } else {
+            tags_str.split(',').map(|s| s.to_owned()).collect()
+        };
+
+        Ok(StoredSkill {
+            name: row.get(0)?,
+            description: row.get(1)?,
+            instructions: row.get(2)?,
+            trigger_hint: row.get(3)?,
+            tags,
+            version: row.get(5)?,
+            created_at: row.get(6)?,
+            updated_at: row.get(7)?,
+        })
+    }
+
     /// Create or update a skill. If the skill already exists, its version is bumped.
     pub fn upsert(
         &self,
@@ -2432,25 +2455,7 @@ impl SkillStore {
                 "SELECT name, description, instructions, trigger_hint, tags, version, created_at, updated_at
                  FROM skills WHERE name = ?1",
                 params![name],
-                |row| {
-                    let tags_str: String = row.get(4)?;
-                    let tags = if tags_str.is_empty() {
-                        Vec::new()
-                    } else {
-                        tags_str.split(',').map(|s| s.to_owned()).collect()
-                    };
-
-                    Ok(StoredSkill {
-                        name: row.get(0)?,
-                        description: row.get(1)?,
-                        instructions: row.get(2)?,
-                        trigger_hint: row.get(3)?,
-                        tags,
-                        version: row.get(5)?,
-                        created_at: row.get(6)?,
-                        updated_at: row.get(7)?,
-                    })
-                },
+                Self::row_to_skill,
             )
             .optional()
             .map_err(|source| StorageError::Sqlite {
@@ -2473,25 +2478,7 @@ impl SkillStore {
             })?;
 
         let skills = stmt
-            .query_map([], |row| {
-                let tags_str: String = row.get(4)?;
-                let tags = if tags_str.is_empty() {
-                    Vec::new()
-                } else {
-                    tags_str.split(',').map(|s| s.to_owned()).collect()
-                };
-
-                Ok(StoredSkill {
-                    name: row.get(0)?,
-                    description: row.get(1)?,
-                    instructions: row.get(2)?,
-                    trigger_hint: row.get(3)?,
-                    tags,
-                    version: row.get(5)?,
-                    created_at: row.get(6)?,
-                    updated_at: row.get(7)?,
-                })
-            })
+            .query_map([], Self::row_to_skill)
             .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
@@ -2521,25 +2508,7 @@ impl SkillStore {
             })?;
 
         let skills = stmt
-            .query_map(params![pattern], |row| {
-                let tags_str: String = row.get(4)?;
-                let tags = if tags_str.is_empty() {
-                    Vec::new()
-                } else {
-                    tags_str.split(',').map(|s| s.to_owned()).collect()
-                };
-
-                Ok(StoredSkill {
-                    name: row.get(0)?,
-                    description: row.get(1)?,
-                    instructions: row.get(2)?,
-                    trigger_hint: row.get(3)?,
-                    tags,
-                    version: row.get(5)?,
-                    created_at: row.get(6)?,
-                    updated_at: row.get(7)?,
-                })
-            })
+            .query_map(params![pattern], Self::row_to_skill)
             .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
@@ -3148,31 +3117,26 @@ impl MemoryStore {
     /// Get a single memory by ID. Returns `None` if not found.
     pub fn get(&self, id: &str) -> Result<Option<StoredMemory>, StorageError> {
         let connection = open(&self.database_path)?;
-        let mut stmt = connection
-            .prepare(
+        connection
+            .query_row(
                 "SELECT id, session_id, kind, content, created_at
                  FROM memories WHERE id = ?1",
+                params![id],
+                |row| {
+                    Ok(StoredMemory {
+                        id: row.get(0)?,
+                        session_id: row.get(1)?,
+                        kind: row.get(2)?,
+                        content: row.get(3)?,
+                        created_at: row.get(4)?,
+                    })
+                },
             )
-            .map_err(|source| StorageError::Sqlite {
-                path: self.database_path.clone(),
-                source,
-            })?;
-        let result = stmt
-            .query_row(params![id], |row| {
-                Ok(StoredMemory {
-                    id: row.get(0)?,
-                    session_id: row.get(1)?,
-                    kind: row.get(2)?,
-                    content: row.get(3)?,
-                    created_at: row.get(4)?,
-                })
-            })
             .optional()
             .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?;
-        Ok(result)
+            })
     }
 
     /// Full-text search across stored memories.
@@ -4058,14 +4022,11 @@ impl AuditLogStore {
                 source,
             })?;
 
-        let mut entries = Vec::new();
-        for row in rows {
-            entries.push(row.map_err(|source| StorageError::Sqlite {
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?);
-        }
-        Ok(entries)
+            })
     }
 
     /// Query audit entries by event type.
@@ -4099,14 +4060,11 @@ impl AuditLogStore {
                 source,
             })?;
 
-        let mut entries = Vec::new();
-        for row in rows {
-            entries.push(row.map_err(|source| StorageError::Sqlite {
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?);
-        }
-        Ok(entries)
+            })
     }
 
     /// Query recent audit entries across all sessions.
@@ -4139,14 +4097,11 @@ impl AuditLogStore {
                 source,
             })?;
 
-        let mut entries = Vec::new();
-        for row in rows {
-            entries.push(row.map_err(|source| StorageError::Sqlite {
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?);
-        }
-        Ok(entries)
+            })
     }
 
     /// Count total audit entries and entries per event type.
@@ -4173,14 +4128,11 @@ impl AuditLogStore {
                 source,
             })?;
 
-        let mut stats = Vec::new();
-        for row in rows {
-            stats.push(row.map_err(|source| StorageError::Sqlite {
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?);
-        }
-        Ok(stats)
+            })
     }
 
     /// Aggregate tool usage analytics from tool_call_end audit events.
@@ -4222,14 +4174,11 @@ impl AuditLogStore {
                 source,
             })?;
 
-        let mut analytics = Vec::new();
-        for row in rows {
-            analytics.push(row.map_err(|source| StorageError::Sqlite {
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?);
-        }
-        Ok(analytics)
+            })
     }
 
     /// Aggregate LLM usage analytics from llm_response audit events.
@@ -4270,14 +4219,11 @@ impl AuditLogStore {
                 source,
             })?;
 
-        let mut analytics = Vec::new();
-        for row in rows {
-            analytics.push(row.map_err(|source| StorageError::Sqlite {
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|source| StorageError::Sqlite {
                 path: self.database_path.clone(),
                 source,
-            })?);
-        }
-        Ok(analytics)
+            })
     }
 
     /// Delete audit entries older than the given number of days.
@@ -4358,7 +4304,7 @@ impl ResponseCacheStore {
                 source,
             })?;
 
-        if let Some(ref _e) = entry {
+        if entry.is_some() {
             let _ = connection.execute(
                 "UPDATE response_cache SET hit_count = hit_count + 1 WHERE cache_key = ?1",
                 params![cache_key],


### PR DESCRIPTION
## Summary
- **Remove duplicate `count_sessions`**: `session_count` and `count_sessions` were identical methods on `SessionStore`. Removed `count_sessions` and updated two callers in `genesis-cli` and `genesis-core` to use `session_count`.
- **Fix unused binding**: Replaced `if let Some(ref _e) = entry` with `if entry.is_some()` in `ResponseCacheStore::get`.
- **Simplify `MemoryStore::get`**: Replaced `prepare()` + `stmt.query_row()` with direct `connection.query_row()`, matching the pattern used by every other single-row lookup in the file.
- **Extract `row_to_skill` helper**: Deduplicated the row-to-`StoredSkill` mapping closure that was copied across `get`, `list_all`, and `find_by_tag` into a single `fn row_to_skill` method, following the existing `row_to_trait` / `row_to_subagent` / `row_to_usage` pattern.
- **Use `.collect()` pattern in AuditLogStore**: Replaced manual `for row in rows { entries.push(...) }` loops in 6 methods (`by_session`, `by_event_type`, `recent`, `stats`, `tool_analytics`, `llm_analytics`) with the idiomatic `.collect::<Result<Vec<_>, _>>()` pattern used everywhere else in the file.
- **Optimize `purge_older_than`**: Replaced N*3 individual DELETE loop with 2 bulk SQL statements in a transaction. The `session_search` FTS table is cleaned via a subquery, and `messages` are cleaned via `ON DELETE CASCADE` from the sessions foreign key.
- **Skipped** `SCHEMA_VERSION.to_string()` change: The metadata table column is `TEXT NOT NULL`, and rusqlite enforces column type on read, so storing as i64 and reading back as i64 causes `InvalidColumnType` errors. Left as-is.

## Test plan
- [x] `cargo build --workspace` passes (0 errors)
- [x] `cargo test -p genesis-storage` passes (101 tests)
- [x] `cargo test -p genesis-cli -p genesis-core` passes (all tests)
- [x] `cargo clippy --workspace -- -D warnings` passes (0 warnings)