### PR TITLE
refactor(tools): extract output combiner, inline TTS args, single-pass newline collapse

### DIFF
--- a/crates/genesis-tools/src/builtins/browse.rs
+++ b/crates/genesis-tools/src/builtins/browse.rs
@@ -81,11 +81,24 @@ impl ToolHandler for BrowseTool {
             text
         };
 
-        let mut content = format!("URL: {url}\nHTTP {status}\n\n{truncated}");
-        // Collapse excessive blank lines for cleaner output
-        while content.contains("\n\n\n") {
-            content = content.replace("\n\n\n", "\n\n");
-        }
+        let content = {
+            let raw = format!("URL: {url}\nHTTP {status}\n\n{truncated}");
+            // Collapse 3+ consecutive newlines to 2 in a single pass
+            let mut result = String::with_capacity(raw.len());
+            let mut newline_count = 0u32;
+            for ch in raw.chars() {
+                if ch == '\n' {
+                    newline_count += 1;
+                    if newline_count <= 2 {
+                        result.push(ch);
+                    }
+                } else {
+                    newline_count = 0;
+                    result.push(ch);
+                }
+            }
+            result
+        };
 
         Ok(ToolOutput {
             content,

--- a/crates/genesis-tools/src/builtins/docker.rs
+++ b/crates/genesis-tools/src/builtins/docker.rs
@@ -48,20 +48,7 @@ impl ToolHandler for DockerExecTool {
         let stderr = truncate_output_bytes(&output.stderr);
         let exit_code = output.status.code().unwrap_or(-1);
 
-        let mut content = String::new();
-        if !stdout.is_empty() {
-            content.push_str(&stdout);
-        }
-        if !stderr.is_empty() {
-            if !content.is_empty() {
-                content.push('\n');
-            }
-            content.push_str("[stderr]\n");
-            content.push_str(&stderr);
-        }
-        if content.is_empty() {
-            content = format!("(no output, exit code {exit_code})");
-        }
+        let content = super::combine_command_output(&stdout, &stderr, exit_code);
 
         Ok(ToolOutput {
             content,

--- a/crates/genesis-tools/src/builtins/mod.rs
+++ b/crates/genesis-tools/src/builtins/mod.rs
@@ -34,3 +34,24 @@ pub mod user_model;
 pub mod vision;
 pub mod web;
 pub mod web_search;
+
+/// Combine stdout and stderr from a command execution into a single string.
+/// If both are empty, returns a message with the exit code.
+pub(crate) fn combine_command_output(stdout: &str, stderr: &str, exit_code: i32) -> String {
+    let mut content = String::new();
+    if !stdout.is_empty() {
+        content.push_str(stdout);
+    }
+    if !stderr.is_empty() {
+        if !content.is_empty() {
+            content.push('\n');
+        }
+        content.push_str("[stderr]\n");
+        content.push_str(stderr);
+    }
+    if content.is_empty() {
+        format!("(no output, exit code {exit_code})")
+    } else {
+        content
+    }
+}

--- a/crates/genesis-tools/src/builtins/ssh.rs
+++ b/crates/genesis-tools/src/builtins/ssh.rs
@@ -57,20 +57,7 @@ impl ToolHandler for SshExecTool {
         let stderr = truncate_output_bytes(&output.stderr);
         let exit_code = output.status.code().unwrap_or(-1);
 
-        let mut content = String::new();
-        if !stdout.is_empty() {
-            content.push_str(&stdout);
-        }
-        if !stderr.is_empty() {
-            if !content.is_empty() {
-                content.push('\n');
-            }
-            content.push_str("[stderr]\n");
-            content.push_str(&stderr);
-        }
-        if content.is_empty() {
-            content = format!("(no output, exit code {exit_code})");
-        }
+        let content = super::combine_command_output(&stdout, &stderr, exit_code);
 
         Ok(ToolOutput {
             content,

--- a/crates/genesis-tools/src/builtins/tts.rs
+++ b/crates/genesis-tools/src/builtins/tts.rs
@@ -41,13 +41,18 @@ impl ToolHandler for TextToSpeechTool {
             }
         }
 
-        let output = Command::new("edge-tts")
-            .args(build_edge_tts_args(text, voice, output_path, rate))
-            .output()
-            .map_err(|e| ToolError::ExecutionFailed {
-                tool: call.name.clone(),
-                reason: format!("failed to spawn edge-tts: {e}"),
-            })?;
+        let mut cmd = Command::new("edge-tts");
+        cmd.arg("--text").arg(text);
+        cmd.arg("--voice").arg(voice);
+        cmd.arg("--write-media").arg(output_path);
+        if let Some(r) = rate {
+            cmd.arg("--rate").arg(r);
+        }
+
+        let output = cmd.output().map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("failed to spawn edge-tts: {e}"),
+        })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
@@ -70,29 +75,6 @@ impl ToolHandler for TextToSpeechTool {
             ]),
         })
     }
-}
-
-fn build_edge_tts_args(
-    text: &str,
-    voice: &str,
-    output_path: &str,
-    rate: Option<&str>,
-) -> Vec<String> {
-    let mut args = vec![
-        "--text".to_owned(),
-        text.to_owned(),
-        "--voice".to_owned(),
-        voice.to_owned(),
-        "--write-media".to_owned(),
-        output_path.to_owned(),
-    ];
-
-    if let Some(rate) = rate {
-        args.push("--rate".to_owned());
-        args.push(rate.to_owned());
-    }
-
-    args
 }
 
 #[cfg(test)]
@@ -145,39 +127,5 @@ mod tests {
                 ..
             }
         ));
-    }
-
-    #[test]
-    fn build_edge_tts_args_uses_defaults() {
-        let args = build_edge_tts_args("hello", DEFAULT_VOICE, "out.mp3", None);
-        assert_eq!(
-            args,
-            vec![
-                "--text",
-                "hello",
-                "--voice",
-                DEFAULT_VOICE,
-                "--write-media",
-                "out.mp3",
-            ]
-        );
-    }
-
-    #[test]
-    fn build_edge_tts_args_includes_rate_when_present() {
-        let args = build_edge_tts_args("hello", "en-GB-SoniaNeural", "out.mp3", Some("+20%"));
-        assert_eq!(
-            args,
-            vec![
-                "--text",
-                "hello",
-                "--voice",
-                "en-GB-SoniaNeural",
-                "--write-media",
-                "out.mp3",
-                "--rate",
-                "+20%",
-            ]
-        );
     }
 }


### PR DESCRIPTION
## Summary

- **Extract shared stdout/stderr combiner**: The identical pattern for assembling command output from stdout + stderr in `docker.rs` and `ssh.rs` is now a single `combine_command_output()` helper in `builtins/mod.rs`, called from both modules.
- **Inline TTS args**: Removed the `build_edge_tts_args` function in `tts.rs` that built an intermediate `Vec<String>` with `.to_owned()` on every static flag. Arguments are now passed directly to `Command::arg()` calls.
- **Single-pass blank line collapse**: Replaced the `while content.contains("\n\n\n")` loop in `browse.rs` with a single-pass character iterator that collapses 3+ consecutive newlines to 2.

## Test plan

- [x] `cargo build --workspace` compiles successfully
- [x] `cargo test -p genesis-tools` -- all 379 tests pass
- [x] `cargo clippy --workspace -- -D warnings` -- zero warnings