### PR TITLE
refactor(provider,core): consolidate completion logging and reduce unnecessary clones

### DIFF
--- a/crates/genesis-core/src/agent_loop.rs
+++ b/crates/genesis-core/src/agent_loop.rs
@@ -2146,20 +2146,20 @@ fn parse_tool_arguments(raw: &str) -> Result<BTreeMap<String, String>, AgentErro
 /// Suggest tool names similar to `name` using edit distance.
 /// Returns up to 3 suggestions sorted by similarity.
 fn suggest_similar_tools(name: &str, tools: &ToolRuntime) -> Vec<String> {
+    let name_lower = name.to_lowercase();
     let mut scored: Vec<(String, usize)> = tools
         .definitions()
         .iter()
         .filter_map(|def| {
-            let dist = edit_distance(&name.to_lowercase(), &def.name.to_lowercase());
+            let def_lower = def.name.to_lowercase();
+            let dist = edit_distance(&name_lower, &def_lower);
             let max_len = name.len().max(def.name.len());
             // Only suggest if within 40% edit distance
             if max_len > 0 && dist <= max_len * 2 / 5 {
                 Some((def.name.clone(), dist))
             } else {
                 // Also match if one is a substring of the other
-                let nl = name.to_lowercase();
-                let dl = def.name.to_lowercase();
-                if dl.contains(&nl) || nl.contains(&dl) {
+                if def_lower.contains(&name_lower) || name_lower.contains(&def_lower) {
                     Some((def.name.clone(), dist))
                 } else {
                     None

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -266,7 +266,7 @@ impl<'a> SessionExecutionService<'a> {
 
     pub async fn run_turn(
         &self,
-        input: SessionTurnInput<'_>,
+        mut input: SessionTurnInput<'_>,
     ) -> Result<SessionTurnOutcome, SessionExecutionError> {
         let span = info_span!(
             "session.run_turn",
@@ -277,7 +277,7 @@ impl<'a> SessionExecutionService<'a> {
         let session_id = input.session_id.to_owned();
         let platform = input.delivery_platform.clone();
         let prompt = input.prompt.to_owned();
-        let images = input.images.clone();
+        let images = std::mem::take(&mut input.images);
 
         let outcome = self.run_turn_with_runner(input, |history| async move {
             let mut agent = self
@@ -301,7 +301,7 @@ impl<'a> SessionExecutionService<'a> {
 
     pub async fn run_turn_streaming<F>(
         &self,
-        input: SessionTurnInput<'_>,
+        mut input: SessionTurnInput<'_>,
         on_chunk: F,
     ) -> Result<SessionTurnOutcome, SessionExecutionError>
     where
@@ -316,7 +316,7 @@ impl<'a> SessionExecutionService<'a> {
         let session_id = input.session_id.to_owned();
         let platform = input.delivery_platform.clone();
         let prompt = input.prompt.to_owned();
-        let images = input.images.clone();
+        let images = std::mem::take(&mut input.images);
 
         let outcome = self.run_turn_streaming_with_runner(input, on_chunk, |history, on_chunk| async move {
             let mut agent = self
@@ -422,18 +422,13 @@ impl<'a> SessionExecutionService<'a> {
 
         // Apply tool filter (allowlist/denylist)
         if let Some(ref filter) = self.loaded.config.runtime.tool_filter {
-            let all_tools: Vec<String> = if filter.allow.is_empty() {
+            let mut allowed: std::collections::HashSet<String> = if filter.allow.is_empty() {
                 tool_runtime
                     .definitions_async()
                     .await
                     .into_iter()
                     .map(|d| d.name)
                     .collect()
-            } else {
-                filter.allow.to_vec()
-            };
-            let mut allowed: std::collections::HashSet<String> = if filter.allow.is_empty() {
-                all_tools.into_iter().collect()
             } else {
                 filter.allow.iter().cloned().collect()
             };

--- a/crates/genesis-provider/src/client.rs
+++ b/crates/genesis-provider/src/client.rs
@@ -6,7 +6,9 @@ use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde::de::DeserializeOwned;
 use tracing::{error, info, warn};
 
-use crate::api_types::{ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse};
+use crate::api_types::{
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatUsage,
+};
 use crate::error::ProviderError;
 use crate::resolve::ResolvedProvider;
 
@@ -273,26 +275,12 @@ impl ChatClient {
             return Err(ProviderError::EmptyChoices);
         }
 
-        let (prompt_tokens, completion_tokens, total_tokens) = completion
-            .usage
-            .as_ref()
-            .map(|usage| {
-                (
-                    usage.prompt_tokens,
-                    usage.completion_tokens,
-                    usage.total_tokens,
-                )
-            })
-            .unwrap_or((0, 0, 0));
-        info!(
-            endpoint = self.endpoint.as_str(),
-            model = request.model.as_str(),
-            elapsed_ms = started_at.elapsed().as_millis() as u64,
-            prompt_tokens,
-            completion_tokens,
-            total_tokens,
-            token_counts_available = completion.usage.is_some(),
-            "chat completion request succeeded"
+        log_completion_success(
+            &self.endpoint,
+            &request.model,
+            started_at.elapsed().as_millis() as u64,
+            completion.usage.as_ref(),
+            "chat completion request succeeded",
         );
 
         Ok(completion)
@@ -341,21 +329,12 @@ impl ChatClient {
             return Err(ProviderError::EmptyChoices);
         }
 
-        let (prompt_tokens, completion_tokens, total_tokens) = completion
-            .usage
-            .as_ref()
-            .map(|u| (u.prompt_tokens, u.completion_tokens, u.total_tokens))
-            .unwrap_or((0, 0, 0));
-
-        info!(
-            endpoint = self.endpoint.as_str(),
-            model = request.model.as_str(),
-            elapsed_ms = started_at.elapsed().as_millis() as u64,
-            prompt_tokens,
-            completion_tokens,
-            total_tokens,
-            token_counts_available = true,
-            "anthropic completion request succeeded"
+        log_completion_success(
+            &self.endpoint,
+            &request.model,
+            started_at.elapsed().as_millis() as u64,
+            completion.usage.as_ref(),
+            "anthropic completion request succeeded",
         );
 
         Ok(completion)
@@ -407,21 +386,12 @@ impl ChatClient {
             return Err(ProviderError::EmptyChoices);
         }
 
-        let (prompt_tokens, completion_tokens, total_tokens) = completion
-            .usage
-            .as_ref()
-            .map(|u| (u.prompt_tokens, u.completion_tokens, u.total_tokens))
-            .unwrap_or((0, 0, 0));
-
-        info!(
-            endpoint = self.endpoint.as_str(),
-            model = request.model.as_str(),
-            elapsed_ms = started_at.elapsed().as_millis() as u64,
-            prompt_tokens,
-            completion_tokens,
-            total_tokens,
-            token_counts_available = completion.usage.is_some(),
-            "gemini completion request succeeded"
+        log_completion_success(
+            &self.endpoint,
+            &request.model,
+            started_at.elapsed().as_millis() as u64,
+            completion.usage.as_ref(),
+            "gemini completion request succeeded",
         );
 
         Ok(completion)
@@ -698,6 +668,29 @@ impl ChatClient {
     pub fn backend(&self) -> &str {
         &self.backend
     }
+}
+
+/// Log a successful (non-streaming) completion with token usage stats.
+fn log_completion_success(
+    endpoint: &str,
+    model: &str,
+    elapsed_ms: u64,
+    usage: Option<&ChatUsage>,
+    label: &str,
+) {
+    let (prompt_tokens, completion_tokens, total_tokens) = usage
+        .map(|u| (u.prompt_tokens, u.completion_tokens, u.total_tokens))
+        .unwrap_or((0, 0, 0));
+    info!(
+        endpoint,
+        model,
+        elapsed_ms,
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+        token_counts_available = usage.is_some(),
+        "{label}"
+    );
 }
 
 /// Backends that support Anthropic-style prompt caching via cache_control.


### PR DESCRIPTION
## Summary

- **Provider: Extract completion logging helper** -- The three non-streaming completion methods (`complete`, `complete_anthropic`, `complete_gemini`) each had an identical ~15-line block extracting usage stats and logging success. Replaced all three with a shared `log_completion_success` free function, removing ~35 lines of duplication.
- **Core: Remove tool filter double-clone** -- When `filter.allow` was non-empty, `build_agent_loop` allocated both an `all_tools: Vec<String>` (immediately discarded) and a `HashSet<String>`, both built from the same allow list. Collapsed into a single `HashSet` construction.
- **Core: Cache `to_lowercase()` in `suggest_similar_tools`** -- `name.to_lowercase()` was called once per tool for `edit_distance` and again in the `else` substring-match branch. Hoisted both `name_lower` and `def_lower` so each is computed once per iteration.
- **Core: Move images instead of cloning** -- `input.images.clone()` in `run_turn` / `run_turn_streaming` was unnecessary since the `images` field is never read after extraction. Replaced with `std::mem::take` to avoid cloning the Vec.

## Test plan

- [x] `cargo build -p genesis-provider -p genesis-core` compiles cleanly
- [x] `cargo test -p genesis-provider -p genesis-core` -- all 784 tests pass (638 core + 146 provider)
- [x] `cargo clippy -p genesis-provider -p genesis-core -- -D warnings` -- zero warnings