### PR TITLE
refactor: replace remaining unwrap/expect with proper error handling

### DIFF
--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -3464,7 +3464,24 @@ async fn chat_batch_handler(
         let sem = Arc::clone(&semaphore);
 
         handles.push(tokio::spawn(async move {
-            let _permit = sem.acquire().await.expect("semaphore closed");
+            let _permit = match sem.acquire().await {
+                Ok(permit) => permit,
+                Err(_) => {
+                    return BatchItemResult {
+                        index,
+                        session_id: item
+                            .session_id
+                            .unwrap_or_else(default_api_session_id),
+                        response: None,
+                        error: Some("batch semaphore closed".to_string()),
+                        turns_used: 0,
+                        tool_calls_made: 0,
+                        estimated_cost: None,
+                        total_input_tokens: 0,
+                        total_output_tokens: 0,
+                    };
+                }
+            };
 
             let mut service = SessionExecutionService::new(&state.loaded);
             if let Some(mcp) = &state.mcp {

--- a/crates/genesis-tools/src/builtins/browser.rs
+++ b/crates/genesis-tools/src/builtins/browser.rs
@@ -84,7 +84,11 @@ impl BrowserManager {
     ) -> Result<(String, Option<String>), ToolError> {
         // Fast path: session already exists
         {
-            let sessions = self.sessions.lock().unwrap();
+            let sessions =
+                self.sessions.lock().map_err(|_| ToolError::ExecutionFailed {
+                    tool: "browser".to_string(),
+                    reason: "browser session lock poisoned".to_string(),
+                })?;
             if let Some(info) = sessions.get(session_id) {
                 return Ok((info.session_name.clone(), info.cdp_url.clone()));
             }
@@ -98,7 +102,11 @@ impl BrowserManager {
         };
 
         // Re-acquire and insert, handling TOCTOU race
-        let mut sessions = self.sessions.lock().unwrap();
+        let mut sessions =
+            self.sessions.lock().map_err(|_| ToolError::ExecutionFailed {
+                tool: "browser".to_string(),
+                reason: "browser session lock poisoned".to_string(),
+            })?;
         if let Some(existing) = sessions.get(session_id) {
             // Another thread created a session in the meantime
             let result = (existing.session_name.clone(), existing.cdp_url.clone());
@@ -117,7 +125,9 @@ impl BrowserManager {
     /// Update the last_activity timestamp for a session and cleanup stale ones.
     pub fn touch_session(&self, session_id: &str) {
         {
-            let mut sessions = self.sessions.lock().unwrap();
+            let Ok(mut sessions) = self.sessions.lock() else {
+                return;
+            };
             if let Some(info) = sessions.get_mut(session_id) {
                 info.last_activity = Instant::now();
             }
@@ -133,7 +143,11 @@ impl BrowserManager {
         tool_name: &str,
     ) -> Result<(String, Option<String>), ToolError> {
         let info = {
-            let sessions = self.sessions.lock().unwrap();
+            let sessions =
+                self.sessions.lock().map_err(|_| ToolError::ExecutionFailed {
+                    tool: tool_name.to_owned(),
+                    reason: "browser session lock poisoned".to_string(),
+                })?;
             sessions
                 .get(session_id)
                 .map(|info| (info.session_name.clone(), info.cdp_url.clone()))
@@ -148,7 +162,9 @@ impl BrowserManager {
 
     /// Mark first_nav as false and return (was_first_nav, features).
     pub fn consume_first_nav(&self, session_id: &str) -> (bool, BTreeMap<String, bool>) {
-        let mut sessions = self.sessions.lock().unwrap();
+        let Ok(mut sessions) = self.sessions.lock() else {
+            return (false, BTreeMap::new());
+        };
         if let Some(info) = sessions.get_mut(session_id) {
             let was_first = info.first_nav;
             info.first_nav = false;
@@ -162,7 +178,9 @@ impl BrowserManager {
     /// applicable and cleans up daemon/socket files.
     pub fn close_session(&self, session_id: &str) {
         let removed = {
-            let mut sessions = self.sessions.lock().unwrap();
+            let Ok(mut sessions) = self.sessions.lock() else {
+                return;
+            };
             sessions.remove(session_id)
         };
 
@@ -189,7 +207,9 @@ impl BrowserManager {
     /// Close all active sessions.
     fn close_all_sessions(&self) {
         let all: Vec<String> = {
-            let sessions = self.sessions.lock().unwrap();
+            let Ok(sessions) = self.sessions.lock() else {
+                return;
+            };
             sessions.keys().cloned().collect()
         };
         for session_id in all {
@@ -200,7 +220,9 @@ impl BrowserManager {
     /// Remove sessions that have been inactive longer than the timeout.
     fn cleanup_stale_sessions(&self) {
         let stale: Vec<String> = {
-            let sessions = self.sessions.lock().unwrap();
+            let Ok(sessions) = self.sessions.lock() else {
+                return;
+            };
             sessions
                 .iter()
                 .filter(|(_, info)| info.last_activity.elapsed() > self.inactivity_timeout)

--- a/crates/genesis-tools/src/builtins/fs.rs
+++ b/crates/genesis-tools/src/builtins/fs.rs
@@ -68,7 +68,7 @@ impl ToolHandler for WriteFileTool {
 
         // Create parent directories if needed.
         if let Some(parent) = Path::new(path).parent() {
-            if !parent.exists() {
+            if !parent.as_os_str().is_empty() {
                 fs::create_dir_all(parent).map_err(|e| ToolError::ExecutionFailed {
                     tool: call.name.clone(),
                     reason: format!("failed to create directories for `{path}`: {e}"),


### PR DESCRIPTION
## Summary

- **browser.rs**: Replace 8 `mutex.lock().unwrap()` calls with proper error handling — `map_err`/`?` for Result-returning functions (`get_or_create_session`, `require_session`) and `let Ok(...) else { return }` for void functions (`touch_session`, `consume_first_nav`, `close_session`, `close_all_sessions`, `cleanup_stale_sessions`)
- **gateway batch handler**: Replace `sem.acquire().await.expect("semaphore closed")` with a `match` that returns an error `BatchItemResult` instead of panicking the spawned task
- **fs.rs WriteFileTool**: Replace TOCTOU-prone `.exists()` check with `.as_os_str().is_empty()` guard, since `create_dir_all` is idempotent and the empty-string check handles the edge case of relative filenames with no directory component

Complementary to PR #95 — no overlap with discord.rs, todo.rs, agent_loop.rs, config, or CLI changes.

## Test plan

- [x] `cargo build -p genesis-tools -p genesis-gateway` compiles cleanly
- [x] `cargo test -p genesis-tools -p genesis-gateway` — 382 tests pass
- [x] `cargo clippy -p genesis-tools -p genesis-gateway -- -D warnings` — zero warnings