### PR TITLE
refactor(core): extract guardrails helper and minor cleanups

### DIFF
--- a/crates/genesis-core/src/agent_loop.rs
+++ b/crates/genesis-core/src/agent_loop.rs
@@ -619,14 +619,10 @@ impl AgentLoop {
         let user_message = if let Some(ref cg) = self.compiled_guardrails {
             let result = cg.check_input(user_message);
             if !result.passed {
-                let blocked_reasons: Vec<&str> = result.violations.iter()
-                    .filter(|v| v.action == crate::guardrails::ViolationAction::Block)
-                    .map(|v| v.message.as_str())
-                    .collect();
                 let agent_result = AgentResult {
                     response: format!(
                         "Your input was blocked by guardrails: {}",
-                        blocked_reasons.join("; ")
+                        format_blocked_reasons(&result)
                     ),
                     turns_used: 0,
                     tool_calls_made: 0,
@@ -998,13 +994,9 @@ impl AgentLoop {
             if let Some(ref cg) = self.compiled_guardrails {
                 let result = cg.check_output(&response_text);
                 if !result.passed {
-                    let blocked_reasons: Vec<&str> = result.violations.iter()
-                        .filter(|v| v.action == crate::guardrails::ViolationAction::Block)
-                        .map(|v| v.message.as_str())
-                        .collect();
                     response_text = format!(
                         "Response blocked by guardrails: {}",
-                        blocked_reasons.join("; ")
+                        format_blocked_reasons(&result)
                     );
                 } else {
                     response_text = result.content;
@@ -1069,14 +1061,10 @@ impl AgentLoop {
         let user_message = if let Some(ref cg) = self.compiled_guardrails {
             let result = cg.check_input(user_message);
             if !result.passed {
-                let blocked_reasons: Vec<&str> = result.violations.iter()
-                    .filter(|v| v.action == crate::guardrails::ViolationAction::Block)
-                    .map(|v| v.message.as_str())
-                    .collect();
                 let agent_result = AgentResult {
                     response: format!(
                         "Your input was blocked by guardrails: {}",
-                        blocked_reasons.join("; ")
+                        format_blocked_reasons(&result)
                     ),
                     turns_used: 0,
                     tool_calls_made: 0,
@@ -1551,13 +1539,9 @@ impl AgentLoop {
                     if let Some(ref cg) = self.compiled_guardrails {
                         let gr = cg.check_output(&response_text);
                         if !gr.passed {
-                            let blocked_reasons: Vec<&str> = gr.violations.iter()
-                                .filter(|v| v.action == crate::guardrails::ViolationAction::Block)
-                                .map(|v| v.message.as_str())
-                                .collect();
                             response_text = format!(
                                 "Response blocked by guardrails: {}",
-                                blocked_reasons.join("; ")
+                                format_blocked_reasons(&gr)
                             );
                         } else {
                             response_text = gr.content;
@@ -2188,6 +2172,16 @@ fn edit_distance(a: &str, b: &str) -> usize {
         std::mem::swap(&mut prev, &mut curr);
     }
     prev[n]
+}
+
+fn format_blocked_reasons(result: &crate::guardrails::GuardrailResult) -> String {
+    result
+        .violations
+        .iter()
+        .filter(|v| v.action == crate::guardrails::ViolationAction::Block)
+        .map(|v| v.message.as_str())
+        .collect::<Vec<&str>>()
+        .join("; ")
 }
 
 #[cfg(test)]

--- a/crates/genesis-core/src/hooks.rs
+++ b/crates/genesis-core/src/hooks.rs
@@ -61,10 +61,6 @@ impl HookRunner {
     }
 }
 
-pub fn load_hooks(config: Vec<HookConfig>) -> HookRunner {
-    HookRunner::new(config)
-}
-
 fn run_hook(config: &HookConfig, context: &serde_json::Value) -> HookResult {
     let started = Instant::now();
     let mut command = shell_command(&config.command);
@@ -153,7 +149,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn load_hooks_builds_runner() {
+    fn hook_runner_new_builds_runner() {
         let hooks = vec![HookConfig {
             event: HookEvent::PreTurn,
             command: "true".to_owned(),
@@ -161,7 +157,7 @@ mod tests {
             enabled: true,
         }];
 
-        let runner = load_hooks(hooks.clone());
+        let runner = HookRunner::new(hooks.clone());
         assert_eq!(runner.hooks(), hooks.as_slice());
     }
 

--- a/crates/genesis-core/src/nudge.rs
+++ b/crates/genesis-core/src/nudge.rs
@@ -157,11 +157,7 @@ fn load_skills_performance_section(db_path: &std::path::Path) -> Option<String> 
             }
         };
 
-        let failure_rate = if uses > 0 {
-            (failures as f64 / uses as f64) * 100.0
-        } else {
-            0.0
-        };
+        let failure_rate = (failures as f64 / uses as f64) * 100.0;
 
         let flag = if failure_rate > 30.0 {
             " [NEEDS IMPROVEMENT]"

--- a/crates/genesis-core/src/scheduler.rs
+++ b/crates/genesis-core/src/scheduler.rs
@@ -13,6 +13,9 @@
 //!   N,M,P - matches any listed value (items can be exact, range, or step)
 //! ```
 
+use chrono::Datelike;
+use chrono::Timelike;
+
 /// A parsed cron expression.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CronExpr {
@@ -292,9 +295,6 @@ impl SchedulerRuntime {
         }
     }
 }
-
-use chrono::Timelike;
-use chrono::Datelike;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- **Extract `format_blocked_reasons` helper** in `agent_loop.rs`: Deduplicated 4 identical guardrail violation formatting blocks into a single private helper function
- **Remove dead else branch** in `nudge.rs`: Simplified `failure_rate` calculation by removing an unreachable `else` branch (the `uses > 0` guard is already enforced by the match arm)
- **Move imports to top** in `scheduler.rs`: Relocated `use chrono::{Datelike, Timelike}` from after the `impl` block to the top of the file with other imports
- **Remove trivial `load_hooks` wrapper** in `hooks.rs`: Removed `load_hooks()` function that was just a pass-through to `HookRunner::new()` — only used in one test, which now calls `HookRunner::new` directly

## Test plan
- [x] `cargo build --workspace` compiles successfully
- [x] `cargo test -p genesis-core` — all 638 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings