### PR TITLE
refactor: normalize provider backend strings to lowercase

### DIFF
--- a/crates/genesis-provider/src/client.rs
+++ b/crates/genesis-provider/src/client.rs
@@ -41,9 +41,13 @@ pub struct ChatClient {
 
 impl ChatClient {
     /// Create a new client from a resolved provider.
+    ///
+    /// The backend string is normalized to lowercase so all downstream
+    /// comparisons can use simple `==`.
     pub fn new(provider: &ResolvedProvider) -> Result<Self, ProviderError> {
-        let is_anthropic = provider.backend == "anthropic";
-        let is_gemini = matches!(provider.backend.as_str(), "gemini" | "google");
+        let backend = provider.backend.to_ascii_lowercase();
+        let is_anthropic = backend == "anthropic";
+        let is_gemini = matches!(backend.as_str(), "gemini" | "google");
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
@@ -111,7 +115,7 @@ impl ChatClient {
             http,
             endpoint,
             model: provider.model.clone(),
-            backend: provider.backend.clone(),
+            backend,
             api_key,
         })
     }

--- a/crates/genesis-provider/src/lib.rs
+++ b/crates/genesis-provider/src/lib.rs
@@ -33,8 +33,11 @@ pub async fn client_from_config(
     base_url: Option<&str>,
     api_key_env: Option<&str>,
 ) -> Result<ChatClient, ProviderError> {
+    let backend = backend.trim().to_ascii_lowercase();
+    let backend = backend.as_str();
+
     // For openai-codex backend, try OAuth credentials first
-    if backend.trim().eq_ignore_ascii_case("openai-codex") {
+    if backend == "openai-codex" {
         match genesis_auth::default_auth_path() {
             Ok(auth_path) => {
                 match genesis_auth::codex::resolve_credentials(&auth_path).await {


### PR DESCRIPTION
## Summary
Ensure backend field is lowercased at construction time so all downstream comparisons use simple `==` instead of mixing case-sensitive and case-insensitive checks. Prevents silent routing bugs from user config case variations (e.g., `Anthropic` vs `anthropic`).

### Problem
Backend comparisons were inconsistent:
- `provider.backend == "anthropic"` (case-sensitive)
- `self.backend.eq_ignore_ascii_case("openai-codex")` (case-insensitive)
- `matches!(backend, "gemini" | "google")` (case-sensitive)

A user with `backend: Anthropic` in their config would silently get routed to the wrong code path.

### Fix
- **`ChatClient::new()`** — normalize `provider.backend` to lowercase before storing, providing a safety net for any `ResolvedProvider` constructed directly
- **`client_from_config()`** — normalize backend at entry with `.trim().to_ascii_lowercase()`, replace `eq_ignore_ascii_case` with simple `==`
- `resolve()` already normalized, so the main path was safe — these changes close the bypass paths

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] All 153 genesis-provider tests pass
- [x] Full workspace tests pass