### PR TITLE
refactor: tighten visibility and remove dead dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,12 +500,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -799,7 +793,6 @@ dependencies = [
  "tracing",
  "tracing-test",
  "uuid",
- "which",
 ]
 
 [[package]]
@@ -1413,12 +1406,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1882,19 +1869,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1902,7 +1876,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2272,7 +2246,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -2850,18 +2824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,12 +2992,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/genesis-core/Cargo.toml
+++ b/crates/genesis-core/Cargo.toml
@@ -29,7 +29,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
 tracing.workspace = true
 uuid.workspace = true
-which.workspace = true
 
 [dev-dependencies]
 insta = "1"

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -2,7 +2,8 @@ pub mod agent_bus;
 pub mod agent_loop;
 pub mod audit;
 pub mod compress;
-pub mod context_security;
+#[allow(dead_code)]
+pub(crate) mod context_security;
 pub mod dataset;
 pub mod embedding;
 pub mod cost;
@@ -21,7 +22,8 @@ pub mod skill_sync;
 pub mod skills;
 pub mod skills_hub;
 pub mod quality;
-pub mod redact;
+#[allow(dead_code)]
+pub(crate) mod redact;
 pub mod skill_manifest;
 pub mod skills_guard;
 pub mod personality;

--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -42,7 +42,7 @@ static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 /// Stale entries (older than 2 minutes) are purged on every check to
 /// prevent unbounded memory growth.
 #[derive(Debug)]
-pub struct RateLimiter {
+pub(crate) struct RateLimiter {
     /// Max requests per 60-second window.  Stored here so the middleware
     /// doesn't need to re-read `AppState`.
     max_rpm: u32,
@@ -103,7 +103,7 @@ impl RateLimiter {
 }
 
 /// Prometheus-style histogram with fixed bucket boundaries.
-pub struct HistogramBuckets {
+pub(crate) struct HistogramBuckets {
     /// Bucket boundaries in milliseconds.
     boundaries: &'static [u64],
     /// Count of observations in each bucket (cumulative).
@@ -171,7 +171,7 @@ pub struct AppState {
     /// Shared HTTP client for outbound platform API calls (connection pooling).
     pub http_client: reqwest::Client,
     /// Optional per-IP rate limiter.
-    pub rate_limiter: Option<RateLimiter>,
+    pub(crate) rate_limiter: Option<RateLimiter>,
     /// Trusted reverse proxy IPs allowed to supply forwarded headers.
     pub trusted_proxies: Vec<IpAddr>,
     /// Webhook event dispatcher for external notifications.
@@ -190,7 +190,7 @@ pub struct AppState {
     /// Total streaming requests.
     pub stream_requests_total: AtomicU64,
     /// Request duration histogram buckets (in ms): [50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, +Inf]
-    pub request_duration_histogram: Mutex<HistogramBuckets>,
+    pub(crate) request_duration_histogram: Mutex<HistogramBuckets>,
     /// Agent message bus for inter-agent communication.
     pub agent_bus: genesis_core::agent_bus::AgentBus,
 }

--- a/crates/genesis-provider/src/lib.rs
+++ b/crates/genesis-provider/src/lib.rs
@@ -3,7 +3,8 @@ mod api_types;
 mod client;
 mod error;
 mod gemini_types;
-pub mod model_metadata;
+#[allow(dead_code)]
+pub(crate) mod model_metadata;
 pub mod parsers;
 pub mod pricing;
 mod resolve;


### PR DESCRIPTION
## Summary

- **Tighten module visibility in genesis-core**: `context_security` and `redact` modules changed from `pub mod` to `pub(crate) mod` — neither is imported by any external crate (verified via workspace-wide search)
- **Tighten module visibility in genesis-provider**: `model_metadata` module changed from `pub mod` to `pub(crate) mod` — not imported externally
- **Tighten struct/field visibility in genesis-gateway**: `RateLimiter` and `HistogramBuckets` structs changed from `pub` to `pub(crate)`, along with the corresponding `rate_limiter` and `request_duration_histogram` fields on `AppState`
- **Remove unused `which` dependency** from genesis-core — `singularity.rs` calls the `which` shell binary via `Command::new("which")`, not the Rust crate
- **`SkillHubError` already has `#[derive(Debug)]`** — no change needed

All visibility changes were verified by searching for external usage patterns across the entire workspace before applying. `#[allow(dead_code)]` added to newly-internal modules that contain test-exercised code intended for future integration.

## Test plan

- [x] `cargo build --workspace` passes with zero warnings
- [x] `cargo clippy --workspace -- -D warnings` passes cleanly
- [x] `cargo test -p genesis-core -p genesis-provider -p genesis-gateway` — 951 tests pass, 0 failures