### PR TITLE
fix(provider,auth): add tool argument parse warnings and model metadata LazyLock

### DIFF
--- a/crates/genesis-auth/src/codex.rs
+++ b/crates/genesis-auth/src/codex.rs
@@ -203,7 +203,7 @@ pub async fn poll_for_authorization(
             403 | 404 => continue,
             status => {
                 return Err(AuthError::DeviceCodeRequest {
-                    message: format!("poll returned status {status}"),
+                    message: format!("device code poll returned unexpected status {status}"),
                 });
             }
         }

--- a/crates/genesis-provider/src/anthropic_types.rs
+++ b/crates/genesis-provider/src/anthropic_types.rs
@@ -258,9 +258,10 @@ pub(crate) fn to_anthropic_request(req: &ChatCompletionRequest) -> AnthropicRequ
                 if let Some(tool_calls) = &msg.tool_calls {
                     for tc in tool_calls {
                         let input: Value =
-                            serde_json::from_str(&tc.function.arguments).unwrap_or(Value::Object(
-                                serde_json::Map::new(),
-                            ));
+                            serde_json::from_str(&tc.function.arguments).unwrap_or_else(|e| {
+                                tracing::warn!(arguments = %tc.function.arguments, error = %e, "invalid JSON in tool call arguments, using empty object");
+                                Value::Object(serde_json::Map::new())
+                            });
                         blocks.push(AnthropicContentBlock::ToolUse {
                             id: tc.id.clone(),
                             name: tc.function.name.clone(),

--- a/crates/genesis-provider/src/gemini_types.rs
+++ b/crates/genesis-provider/src/gemini_types.rs
@@ -211,7 +211,10 @@ pub(crate) fn to_gemini_request(req: &ChatCompletionRequest) -> GeminiRequest {
                 if let Some(tool_calls) = &msg.tool_calls {
                     for tc in tool_calls {
                         let args: Value = serde_json::from_str(&tc.function.arguments)
-                            .unwrap_or(Value::Object(serde_json::Map::new()));
+                            .unwrap_or_else(|e| {
+                                tracing::warn!(arguments = %tc.function.arguments, error = %e, "invalid JSON in tool call arguments, using empty object");
+                                Value::Object(serde_json::Map::new())
+                            });
                         parts.push(GeminiPart::FunctionCall {
                             function_call: GeminiFunctionCall {
                                 name: tc.function.name.clone(),


### PR DESCRIPTION
## Summary

- **Add `tracing::warn` on invalid tool argument JSON** in `anthropic_types.rs` and `gemini_types.rs`: when `serde_json::from_str` fails on tool call arguments, the code was silently falling back to an empty object. Now logs a warning with the raw arguments and parse error before falling back.
- **Improve auth poll error message** in `codex.rs`: changed `"poll returned status {status}"` to `"device code poll returned unexpected status {status}"` for clearer diagnostics.
- **Model metadata LazyLock**: verified that `model_metadata.rs` already uses `LazyLock` with a `KNOWN_METADATA` static and `lookup()` function (addressed by a previous PR). No changes needed.

## Test plan

- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo test -p genesis-provider -p genesis-auth` passes all 174 tests
- [x] `cargo clippy --workspace -- -D warnings` reports zero warnings