### PR TITLE
refactor: remove unused `which` from workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ tracing-test = "0.2"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 libc = "0.2"
-which = "6"
 insta = { version = "1", features = ["yaml"] }
 
 [profile.dev]


### PR DESCRIPTION
## Summary

- Remove the stale `which = "6"` entry from `[workspace.dependencies]` in the root `Cargo.toml`. The `which` crate was removed from `genesis-core`'s dependencies in PR #101, but its workspace-level entry was left behind. No crate in the workspace references `which.workspace = true`.

### Other items investigated (no changes needed)

- **`serde_yaml` in genesis-mcp**: Not present in `crates/genesis-mcp/Cargo.toml` (neither deps nor dev-deps), so nothing to remove.
- **`insta` consolidation**: Already declared in `[workspace.dependencies]` with `features = ["yaml"]`, and both `genesis-core` and `genesis-provider` already use `insta = { workspace = true }` in their dev-deps. No change needed.
- **`[profile.dev.package."*"]` optimization**: Already present in root `Cargo.toml` with `opt-level = 2` (more aggressive than the suggested `opt-level = 1`). No change needed.

## Verification

- `cargo build --workspace` -- passes
- `cargo test -p genesis-mcp` -- all 46 tests pass
- `cargo clippy --workspace -- -D warnings` -- zero warnings

## Test plan

- [x] Workspace builds successfully
- [x] All genesis-mcp tests pass
- [x] Clippy clean with `-D warnings`
- [ ] CI passes