### PR TITLE
refactor(config): add parse_and_set macro and reduce boilerplate

### DIFF
--- a/crates/genesis-config/src/lib.rs
+++ b/crates/genesis-config/src/lib.rs
@@ -907,9 +907,10 @@ pub fn update_provider_in_file(
 /// `ConfigError::InvalidEnvValue` on parse failure.
 macro_rules! parse_and_set {
     ($value:expr, $key:expr, $ty:ty, $target:expr) => {{
-        let v: $ty = $value.parse().map_err(|_| ConfigError::InvalidEnvValue {
+        let val = $value;
+        let v: $ty = val.parse().map_err(|_| ConfigError::InvalidEnvValue {
             name: $key,
-            value: $value.to_owned(),
+            value: val.to_owned(),
         })?;
         $target = Some(v);
     }};
@@ -1017,7 +1018,7 @@ pub fn set_value_in_file(config_path: &Path, key: &str, value: &str) -> Result<(
                 file_config.gateway.get_or_insert_with(GatewayConfig::default).daily_reset_hour
             );
             // Extra validation: hour must be 0..=23.
-            if file_config.gateway.as_ref().unwrap().daily_reset_hour.unwrap() >= 24 {
+            if file_config.gateway.as_ref().expect("just set above").daily_reset_hour.expect("just set above") >= 24 {
                 return Err(ConfigError::InvalidEnvValue {
                     name: "gateway.daily_reset_hour",
                     value: value.to_owned(),


### PR DESCRIPTION
## Summary

- **Add `parse_and_set!` macro** to `set_value_in_file`: replaces 9 identical parse-then-assign match arms with single-line macro invocations, reducing ~100 lines of duplicated code. Arms with extra validation (`gateway.daily_reset_hour` range check, `runtime.reasoning_effort` string matching) keep their explicit logic but use the macro for the parse step where applicable.
- **Bind `file_config.runtime.as_ref()` and `file_config.provider.as_ref()` once** in `load_from_map`: introduces `let rt = ...` and `let prov = ...` bindings to eliminate 11 and 6 repeated `.as_ref()` calls respectively.
- **Make `CacheConfig::default()` delegate to `default_*` functions**: ensures a single source of truth for default values (`default_true()`, `default_cache_ttl()`, `default_cache_context_messages()`) instead of duplicating literals.

## Test plan

- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo test -p genesis-config` passes (25/26; 1 pre-existing env-dependent failure on `main`)
- [x] `cargo clippy --workspace -- -D warnings` reports zero warnings