### PR TITLE
refactor: gateway VecDeque dead letters and HTTP client timeouts

### DIFF
--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -213,7 +213,11 @@ impl AppState {
             api_key,
             api_key_required,
             mcp,
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .user_agent("genesis-gateway/0.1")
+                .build()
+                .unwrap_or_default(),
             rate_limiter: rate_limit_rpm.map(RateLimiter::new),
             trusted_proxies,
             loaded,

--- a/crates/genesis-gateway/src/webhooks.rs
+++ b/crates/genesis-gateway/src/webhooks.rs
@@ -4,6 +4,7 @@
 //! and exponential backoff. Failed deliveries after all retries are logged as
 //! dead-letter entries for later inspection.
 
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -72,7 +73,7 @@ pub struct WebhookMetrics {
 pub struct WebhookDispatcher {
     client: Client,
     configs: Vec<WebhookConfig>,
-    dead_letters: Arc<Mutex<Vec<DeadLetterEntry>>>,
+    dead_letters: Arc<Mutex<VecDeque<DeadLetterEntry>>>,
     metrics: Arc<WebhookMetrics>,
 }
 
@@ -86,7 +87,7 @@ impl WebhookDispatcher {
         Self {
             client,
             configs,
-            dead_letters: Arc::new(Mutex::new(Vec::new())),
+            dead_letters: Arc::new(Mutex::new(VecDeque::new())),
             metrics: Arc::new(WebhookMetrics::default()),
         }
     }
@@ -107,7 +108,7 @@ impl WebhookDispatcher {
 
     /// Return a snapshot of the dead-letter queue.
     pub async fn dead_letters(&self) -> Vec<DeadLetterEntry> {
-        self.dead_letters.lock().await.clone()
+        Vec::from(self.dead_letters.lock().await.clone())
     }
 
     /// Clear the dead-letter queue, returning how many entries were removed.
@@ -232,9 +233,9 @@ impl WebhookDispatcher {
                 let mut dl = dead_letters.lock().await;
                 // Cap the dead-letter queue at 1000 entries
                 if dl.len() >= 1000 {
-                    dl.remove(0);
+                    dl.pop_front();
                 }
-                dl.push(entry);
+                dl.push_back(entry);
             });
         }
     }
@@ -363,7 +364,7 @@ mod tests {
         // Add a dead letter manually for testing
         {
             let mut dl = dispatcher.dead_letters.lock().await;
-            dl.push(DeadLetterEntry {
+            dl.push_back(DeadLetterEntry {
                 url: "http://example.com".into(),
                 event_type: "test".into(),
                 payload: "{}".into(),


### PR DESCRIPTION
## Summary
Two small gateway cleanups for correctness and robustness.

### Changes
- **VecDeque for dead-letter queue** (`webhooks.rs`) — Replace `Vec::remove(0)` (O(n) shift of 999 elements) with `VecDeque::pop_front()` (O(1)) when evicting oldest dead letters at capacity
- **HTTP client timeouts** (`lib.rs`) — Add 30-second timeout and user-agent to `AppState::http_client` which previously used `reqwest::Client::new()` with no limits, meaning a hanging platform API call would leak the connection indefinitely

WebhookDispatcher's separate client (10s timeout) is intentionally kept separate — it serves a different timeout policy for fire-and-forget webhook delivery.

## Test plan
- [x] `cargo clippy -p genesis-gateway -- -D warnings` passes
- [x] All 155 genesis-gateway tests pass