### PR TITLE
refactor(tools): extract shared db_path helper to eliminate 15+ inline constructions

### DIFF
--- a/crates/genesis-tools/src/builtins/channel_directory.rs
+++ b/crates/genesis-tools/src/builtins/channel_directory.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -38,7 +37,7 @@ impl ToolHandler for ListChannelsTool {
             .map(|v| v == "true")
             .unwrap_or(false);
 
-        let db_path = database_path(context);
+        let db_path = context.db_path();
         let store = ChannelStore::new(&db_path);
 
         // Determine which platforms to query.
@@ -93,10 +92,6 @@ impl ToolHandler for ListChannelsTool {
             ]),
         })
     }
-}
-
-fn database_path(context: &ToolContext) -> PathBuf {
-    PathBuf::from(&context.data_dir).join("genesis.db")
 }
 
 /// Return the list of platforms that have API tokens configured.

--- a/crates/genesis-tools/src/builtins/export.rs
+++ b/crates/genesis-tools/src/builtins/export.rs
@@ -25,7 +25,7 @@ impl ToolHandler for SessionExportTool {
 
         let output_path = call.arguments.get("path");
 
-        let db_path = Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
         let store = SessionStore::new(&db_path);
 

--- a/crates/genesis-tools/src/builtins/memory.rs
+++ b/crates/genesis-tools/src/builtins/memory.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use rusqlite::{params, Connection};
 
@@ -26,7 +26,7 @@ impl ToolHandler for MemoryStoreTool {
                 argument: "value",
             })?;
 
-        let database_path = database_path_from_context(context);
+        let database_path = context.db_path();
         let connection = open_database(&call.name, &database_path)?;
         ensure_memory_search_index(&call.name, &connection)?;
 
@@ -90,7 +90,7 @@ impl ToolHandler for MemoryRecallTool {
             .transpose()?
             .unwrap_or(DEFAULT_RECALL_LIMIT);
 
-        let database_path = database_path_from_context(context);
+        let database_path = context.db_path();
         let connection = open_database(&call.name, &database_path)?;
         ensure_memory_search_index(&call.name, &connection)?;
 
@@ -149,10 +149,6 @@ impl ToolHandler for MemoryRecallTool {
     }
 }
 
-fn database_path_from_context(context: &ToolContext) -> PathBuf {
-    Path::new(&context.data_dir).join("genesis.db")
-}
-
 fn open_database(tool_name: &str, database_path: &Path) -> Result<Connection, ToolError> {
     Connection::open(database_path).map_err(|error| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
@@ -193,7 +189,7 @@ mod tests {
     use genesis_storage::{bootstrap, SessionStore};
     use tempfile::tempdir;
 
-    use super::{database_path_from_context, MemoryRecallTool, MemoryStoreTool};
+    use super::{MemoryRecallTool, MemoryStoreTool};
     use crate::{ToolCall, ToolContext, ToolHandler};
 
     fn ctx(data_dir: &str) -> ToolContext {
@@ -278,6 +274,6 @@ mod tests {
         let dir = tempdir().expect("tempdir should exist");
         let context = ctx(dir.path().to_string_lossy().as_ref());
 
-        assert_eq!(database_path_from_context(&context), dir.path().join("genesis.db"));
+        assert_eq!(context.db_path(), dir.path().join("genesis.db"));
     }
 }

--- a/crates/genesis-tools/src/builtins/schedule.rs
+++ b/crates/genesis-tools/src/builtins/schedule.rs
@@ -42,7 +42,7 @@ impl ToolHandler for ScheduleCreateTool {
         }
 
         let id = format!("sched-{}", &uuid_v4()[..8]);
-        let store = ScheduleStore::new(&std::path::Path::new(&context.data_dir).join("genesis.db"));
+        let store = ScheduleStore::new(&context.db_path());
         let schedule = store
             .create(&id, cron, destination, prompt)
             .map_err(|e| ToolError::ExecutionFailed {
@@ -68,7 +68,7 @@ pub struct ScheduleListTool;
 
 impl ToolHandler for ScheduleListTool {
     fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
-        let store = ScheduleStore::new(&std::path::Path::new(&context.data_dir).join("genesis.db"));
+        let store = ScheduleStore::new(&context.db_path());
         let schedules = store
             .list_all()
             .map_err(|e| ToolError::ExecutionFailed {
@@ -115,7 +115,7 @@ impl ToolHandler for ScheduleDeleteTool {
                 argument: "id",
             })?;
 
-        let store = ScheduleStore::new(&std::path::Path::new(&context.data_dir).join("genesis.db"));
+        let store = ScheduleStore::new(&context.db_path());
         let deleted = store
             .delete(id)
             .map_err(|e| ToolError::ExecutionFailed {

--- a/crates/genesis-tools/src/builtins/session.rs
+++ b/crates/genesis-tools/src/builtins/session.rs
@@ -17,7 +17,7 @@ impl ToolHandler for SessionSearchTool {
                 argument: "query",
             })?;
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
         let store = SessionStore::new(&db_path);
 
@@ -83,7 +83,7 @@ impl ToolHandler for SessionHistoryTool {
             .transpose()?
             .unwrap_or(20);
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
         let store = SessionStore::new(&db_path);
 

--- a/crates/genesis-tools/src/builtins/skill.rs
+++ b/crates/genesis-tools/src/builtins/skill.rs
@@ -41,7 +41,7 @@ impl ToolHandler for SkillCreateTool {
             .map(|t| t.split(',').map(|s| s.trim()).collect())
             .unwrap_or_default();
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
         let store = SkillStore::new(&db_path);
 
@@ -73,7 +73,7 @@ pub struct SkillListTool;
 
 impl ToolHandler for SkillListTool {
     fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let store = SkillStore::new(&db_path);
 
         let skills = store.list_all().map_err(|e| ToolError::ExecutionFailed {
@@ -124,7 +124,7 @@ impl ToolHandler for SkillGetTool {
                 argument: "name",
             })?;
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let store = SkillStore::new(&db_path);
 
         let skill = store
@@ -173,7 +173,7 @@ impl ToolHandler for SkillDeleteTool {
                 argument: "name",
             })?;
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let store = SkillStore::new(&db_path);
 
         let deleted = store.delete(name).map_err(|e| ToolError::ExecutionFailed {
@@ -231,7 +231,7 @@ impl ToolHandler for SkillRecordUsageTool {
 
         let feedback = call.arguments.get("feedback").map(|s| s.as_str());
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
 
         // Verify the skill exists

--- a/crates/genesis-tools/src/builtins/skill_file.rs
+++ b/crates/genesis-tools/src/builtins/skill_file.rs
@@ -5,7 +5,7 @@ use genesis_storage::{bootstrap, SkillFileStore};
 use crate::{ToolCall, ToolContext, ToolError, ToolHandler, ToolOutput};
 
 fn file_store(context: &ToolContext) -> SkillFileStore {
-    let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+    let db_path = context.db_path();
     let _ = bootstrap(&db_path);
     SkillFileStore::new(&db_path)
 }

--- a/crates/genesis-tools/src/builtins/subagent.rs
+++ b/crates/genesis-tools/src/builtins/subagent.rs
@@ -40,7 +40,7 @@ impl ToolHandler for SpawnSubagentTool {
             .cloned()
             .unwrap_or_else(|| "subagent".to_owned());
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
 
         let subagent_id = generate_subagent_id(&context.session_id);
@@ -97,7 +97,7 @@ impl ToolHandler for CheckSubagentTool {
                 argument: "subagent_id",
             })?;
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let store = SubagentStore::new(&db_path);
 
         let subagent = store
@@ -141,7 +141,7 @@ pub struct ListSubagentsTool;
 
 impl ToolHandler for ListSubagentsTool {
     fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let store = SubagentStore::new(&db_path);
 
         let subagents = store

--- a/crates/genesis-tools/src/builtins/user_model.rs
+++ b/crates/genesis-tools/src/builtins/user_model.rs
@@ -33,7 +33,7 @@ impl ToolHandler for UserObserveTool {
                 argument: "value",
             })?;
 
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let _ = bootstrap(&db_path);
         let store = UserModelStore::new(&db_path);
 
@@ -67,7 +67,7 @@ pub struct UserModelTool;
 
 impl ToolHandler for UserModelTool {
     fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
-        let db_path = std::path::Path::new(&context.data_dir).join("genesis.db");
+        let db_path = context.db_path();
         let store = UserModelStore::new(&db_path);
 
         let category = call.arguments.get("category");

--- a/crates/genesis-tools/src/lib.rs
+++ b/crates/genesis-tools/src/lib.rs
@@ -3,6 +3,7 @@ pub mod http;
 pub mod url_safety;
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use genesis_types::ToolDefinition;
@@ -105,6 +106,13 @@ impl PartialEq for ToolContext {
             && self.terminal_backend == other.terminal_backend
             && self.default_working_dir == other.default_working_dir
         // sandbox_manager intentionally excluded from equality comparison
+    }
+}
+
+impl ToolContext {
+    /// Return the path to the SQLite database for this context's data directory.
+    pub fn db_path(&self) -> PathBuf {
+        PathBuf::from(&self.data_dir).join("genesis.db")
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `ToolContext::db_path()` method that returns `PathBuf::from(&self.data_dir).join("genesis.db")`, centralising the database path construction that was duplicated across the tools crate.
- Replaces 18 inline `Path::new(&context.data_dir).join("genesis.db")` expressions across 9 tool files with `context.db_path()`.
- Removes two now-redundant private helpers: `database_path_from_context` in `memory.rs` and `database_path` in `channel_directory.rs`.

## Files changed

| File | Change |
|------|--------|
| `lib.rs` | Added `ToolContext::db_path()` method |
| `builtins/skill.rs` | 5 occurrences replaced |
| `builtins/subagent.rs` | 3 occurrences replaced |
| `builtins/schedule.rs` | 3 occurrences replaced |
| `builtins/session.rs` | 2 occurrences replaced |
| `builtins/user_model.rs` | 2 occurrences replaced |
| `builtins/memory.rs` | 2 occurrences replaced, private helper removed |
| `builtins/channel_directory.rs` | 1 occurrence replaced, private helper removed |
| `builtins/export.rs` | 1 occurrence replaced |
| `builtins/skill_file.rs` | 1 occurrence replaced |

## Test plan

- [x] `cargo build -p genesis-tools` compiles cleanly
- [x] `cargo test -p genesis-tools` passes (380/381; the one failure `ptc_rpc_wire_protocol` is pre-existing on `main`)
- [x] `cargo clippy -p genesis-tools -- -D warnings` reports zero warnings