### PR TITLE
refactor: propagate bootstrap errors and use shared output helper in tools

### DIFF
--- a/crates/genesis-tools/src/builtins/export.rs
+++ b/crates/genesis-tools/src/builtins/export.rs
@@ -26,7 +26,10 @@ impl ToolHandler for SessionExportTool {
         let output_path = call.arguments.get("path");
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
         let store = SessionStore::new(&db_path);
 
         // Load session title

--- a/crates/genesis-tools/src/builtins/session.rs
+++ b/crates/genesis-tools/src/builtins/session.rs
@@ -18,7 +18,10 @@ impl ToolHandler for SessionSearchTool {
             })?;
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
         let store = SessionStore::new(&db_path);
 
         let sessions = store
@@ -84,7 +87,10 @@ impl ToolHandler for SessionHistoryTool {
             .unwrap_or(20);
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
         let store = SessionStore::new(&db_path);
 
         let messages = store

--- a/crates/genesis-tools/src/builtins/shell.rs
+++ b/crates/genesis-tools/src/builtins/shell.rs
@@ -389,18 +389,7 @@ impl ToolHandler for ShellExecTool {
             .unwrap_or_default();
         let exit_code = status.code().unwrap_or(-1);
 
-        let mut content = String::new();
-        content.push_str(&stdout);
-        if !stderr.is_empty() {
-            if !content.is_empty() {
-                content.push('\n');
-            }
-            content.push_str("[stderr]\n");
-            content.push_str(&stderr);
-        }
-        if content.is_empty() {
-            content = format!("(no output, exit code {exit_code})");
-        }
+        let content = super::combine_command_output(&stdout, &stderr, exit_code);
 
         Ok(ToolOutput {
             content,

--- a/crates/genesis-tools/src/builtins/skill.rs
+++ b/crates/genesis-tools/src/builtins/skill.rs
@@ -42,7 +42,10 @@ impl ToolHandler for SkillCreateTool {
             .unwrap_or_default();
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
         let store = SkillStore::new(&db_path);
 
         let skill = store
@@ -232,7 +235,10 @@ impl ToolHandler for SkillRecordUsageTool {
         let feedback = call.arguments.get("feedback").map(|s| s.as_str());
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
 
         // Verify the skill exists
         let skill_store = SkillStore::new(&db_path);

--- a/crates/genesis-tools/src/builtins/skill_file.rs
+++ b/crates/genesis-tools/src/builtins/skill_file.rs
@@ -4,10 +4,13 @@ use genesis_storage::{bootstrap, SkillFileStore};
 
 use crate::{ToolCall, ToolContext, ToolError, ToolHandler, ToolOutput};
 
-fn file_store(context: &ToolContext) -> SkillFileStore {
+fn file_store(context: &ToolContext, tool_name: &str) -> Result<SkillFileStore, ToolError> {
     let db_path = context.db_path();
-    let _ = bootstrap(&db_path);
-    SkillFileStore::new(&db_path)
+    bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+        tool: tool_name.to_owned(),
+        reason: format!("database initialization failed: {e}"),
+    })?;
+    Ok(SkillFileStore::new(&db_path))
 }
 
 /// Tool that returns the content of a supporting file attached to a skill.
@@ -31,7 +34,7 @@ impl ToolHandler for SkillViewFileTool {
                 argument: "file_path",
             })?;
 
-        let store = file_store(context);
+        let store = file_store(context, &call.name)?;
 
         let content = store
             .get_file(skill_name, file_path)
@@ -86,7 +89,7 @@ impl ToolHandler for SkillStoreFileTool {
                 argument: "content",
             })?;
 
-        let store = file_store(context);
+        let store = file_store(context, &call.name)?;
 
         store
             .store_file(skill_name, file_path, content)
@@ -119,7 +122,7 @@ impl ToolHandler for SkillListFilesTool {
                 argument: "skill_name",
             })?;
 
-        let store = file_store(context);
+        let store = file_store(context, &call.name)?;
 
         let files = store
             .list_files(skill_name)
@@ -171,7 +174,7 @@ impl ToolHandler for SkillDeleteFileTool {
                 argument: "file_path",
             })?;
 
-        let store = file_store(context);
+        let store = file_store(context, &call.name)?;
 
         let deleted = store
             .delete_file(skill_name, file_path)

--- a/crates/genesis-tools/src/builtins/subagent.rs
+++ b/crates/genesis-tools/src/builtins/subagent.rs
@@ -41,7 +41,10 @@ impl ToolHandler for SpawnSubagentTool {
             .unwrap_or_else(|| "subagent".to_owned());
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
 
         let subagent_id = generate_subagent_id(&context.session_id);
         let child_session_id = generate_child_session_id(&context.session_id);

--- a/crates/genesis-tools/src/builtins/user_model.rs
+++ b/crates/genesis-tools/src/builtins/user_model.rs
@@ -34,7 +34,10 @@ impl ToolHandler for UserObserveTool {
             })?;
 
         let db_path = context.db_path();
-        let _ = bootstrap(&db_path);
+        bootstrap(&db_path).map_err(|e| ToolError::ExecutionFailed {
+            tool: call.name.clone(),
+            reason: format!("database initialization failed: {e}"),
+        })?;
         let store = UserModelStore::new(&db_path);
 
         let trait_record = store


### PR DESCRIPTION
## Summary
Two cleanups in genesis-tools: fix 8 silenced database errors and eliminate duplicated output formatting.

### Changes
- **Propagate bootstrap errors** (7 files, 8 sites) — Replace `let _ = bootstrap(&db_path)` with proper error propagation via `map_err` + `?`. Previously, a failed bootstrap (permissions, corrupt DB) would be silently ignored and the tool would fail later with an obscure SQLite error
- **Use shared `combine_command_output`** (`shell.rs`) — Replace 12-line inline output formatting block with the existing shared helper already used by docker.rs and ssh.rs

### Files changed
- `builtins/skill.rs` (2 sites)
- `builtins/export.rs` (1 site)
- `builtins/subagent.rs` (1 site)
- `builtins/session.rs` (2 sites)
- `builtins/skill_file.rs` (1 site — refactored helper to return Result)
- `builtins/user_model.rs` (1 site)
- `builtins/shell.rs` (output helper dedup)

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] All 382 genesis-tools tests pass