### PR TITLE
refactor(gateway): narrow public API surface to pub(crate)

### DIFF
--- a/crates/genesis-gateway/src/commands.rs
+++ b/crates/genesis-gateway/src/commands.rs
@@ -10,7 +10,7 @@ use genesis_storage::SessionStore;
 use tracing::{info, warn};
 
 /// Result of processing a gateway command.
-pub enum CommandResult {
+pub(crate) enum CommandResult {
     /// Command was handled; send this reply to the user.
     Reply(String),
     /// Not a command; pass the message through to the agent.
@@ -25,7 +25,7 @@ pub enum CommandResult {
 /// - `/stop` — acknowledge stop
 /// - `/id` — show the current session ID
 /// - `/config` — show current model and session info
-pub fn handle_command(
+pub(crate) fn handle_command(
     text: &str,
     session_id: &str,
     store: &SessionStore,
@@ -142,7 +142,7 @@ pub fn handle_command(
 /// Returns `true` if the session was expired and deleted (caller should
 /// treat this as a fresh session). Returns `false` if the session is
 /// still valid or doesn't exist.
-pub fn check_session_expiry(
+pub(crate) fn check_session_expiry(
     session_id: &str,
     store: &SessionStore,
     gateway: Option<&GatewayConfig>,

--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -232,7 +232,7 @@ impl AppState {
 
 /// Request body for the `/chat` endpoint.
 #[derive(Debug, Deserialize)]
-pub struct ChatRequest {
+pub(crate) struct ChatRequest {
     pub message: String,
     #[serde(default = "default_platform")]
     pub platform: String,
@@ -254,7 +254,7 @@ pub struct ChatRequest {
 
 /// An image input for multimodal chat requests.
 #[derive(Debug, Clone, Deserialize)]
-pub struct ImageInput {
+pub(crate) struct ImageInput {
     /// Image URL (http/https) or base64 data URI.
     pub url: String,
     /// Optional detail level: "low", "high", or "auto" (default).
@@ -296,7 +296,7 @@ fn storage_err(e: impl std::fmt::Display) -> (StatusCode, String) {
 
 /// Response body from the `/chat` endpoint.
 #[derive(Debug, Serialize)]
-pub struct ChatResponse {
+pub(crate) struct ChatResponse {
     pub session_id: String,
     pub response: String,
     pub turns_used: usize,
@@ -312,14 +312,14 @@ pub struct ChatResponse {
 
 /// SSE payload for a streamed token chunk.
 #[derive(Debug, Serialize)]
-pub struct StreamChunkResponse {
+pub(crate) struct StreamChunkResponse {
     pub session_id: String,
     pub content: String,
 }
 
 /// SSE payload signaling final completion.
 #[derive(Debug, Serialize)]
-pub struct StreamDoneResponse {
+pub(crate) struct StreamDoneResponse {
     pub session_id: String,
     pub response: String,
     pub turns_used: usize,
@@ -332,14 +332,14 @@ pub struct StreamDoneResponse {
 
 /// SSE payload signaling an execution failure.
 #[derive(Debug, Serialize)]
-pub struct StreamErrorResponse {
+pub(crate) struct StreamErrorResponse {
     pub session_id: String,
     pub error: String,
 }
 
 /// Health check response.
 #[derive(Debug, Serialize)]
-pub struct HealthResponse {
+pub(crate) struct HealthResponse {
     pub status: String,
     pub version: String,
     pub uptime_seconds: u64,
@@ -352,7 +352,7 @@ pub struct HealthResponse {
 
 /// Detailed MCP server status response.
 #[derive(Debug, Serialize)]
-pub struct McpStatusResponse {
+pub(crate) struct McpStatusResponse {
     pub servers: Vec<McpServerStatus>,
     pub total_tools: usize,
     pub total_resources: usize,
@@ -361,7 +361,7 @@ pub struct McpStatusResponse {
 
 /// Status of a single MCP server.
 #[derive(Debug, Serialize)]
-pub struct McpServerStatus {
+pub(crate) struct McpServerStatus {
     pub name: String,
     pub connected: bool,
 }
@@ -1335,7 +1335,7 @@ async fn usage_handler(
 
 /// Request body for creating/updating a skill.
 #[derive(Debug, Deserialize)]
-pub struct UpsertSkillRequest {
+pub(crate) struct UpsertSkillRequest {
     pub name: String,
     pub description: String,
     pub instructions: String,
@@ -3269,7 +3269,7 @@ async fn chat_stream_handler(
 
 /// A single prompt within a batch request.
 #[derive(Debug, Deserialize)]
-pub struct BatchItem {
+pub(crate) struct BatchItem {
     pub message: String,
     #[serde(default = "default_platform")]
     pub platform: String,
@@ -3284,7 +3284,7 @@ pub struct BatchItem {
 
 /// Request body for the `/chat/batch` endpoint.
 #[derive(Debug, Deserialize)]
-pub struct BatchRequest {
+pub(crate) struct BatchRequest {
     pub items: Vec<BatchItem>,
     /// Maximum concurrent executions (default: 4, max: 16).
     #[serde(default = "default_batch_concurrency")]
@@ -3297,7 +3297,7 @@ fn default_batch_concurrency() -> usize {
 
 /// Result of a single item in a batch.
 #[derive(Debug, Serialize)]
-pub struct BatchItemResult {
+pub(crate) struct BatchItemResult {
     pub index: usize,
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3314,7 +3314,7 @@ pub struct BatchItemResult {
 
 /// Response body for the `/chat/batch` endpoint.
 #[derive(Debug, Serialize)]
-pub struct BatchResponse {
+pub(crate) struct BatchResponse {
     pub results: Vec<BatchItemResult>,
     pub total_items: usize,
     pub successful: usize,

--- a/crates/genesis-gateway/src/verify.rs
+++ b/crates/genesis-gateway/src/verify.rs
@@ -15,7 +15,7 @@ type HmacSha256 = Hmac<Sha256>;
 const WEBHOOK_TIMESTAMP_TOLERANCE_SECS: i64 = 300;
 
 /// Verify a simple token-style shared-secret header/value.
-pub fn verify_secret_token(secret: &str, provided: Option<&str>) -> bool {
+pub(crate) fn verify_secret_token(secret: &str, provided: Option<&str>) -> bool {
     match provided {
         Some(candidate) => constant_time_eq(secret.as_bytes(), candidate.as_bytes()),
         None => false,
@@ -47,7 +47,7 @@ fn timestamp_within_window(timestamp: &str, tolerance_secs: i64) -> bool {
 /// signing secret as key.
 ///
 /// Returns `true` if the signature is valid.
-pub fn verify_slack_signature(
+pub(crate) fn verify_slack_signature(
     signing_secret: &str,
     timestamp: &str,
     body: &[u8],
@@ -87,7 +87,7 @@ pub fn verify_slack_signature(
 ///
 /// The signature is computed over `{timestamp}{body}` using the
 /// application's public key.
-pub fn verify_discord_signature(
+pub(crate) fn verify_discord_signature(
     public_key_hex: &str,
     timestamp: &str,
     body: &[u8],
@@ -140,7 +140,7 @@ pub fn verify_discord_signature(
 /// WhatsApp includes an `x-hub-signature-256` header with the form:
 /// `sha256=<hex_hmac_sha256>`, where the HMAC is computed over the raw
 /// request body with the app secret as key.
-pub fn verify_whatsapp_signature(secret: &str, signature: Option<&str>, body: &[u8]) -> bool {
+pub(crate) fn verify_whatsapp_signature(secret: &str, signature: Option<&str>, body: &[u8]) -> bool {
     let signature = match signature.and_then(|sig| sig.strip_prefix("sha256=")) {
         Some(value) => value,
         None => return false,
@@ -157,7 +157,7 @@ pub fn verify_whatsapp_signature(secret: &str, signature: Option<&str>, body: &[
 }
 
 /// Constant-time comparison to prevent timing attacks.
-pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
     }


### PR DESCRIPTION
## Summary

- Narrowed 14 gateway-internal request/response types (`ChatRequest`, `ImageInput`, `ChatResponse`, `StreamChunkResponse`, `StreamDoneResponse`, `StreamErrorResponse`, `HealthResponse`, `McpStatusResponse`, `McpServerStatus`, `UpsertSkillRequest`, `BatchItem`, `BatchRequest`, `BatchItemResult`, `BatchResponse`) from `pub` to `pub(crate)` in `lib.rs` -- these are only used within the gateway crate's handlers.
- Narrowed all 5 public functions in `verify.rs` (`verify_secret_token`, `verify_slack_signature`, `verify_discord_signature`, `verify_whatsapp_signature`, `constant_time_eq`) to `pub(crate)` -- only used by the gateway's `platforms/` module.
- Narrowed `CommandResult`, `handle_command`, and `check_session_expiry` in `commands.rs` to `pub(crate)` -- only used within the gateway crate.
- Kept `AppState`, `build_router`, `RateLimiter`, and `HistogramBuckets` as `pub` since `RateLimiter` and `HistogramBuckets` are exposed via `AppState`'s public fields.

## Test plan

- [x] `cargo build --workspace` compiles cleanly with no warnings
- [x] `cargo test -p genesis-gateway` -- all 155 tests pass
- [x] `cargo clippy --workspace -- -D warnings` -- zero warnings