### PR TITLE
refactor: eliminate unnecessary allocations and deduplicate constants in genesis-core

### DIFF
--- a/crates/genesis-core/src/agent_loop.rs
+++ b/crates/genesis-core/src/agent_loop.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use crate::cost::{BudgetStatus, SessionCost};
 use crate::hooks::{HookEvent, HookResult, HookRunner};
+use crate::nudge::SKILL_CREATION_NUDGE;
 use crate::sanitize;
 use crate::trajectory::TrajectoryRecorder;
 use crate::ToolRuntime;
@@ -126,14 +127,6 @@ would be valuable in future sessions — not session-specific details.";
 
 /// Number of tool calls in a single turn that triggers a skill creation nudge.
 const SKILL_CREATION_THRESHOLD: usize = 8;
-
-/// The skill creation nudge message injected as a system message.
-const SKILL_CREATION_NUDGE: &str = "\
-[Skill creation opportunity] The task you just completed was multi-step and \
-complex. Consider whether the approach you used could be distilled into a \
-reusable skill. If so, call `skill_create` with a descriptive name, clear \
-instructions for how to handle this type of task, and relevant tags. Good \
-skills capture durable patterns — not one-off details.";
 
 impl Default for AgentLoopConfig {
     fn default() -> Self {
@@ -291,6 +284,11 @@ impl AgentLoop {
         hook_runner: HookRunner,
     ) -> Self {
         Self::with_history(client, tools, config, hook_runner, Vec::new())
+    }
+
+    /// Return the session ID as a `&str`, defaulting to `""` when unset.
+    fn session_id_str(&self) -> &str {
+        self.config.session_id.as_deref().unwrap_or_default()
     }
 
     pub fn with_history(
@@ -605,7 +603,7 @@ impl AgentLoop {
         user_message: &str,
         images: Vec<genesis_provider::ImageUrl>,
     ) -> Result<AgentResult, AgentError> {
-        let hook_session = self.config.session_id.clone().unwrap_or_default();
+        let hook_session = self.session_id_str().to_owned();
         self.fire_shell_hooks(
             HookEvent::PreTurn,
             serde_json::json!({
@@ -1046,7 +1044,7 @@ impl AgentLoop {
     where
         F: FnMut(StreamEvent<'_>),
     {
-        let hook_session = self.config.session_id.clone().unwrap_or_default();
+        let hook_session = self.session_id_str().to_owned();
         self.fire_shell_hooks(
             HookEvent::PreTurn,
             serde_json::json!({
@@ -1615,7 +1613,7 @@ impl AgentLoop {
             return;
         }
 
-        let hook_session = self.config.session_id.clone().unwrap_or_default();
+        let hook_session = self.session_id_str().to_owned();
         for tool in &stuck_tools {
             let count = self.tool_failure_counts[tool];
             warn!(
@@ -1853,7 +1851,7 @@ impl AgentLoop {
             self.messages.insert(drop_start, summary_msg);
         }
 
-        let hook_session = self.config.session_id.clone().unwrap_or_default();
+        let hook_session = self.session_id_str().to_owned();
         self.hooks
             .on_context_prune(&hook_session, messages_before, self.messages.len());
     }

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -15,6 +15,7 @@ use tracing::{debug, error, info, info_span, warn, Instrument};
 use genesis_mcp::McpManager;
 
 use crate::agent_loop::{AgentError, AgentLoop, AgentLoopConfig, AgentResult, SubagentSpawner};
+use crate::nudge::SKILL_CREATION_NUDGE;
 use crate::prompt::{SystemPromptBuilder, load_context_file};
 use crate::sandbox::{
     BackendSpecific, SandboxBackend, SandboxConfig,
@@ -363,9 +364,10 @@ impl<'a> SessionExecutionService<'a> {
             return None;
         }
 
+        use std::fmt::Write;
         let mut section = String::new();
         for mem in &memories {
-            section.push_str(&format!("- [{}] {}\n", mem.kind, mem.content));
+            let _ = writeln!(section, "- [{}] {}", mem.kind, mem.content);
         }
         Some(section)
     }
@@ -757,19 +759,18 @@ impl<'a> SessionExecutionService<'a> {
 
             let outcome = self.run_turn(turn_input).await?;
 
-            let step_output = outcome.result.response.clone();
+            let step_output = outcome.result.response;  // move, not clone
             total_input_tokens += outcome.result.total_input_tokens;
             total_output_tokens += outcome.result.total_output_tokens;
 
             step_outputs.insert(step.name.clone(), step_output.clone());
+            final_output = step_output.clone();
             step_results.push(StepResult {
                 step_name: step.name.clone(),
-                output: step_output.clone(),
+                output: step_output,  // move last use
                 input_tokens: outcome.result.total_input_tokens,
                 output_tokens: outcome.result.total_output_tokens,
             });
-
-            final_output = step_output;
 
             info!(
                 step = i + 1,
@@ -1112,16 +1113,6 @@ const SKILL_NUDGE_TOOL_THRESHOLD: usize = 5;
 /// Minimum turns used before injecting a skill creation nudge.
 const SKILL_NUDGE_TURN_THRESHOLD: usize = 3;
 
-/// Nudge message injected after complex turns to encourage autonomous skill
-/// creation. Stored as a system message in the session so the agent sees it
-/// at the start of the next turn.
-const SKILL_CREATION_NUDGE: &str = "\
-[Skill creation opportunity] The task you just completed was multi-step and \
-complex. Consider whether the approach you used could be distilled into a \
-reusable skill. If so, call `skill_create` with a descriptive name, clear \
-instructions for how to handle this type of task, and relevant tags. Good \
-skills capture durable patterns — not one-off details.";
-
 /// After a complex turn (many tool calls, multiple turns), inject a system
 /// message nudging the agent to create a skill from the pattern. The nudge
 /// is persisted so it appears when the next turn loads history.
@@ -1157,7 +1148,13 @@ fn maybe_inject_skill_nudge(
 fn generate_session_title(prompt: &str) -> String {
     const MAX_LEN: usize = 60;
 
-    let normalized: String = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+    let normalized = prompt.split_whitespace().fold(String::new(), |mut acc, w| {
+        if !acc.is_empty() {
+            acc.push(' ');
+        }
+        acc.push_str(w);
+        acc
+    });
 
     let truncated: String = normalized.chars().take(MAX_LEN).collect();
 

--- a/crates/genesis-core/src/nudge.rs
+++ b/crates/genesis-core/src/nudge.rs
@@ -9,6 +9,16 @@ use genesis_storage::{bootstrap, format_user_traits, SessionStore, SkillStore, S
 
 use crate::execution::{SessionExecutionError, SessionExecutionService, SessionTurnInput};
 
+/// The skill creation nudge message injected as a system message after complex
+/// turns. Shared between the agent loop (in-flight nudge) and execution service
+/// (persisted nudge for the next turn).
+pub const SKILL_CREATION_NUDGE: &str = "\
+[Skill creation opportunity] The task you just completed was multi-step and \
+complex. Consider whether the approach you used could be distilled into a \
+reusable skill. If so, call `skill_create` with a descriptive name, clear \
+instructions for how to handle this type of task, and relevant tags. Good \
+skills capture durable patterns — not one-off details.";
+
 /// Build a reflection prompt from the agent's current knowledge state.
 ///
 /// This loads memories, user model traits, and recent sessions from storage,


### PR DESCRIPTION
## Summary
Five small optimizations in genesis-core eliminating unnecessary allocations and deduplicating constants.

### Changes
- **`session_id_str()` accessor** — Centralize `self.config.session_id.as_deref().unwrap_or_default()` into one method, replacing 4 scattered `clone().unwrap_or_default()` calls
- **Eliminate intermediate Vec** — `generate_session_title` used `.collect::<Vec<_>>().join(" ")` for whitespace normalization; now uses `fold` to build the string directly
- **`writeln!` instead of `push_str(&format!())`** — `recall_memories` loop avoids a temporary String allocation per memory entry
- **Deduplicate `SKILL_CREATION_NUDGE`** — Move identical constant from both `agent_loop.rs` and `execution.rs` into `nudge.rs` (single source of truth)
- **Reduce clones in `run_workflow`** — Reorder operations so `step_output` is moved on its last use instead of cloned, saving one String clone per workflow step

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] All 643 genesis-core tests pass