### PR TITLE
refactor(core): explicit tokio features, consolidate test helpers, warn on unknown guardrail action

### DIFF
--- a/crates/genesis-core/Cargo.toml
+++ b/crates/genesis-core/Cargo.toml
@@ -26,7 +26,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
 tracing.workspace = true
 uuid.workspace = true
 which.workspace = true

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -1401,6 +1401,7 @@ mod tests {
         SessionTurnInput,
     };
     use crate::agent_loop::AgentResult;
+    use crate::tests::test_loaded_config;
     use genesis_provider::MessageContent;
     use genesis_config::{
         AppPaths, GenesisConfig, LoadedConfig, ProviderConfig, RuntimeConfig, StorageConfig,
@@ -1605,55 +1606,6 @@ mod tests {
             .expect("lookup should succeed")
             .expect("session should exist");
         assert_eq!(session.platform, "api");
-    }
-
-    fn test_loaded_config(data_dir: PathBuf, database_path: PathBuf) -> LoadedConfig {
-        LoadedConfig {
-            config: GenesisConfig {
-                schema_version: 1,
-                profile: "operator".to_owned(),
-                provider: ProviderConfig {
-                    backend: "openai".to_owned(),
-                    model: "gpt-4.1-mini".to_owned(),
-                    base_url: Some("http://localhost:8000/v1".to_owned()),
-                    api_key_env: None,
-                    extra_body: None,
-                    tool_call_parser: None,
-                },
-                tool_provider: None,
-                fallback_providers: Vec::new(),
-                mcp_servers: std::collections::HashMap::new(),
-                storage: StorageConfig {
-                    data_dir: data_dir.clone(),
-                    database_path: database_path.clone(),
-                },
-                runtime: RuntimeConfig {
-                    max_concurrency: 4,
-                    allow_destructive_tools: false,
-                    max_turns: 20,
-                    max_context_messages: None,
-                    budget_limit: None,
-                    terminal: None,
-                    thinking_budget: None,
-                    max_context_tokens: None,
-                    max_iterations: None,
-                    context_security: genesis_config::ContextSecurityPolicy::default(),
-                    reasoning_effort: None,
-                    cache: None,
-                    tool_filter: None,
-                    guardrails: None,
-                },
-                gateway: None,
-                toolsets: std::collections::HashMap::new(),
-                personality: None,
-                embedding: None,
-            },
-            paths: AppPaths {
-                config_path: PathBuf::from("/tmp/genesis/config.yaml"),
-                data_dir,
-                database_path,
-            },
-        }
     }
 
     #[test]

--- a/crates/genesis-core/src/guardrails.rs
+++ b/crates/genesis-core/src/guardrails.rs
@@ -428,7 +428,12 @@ impl From<&genesis_config::GuardrailsConfig> for GuardrailConfig {
         let pii_action = match cfg.pii_action.as_str() {
             "block" => ViolationAction::Block,
             "warn" => ViolationAction::Warn,
-            _ => ViolationAction::Redact,
+            other => {
+                if other != "redact" {
+                    tracing::warn!(pii_action = other, "unrecognized pii_action in guardrails config, defaulting to redact");
+                }
+                ViolationAction::Redact
+            }
         };
         let custom_rules = cfg.custom_rules.iter().map(|r| {
             let applies_to = match r.applies_to.as_str() {

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -935,7 +935,7 @@ pub fn default_tool_count() -> usize {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::{
         build_default_tool_runtime, build_execution_context_from_loaded, CheckStatus, SessionPlan,
     };
@@ -946,6 +946,58 @@ mod tests {
     use genesis_types::{DeliveryPlatform, ModelProviderKind, RuntimeEvent};
     use std::collections::BTreeMap;
     use std::path::PathBuf;
+
+    /// Shared test helper: build a minimal `LoadedConfig` with caller-specified paths.
+    ///
+    /// Re-used across `execution`, `nudge`, and `lib` test modules to avoid duplication.
+    pub(crate) fn test_loaded_config(data_dir: PathBuf, database_path: PathBuf) -> LoadedConfig {
+        LoadedConfig {
+            config: GenesisConfig {
+                schema_version: 1,
+                profile: "operator".to_owned(),
+                provider: ProviderConfig {
+                    backend: "openai".to_owned(),
+                    model: "gpt-4.1-mini".to_owned(),
+                    base_url: Some("http://localhost:8000/v1".to_owned()),
+                    api_key_env: None,
+                    extra_body: None,
+                    tool_call_parser: None,
+                },
+                tool_provider: None,
+                fallback_providers: Vec::new(),
+                mcp_servers: std::collections::HashMap::new(),
+                storage: StorageConfig {
+                    data_dir: data_dir.clone(),
+                    database_path: database_path.clone(),
+                },
+                runtime: RuntimeConfig {
+                    max_concurrency: 4,
+                    allow_destructive_tools: false,
+                    max_turns: 20,
+                    max_context_messages: None,
+                    budget_limit: None,
+                    terminal: None,
+                    thinking_budget: None,
+                    max_context_tokens: None,
+                    max_iterations: None,
+                    context_security: genesis_config::ContextSecurityPolicy::default(),
+                    reasoning_effort: None,
+                    cache: None,
+                    tool_filter: None,
+                    guardrails: None,
+                },
+                gateway: None,
+                toolsets: std::collections::HashMap::new(),
+                personality: None,
+                embedding: None,
+            },
+            paths: AppPaths {
+                config_path: PathBuf::from("/tmp/genesis/config.yaml"),
+                data_dir,
+                database_path,
+            },
+        }
+    }
 
     fn sample_loaded_config() -> LoadedConfig {
         LoadedConfig {

--- a/crates/genesis-core/src/nudge.rs
+++ b/crates/genesis-core/src/nudge.rs
@@ -195,60 +195,8 @@ fn load_recent_sessions_section(db_path: &std::path::Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use genesis_config::{
-        AppPaths, GenesisConfig, LoadedConfig, ProviderConfig, RuntimeConfig, StorageConfig,
-    };
-    use std::path::PathBuf;
+    use crate::tests::test_loaded_config;
     use tempfile::tempdir;
-
-    fn test_loaded_config(data_dir: PathBuf, database_path: PathBuf) -> LoadedConfig {
-        LoadedConfig {
-            config: GenesisConfig {
-                schema_version: 1,
-                profile: "operator".to_owned(),
-                provider: ProviderConfig {
-                    backend: "openai".to_owned(),
-                    model: "gpt-4.1-mini".to_owned(),
-                    base_url: Some("http://localhost:8000/v1".to_owned()),
-                    api_key_env: None,
-                    extra_body: None,
-                    tool_call_parser: None,
-                },
-                tool_provider: None,
-                fallback_providers: Vec::new(),
-                mcp_servers: std::collections::HashMap::new(),
-                storage: StorageConfig {
-                    data_dir: data_dir.clone(),
-                    database_path: database_path.clone(),
-                },
-                runtime: RuntimeConfig {
-                    max_concurrency: 4,
-                    allow_destructive_tools: false,
-                    max_turns: 20,
-                    max_context_messages: None,
-                    budget_limit: None,
-                    terminal: None,
-                    thinking_budget: None,
-                    max_context_tokens: None,
-                    max_iterations: None,
-                    context_security: genesis_config::ContextSecurityPolicy::default(),
-                    reasoning_effort: None,
-                    cache: None,
-                    tool_filter: None,
-                    guardrails: None,
-                },
-                gateway: None,
-                toolsets: std::collections::HashMap::new(),
-                personality: None,
-                embedding: None,
-            },
-            paths: AppPaths {
-                config_path: PathBuf::from("/tmp/genesis/config.yaml"),
-                data_dir,
-                database_path,
-            },
-        }
-    }
 
     #[test]
     fn nudge_prompt_includes_reflection_instructions() {


### PR DESCRIPTION
## Summary

- **Explicit tokio features in genesis-core/Cargo.toml**: Declares `rt`, `sync`, `time`, `macros` features directly instead of relying on implicit feature unification from sibling crates. Makes genesis-core self-contained.
- **Consolidate duplicated `test_loaded_config` helpers**: Moves the identical `test_loaded_config(data_dir, database_path)` helper from `nudge.rs` and `execution.rs` test modules into a single `pub(crate)` function in `lib.rs::tests`. Both modules now import it via `crate::tests::test_loaded_config`. Net removal of ~100 lines of duplication.
- **Warn on unrecognized guardrails `pii_action`**: The `From<&GuardrailsConfig>` impl now logs `tracing::warn!` when `pii_action` is not one of `"block"`, `"warn"`, or `"redact"`, helping surface config typos that would otherwise silently default to redact.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test -p genesis-core` passes (639 tests)
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings