### PR TITLE
refactor: extract shared test_ctx helper for genesis-tools tests

### DIFF
--- a/crates/genesis-tools/src/builtins/browse.rs
+++ b/crates/genesis-tools/src/builtins/browse.rs
@@ -285,15 +285,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/browser.rs
+++ b/crates/genesis-tools/src/builtins/browser.rs
@@ -1469,15 +1469,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test-session".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/channel_directory.rs
+++ b/crates/genesis-tools/src/builtins/channel_directory.rs
@@ -437,13 +437,8 @@ mod tests {
         std::fs::create_dir_all(&dir).ok();
         genesis_storage::bootstrap(&dir.join("genesis.db")).ok();
         ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
             data_dir: dir.to_string_lossy().to_string(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
+            ..crate::test_utils::test_ctx()
         }
     }
 

--- a/crates/genesis-tools/src/builtins/clarify.rs
+++ b/crates/genesis-tools/src/builtins/clarify.rs
@@ -56,15 +56,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/code_execution.rs
+++ b/crates/genesis-tools/src/builtins/code_execution.rs
@@ -745,15 +745,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     // --- Basic code execution tests (non-PTC) ---

--- a/crates/genesis-tools/src/builtins/docker.rs
+++ b/crates/genesis-tools/src/builtins/docker.rs
@@ -66,15 +66,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/fs.rs
+++ b/crates/genesis-tools/src/builtins/fs.rs
@@ -153,15 +153,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/git.rs
+++ b/crates/genesis-tools/src/builtins/git.rs
@@ -425,22 +425,11 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     fn ctx_no_destructive() -> ToolContext {
-        ToolContext {
-            allow_destructive_tools: false,
-            ..ctx()
-        }
+        crate::test_utils::test_ctx()
     }
 
     /// Initialise a temporary git repo with one commit so that tools have

--- a/crates/genesis-tools/src/builtins/glob.rs
+++ b/crates/genesis-tools/src/builtins/glob.rs
@@ -160,15 +160,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     fn make_call(args: Vec<(&str, &str)>) -> ToolCall {

--- a/crates/genesis-tools/src/builtins/homeassistant.rs
+++ b/crates/genesis-tools/src/builtins/homeassistant.rs
@@ -404,15 +404,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/image_gen.rs
+++ b/crates/genesis-tools/src/builtins/image_gen.rs
@@ -192,15 +192,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     fn make_call(args: Vec<(&str, &str)>) -> ToolCall {

--- a/crates/genesis-tools/src/builtins/memory.rs
+++ b/crates/genesis-tools/src/builtins/memory.rs
@@ -195,12 +195,8 @@ mod tests {
     fn ctx(data_dir: &str) -> ToolContext {
         ToolContext {
             session_id: "session-42".to_owned(),
-            profile: "operator".to_owned(),
             data_dir: data_dir.to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
+            ..crate::test_utils::test_ctx()
         }
     }
 

--- a/crates/genesis-tools/src/builtins/mixture.rs
+++ b/crates/genesis-tools/src/builtins/mixture.rs
@@ -225,15 +225,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/patch.rs
+++ b/crates/genesis-tools/src/builtins/patch.rs
@@ -460,15 +460,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     // ── Exact match tests (preserved from original) ──

--- a/crates/genesis-tools/src/builtins/process.rs
+++ b/crates/genesis-tools/src/builtins/process.rs
@@ -542,15 +542,7 @@ mod tests {
     use crate::MAX_OUTPUT_BYTES;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     // -----------------------------------------------------------------------

--- a/crates/genesis-tools/src/builtins/process_registry.rs
+++ b/crates/genesis-tools/src/builtins/process_registry.rs
@@ -978,15 +978,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     fn make_call(action: &str, extra: &[(&str, &str)]) -> ToolCall {

--- a/crates/genesis-tools/src/builtins/reason.rs
+++ b/crates/genesis-tools/src/builtins/reason.rs
@@ -113,15 +113,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/search.rs
+++ b/crates/genesis-tools/src/builtins/search.rs
@@ -167,15 +167,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/send_message.rs
+++ b/crates/genesis-tools/src/builtins/send_message.rs
@@ -474,15 +474,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/shell.rs
+++ b/crates/genesis-tools/src/builtins/shell.rs
@@ -422,15 +422,7 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]
@@ -504,13 +496,8 @@ mod tests {
         };
 
         let context = ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
             default_working_dir: Some("/tmp".to_owned()),
-            sandbox_manager: None,
+            ..crate::test_utils::test_ctx_destructive()
         };
 
         let output = tool.run(&call, &context).expect("should succeed");
@@ -533,13 +520,8 @@ mod tests {
         };
 
         let context = ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
             default_working_dir: Some("/tmp".to_owned()),
-            sandbox_manager: None,
+            ..crate::test_utils::test_ctx_destructive()
         };
 
         let output = tool.run(&call, &context).expect("should succeed");

--- a/crates/genesis-tools/src/builtins/ssh.rs
+++ b/crates/genesis-tools/src/builtins/ssh.rs
@@ -75,15 +75,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/todo.rs
+++ b/crates/genesis-tools/src/builtins/todo.rs
@@ -199,26 +199,13 @@ mod tests {
     use crate::ToolContext;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     fn ctx_with_session(session_id: &str) -> ToolContext {
         ToolContext {
             session_id: session_id.to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
+            ..crate::test_utils::test_ctx_destructive()
         }
     }
 

--- a/crates/genesis-tools/src/builtins/trajectory.rs
+++ b/crates/genesis-tools/src/builtins/trajectory.rs
@@ -395,12 +395,8 @@ mod tests {
     fn ctx(data_dir: &str) -> ToolContext {
         ToolContext {
             session_id: "session-42".to_owned(),
-            profile: "operator".to_owned(),
             data_dir: data_dir.to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
+            ..crate::test_utils::test_ctx()
         }
     }
 

--- a/crates/genesis-tools/src/builtins/transcribe.rs
+++ b/crates/genesis-tools/src/builtins/transcribe.rs
@@ -184,15 +184,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     fn make_call(args: Vec<(&str, &str)>) -> ToolCall {

--- a/crates/genesis-tools/src/builtins/tree.rs
+++ b/crates/genesis-tools/src/builtins/tree.rs
@@ -255,15 +255,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     fn make_call(args: Vec<(&str, &str)>) -> ToolCall {

--- a/crates/genesis-tools/src/builtins/tts.rs
+++ b/crates/genesis-tools/src/builtins/tts.rs
@@ -82,15 +82,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: true,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx_destructive()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/vision.rs
+++ b/crates/genesis-tools/src/builtins/vision.rs
@@ -224,15 +224,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     fn make_call(args: Vec<(&str, &str)>) -> ToolCall {

--- a/crates/genesis-tools/src/builtins/web.rs
+++ b/crates/genesis-tools/src/builtins/web.rs
@@ -146,15 +146,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/web_search.rs
+++ b/crates/genesis-tools/src/builtins/web_search.rs
@@ -159,15 +159,7 @@ mod tests {
     use super::*;
 
     fn ctx() -> ToolContext {
-        ToolContext {
-            session_id: "test".to_owned(),
-            profile: "test".to_owned(),
-            data_dir: "/tmp".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     #[test]

--- a/crates/genesis-tools/src/lib.rs
+++ b/crates/genesis-tools/src/lib.rs
@@ -1652,6 +1652,35 @@ impl ToolHandler for SessionInfoTool {
 }
 
 #[cfg(test)]
+pub mod test_utils {
+    use super::ToolContext;
+
+    /// Create a test `ToolContext` with standard defaults.
+    ///
+    /// Uses `allow_destructive_tools: false`. For tests requiring destructive
+    /// tool access, use [`test_ctx_destructive`] instead.
+    pub fn test_ctx() -> ToolContext {
+        ToolContext {
+            session_id: "test".to_owned(),
+            profile: "test".to_owned(),
+            data_dir: "/tmp".to_owned(),
+            allow_destructive_tools: false,
+            terminal_backend: None,
+            default_working_dir: None,
+            sandbox_manager: None,
+        }
+    }
+
+    /// Create a test `ToolContext` with destructive tool access enabled.
+    pub fn test_ctx_destructive() -> ToolContext {
+        ToolContext {
+            allow_destructive_tools: true,
+            ..test_ctx()
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::{
         default_registry, ApprovalPolicy, ToolCall, ToolContext, ToolError, ToolHandler,
@@ -1676,15 +1705,7 @@ mod tests {
     }
 
     fn sample_context() -> ToolContext {
-        ToolContext {
-            session_id: "session-42".to_owned(),
-            profile: "operator".to_owned(),
-            data_dir: "/tmp/genesis".to_owned(),
-            allow_destructive_tools: false,
-            terminal_backend: None,
-            default_working_dir: None,
-            sandbox_manager: None,
-        }
+        crate::test_utils::test_ctx()
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Replace 29 duplicated `fn ctx() -> ToolContext` test helpers with a shared `test_utils::test_ctx()` function. Net result: **-218 lines** (63 insertions, 281 deletions).

### Changes
- **New `test_utils` module** in `crates/genesis-tools/src/lib.rs` with `test_ctx()` and `test_ctx_destructive()` helpers (behind `#[cfg(test)]`)
- **Updated 29 test modules** across `crates/genesis-tools/src/builtins/` to use the shared helpers
- Files with custom needs (memory.rs, trajectory.rs, channel_directory.rs) use struct update syntax `..test_ctx()` to override specific fields
- Secondary helpers (`ctx_with_session`, `ctx_no_destructive`, etc.) also delegate to the shared base

Adding new fields to `ToolContext` is now a single-point change instead of updating 29 separate functions.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] `cargo test -p genesis-tools` — all 381 tests pass
- [x] Only test code changed — no production code modifications