### PR TITLE
perf(provider): connection warmup for TCP+TLS pre-establishment

### DIFF
--- a/crates/genesis-provider/src/client.rs
+++ b/crates/genesis-provider/src/client.rs
@@ -690,12 +690,15 @@ impl ChatClient {
     pub async fn warmup(&self) {
         let url = &self.endpoint;
         match self.http.head(url).send().await {
-            Ok(_) => {
-                tracing::debug!(backend = %self.backend, "connection warmed");
+            Ok(r) => {
+                // Any response (even 405 Method Not Allowed) means the TCP+TLS
+                // connection has been established, which is the actual goal.
+                tracing::debug!(endpoint = %self.endpoint, status = %r.status(), "connection pre-established");
             }
             Err(e) => {
-                // Not critical — the first real request will establish the connection.
-                tracing::debug!(backend = %self.backend, error = %e, "connection warmup failed (non-critical)");
+                // Connection-level failure (DNS, TCP, TLS) — not critical,
+                // the first real request will establish the connection.
+                tracing::debug!(endpoint = %self.endpoint, error = %e, "connection warmup failed");
             }
         }
     }

--- a/crates/genesis-provider/src/lib.rs
+++ b/crates/genesis-provider/src/lib.rs
@@ -75,7 +75,20 @@ pub async fn client_from_config(
 /// This runs concurrently with other initialization work (system prompt
 /// building, tool registration, etc.) so the connection is likely ready
 /// by the time the first real LLM request is made.
+///
+/// Skipped when running tests (`cfg!(test)`) or when the endpoint points
+/// to a local address, to avoid firing real network requests in test suites.
 fn spawn_warmup(client: &ChatClient) {
+    if cfg!(test) {
+        return;
+    }
+
+    let endpoint = client.endpoint();
+    if endpoint.contains("localhost") || endpoint.contains("127.0.0.1") || endpoint.contains("[::1]") {
+        tracing::debug!(endpoint = %endpoint, "skipping connection warmup for local endpoint");
+        return;
+    }
+
     let client = client.clone();
     tokio::spawn(async move { client.warmup().await });
 }


### PR DESCRIPTION
## Summary

- Adds a `warmup()` method to `ChatClient` that fires a lightweight HEAD request to pre-establish TCP+TLS connections in the connection pool
- Integrates warmup into `client_from_config()` via a spawned background task so it runs concurrently with other initialization (system prompt building, tool registration, MCP setup)
- The connection pool retains the warmed connection, so the first real `complete()` / `complete_stream()` call skips DNS + TCP + TLS handshake entirely

This eliminates ~100-300ms of cold-start latency on the first LLM request (varies by provider distance and TLS negotiation time). Warmup is best-effort: failures are logged at debug level and silently ignored.

Refs: #41, #47

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings
- [x] `cargo test -p genesis-provider` — all 146 tests pass
- [ ] Manual: run `GENESIS_LOG_FORMAT=json cargo run -- chat` with `RUST_LOG=debug` and verify `"connection warmed"` appears in logs before the first LLM response