### PR TITLE
refactor: structured logging consistency across crates

### DIFF
--- a/crates/genesis-auth/src/codex.rs
+++ b/crates/genesis-auth/src/codex.rs
@@ -406,7 +406,7 @@ async fn resolve_credentials_inner(
                     });
                 }
                 Err(e) => {
-                    tracing::warn!("Token refresh failed, using existing token: {e}");
+                    tracing::warn!(error = %e, "token refresh failed, using existing token");
                 }
             }
         }
@@ -443,7 +443,7 @@ pub async fn login(auth_store_path: &Path) -> Result<ResolvedCredentials, AuthEr
 
     if !is_remote_session() {
         if let Err(e) = open::that(&device.verification_url) {
-            tracing::debug!("Could not open browser: {e}");
+            tracing::debug!(error = %e, "could not open browser");
         }
     }
 

--- a/crates/genesis-core/src/agent_loop.rs
+++ b/crates/genesis-core/src/agent_loop.rs
@@ -1620,7 +1620,8 @@ impl AgentLoop {
             let count = self.tool_failure_counts[tool];
             warn!(
                 tool_name = tool.as_str(),
-                "tool has failed {count} consecutive times, injecting stuck-loop nudge",
+                failure_count = count,
+                "tool has repeated failures, injecting stuck-loop nudge",
             );
             self.hooks.on_stuck_loop(&hook_session, tool, count);
             // Reset the counter so we don't spam nudges

--- a/crates/genesis-core/src/delivery.rs
+++ b/crates/genesis-core/src/delivery.rs
@@ -22,6 +22,8 @@ use std::collections::HashSet;
 use std::fmt;
 use std::path::{Path, PathBuf};
 
+use tracing::{error, info, warn};
+
 /// The maximum message length for platform delivery before truncation.
 const PLATFORM_MAX_LENGTH: usize = 4000;
 
@@ -265,7 +267,7 @@ impl DeliveryRouter {
                     }
                 } else {
                     // Graceful fallback: origin unavailable → local
-                    tracing::warn!("origin platform not configured, falling back to local");
+                    warn!("origin platform not configured, falling back to local");
                     ResolvedDestination {
                         platform: "local".to_owned(),
                         chat_id: None,
@@ -278,7 +280,7 @@ impl DeliveryRouter {
             },
             DeliveryTarget::Platform { platform, chat_id } => {
                 if !is_known_platform(platform) {
-                    tracing::warn!(
+                    warn!(
                         platform = platform.as_str(),
                         "unknown platform, falling back to local"
                     );
@@ -334,7 +336,7 @@ impl DeliveryRouter {
 
         match save_local_output(&self.config.output_dir, job_id, output) {
             Ok(path) => {
-                tracing::info!(
+                info!(
                     job_id = job_id,
                     path = %path.display(),
                     "schedule output saved locally"
@@ -347,7 +349,7 @@ impl DeliveryRouter {
                 }
             }
             Err(e) => {
-                tracing::error!(
+                error!(
                     job_id = job_id,
                     error = %e,
                     "failed to save schedule output locally"
@@ -373,7 +375,7 @@ impl DeliveryRouter {
         let message = if output.len() > PLATFORM_MAX_LENGTH {
             // Save the full output locally before truncating
             if let Err(e) = save_local_output(&self.config.output_dir, job_id, output) {
-                tracing::warn!(
+                warn!(
                     job_id = job_id,
                     error = %e,
                     "failed to save full output locally before truncation"
@@ -389,7 +391,7 @@ impl DeliveryRouter {
             .await
         {
             Ok(()) => {
-                tracing::info!(
+                info!(
                     job_id = job_id,
                     destination = %dest,
                     "schedule output delivered to platform"
@@ -402,7 +404,7 @@ impl DeliveryRouter {
                 }
             }
             Err(e) => {
-                tracing::error!(
+                error!(
                     job_id = job_id,
                     destination = %dest,
                     error = %e,
@@ -413,7 +415,7 @@ impl DeliveryRouter {
                 let fallback_ok =
                     match save_local_output(&self.config.output_dir, job_id, output) {
                         Ok(path) => {
-                            tracing::info!(
+                            info!(
                                 job_id = job_id,
                                 path = %path.display(),
                                 "fallback local save succeeded"
@@ -421,7 +423,7 @@ impl DeliveryRouter {
                             true
                         }
                         Err(local_err) => {
-                            tracing::error!(
+                            error!(
                                 job_id = job_id,
                                 error = %local_err,
                                 "fallback local save also failed"

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -1215,7 +1215,7 @@ fn create_sandbox_components(loaded: &LoadedConfig) -> Option<SandboxComponents>
             let sb = match SingularitySandbox::new() {
                 Ok(sb) => sb,
                 Err(e) => {
-                    warn!("singularity backend unavailable: {e}");
+                    warn!(error = %e, backend = "singularity", "sandbox backend unavailable");
                     return None;
                 }
             };
@@ -1246,7 +1246,7 @@ fn create_sandbox_components(loaded: &LoadedConfig) -> Option<SandboxComponents>
             let sb = match ModalSandbox::new(&data_dir) {
                 Ok(sb) => sb,
                 Err(e) => {
-                    warn!("modal backend unavailable: {e}");
+                    warn!(error = %e, backend = "modal", "sandbox backend unavailable");
                     return None;
                 }
             };
@@ -1279,7 +1279,7 @@ fn create_sandbox_components(loaded: &LoadedConfig) -> Option<SandboxComponents>
             let sb = match DaytonaSandbox::new() {
                 Ok(sb) => sb,
                 Err(e) => {
-                    warn!("daytona backend unavailable: {e}");
+                    warn!(error = %e, backend = "daytona", "sandbox backend unavailable");
                     return None;
                 }
             };

--- a/crates/genesis-gateway/src/platforms/discord.rs
+++ b/crates/genesis-gateway/src/platforms/discord.rs
@@ -142,7 +142,7 @@ pub async fn interactions_handler(
                 data: None,
             })
             .map_err(|e| {
-                error!("failed to serialize interaction response: {e}");
+                error!(error = %e, "failed to serialize interaction response");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?,
         ));
@@ -172,7 +172,7 @@ pub async fn interactions_handler(
                     }),
                 })
                 .map_err(|e| {
-                    error!("failed to serialize interaction response: {e}");
+                    error!(error = %e, "failed to serialize interaction response");
                     StatusCode::INTERNAL_SERVER_ERROR
                 })?,
             ));
@@ -208,7 +208,7 @@ pub async fn interactions_handler(
                         data: Some(InteractionResponseData { content: reply }),
                     })
                     .map_err(|e| {
-                        error!("failed to serialize interaction response: {e}");
+                        error!(error = %e, "failed to serialize interaction response");
                         StatusCode::INTERNAL_SERVER_ERROR
                     })?,
                 ));
@@ -222,7 +222,7 @@ pub async fn interactions_handler(
                         }),
                     })
                     .map_err(|e| {
-                        error!("failed to serialize interaction response: {e}");
+                        error!(error = %e, "failed to serialize interaction response");
                         StatusCode::INTERNAL_SERVER_ERROR
                     })?,
                 ));
@@ -241,7 +241,7 @@ pub async fn interactions_handler(
                     data: Some(InteractionResponseData { content: reply }),
                 })
                 .map_err(|e| {
-                    error!("failed to serialize interaction response: {e}");
+                    error!(error = %e, "failed to serialize interaction response");
                     StatusCode::INTERNAL_SERVER_ERROR
                 })?,
             ));
@@ -316,7 +316,7 @@ pub async fn interactions_handler(
                 data: None,
             })
             .map_err(|e| {
-                error!("failed to serialize interaction response: {e}");
+                error!(error = %e, "failed to serialize interaction response");
                 StatusCode::INTERNAL_SERVER_ERROR
             })?,
         ));

--- a/crates/genesis-mcp/src/lib.rs
+++ b/crates/genesis-mcp/src/lib.rs
@@ -136,7 +136,7 @@ impl McpManager {
             None => return false,
         };
 
-        warn!(server = server_name, "attempting MCP server reconnection");
+        info!(server = server_name, "attempting MCP server reconnection");
 
         match McpClient::connect(config).await {
             Ok(client) => {

--- a/crates/genesis-mcp/src/transport.rs
+++ b/crates/genesis-mcp/src/transport.rs
@@ -87,15 +87,15 @@ impl StdioTransport {
         tokio::spawn(async move {
             while let Some(msg) = outgoing_rx.recv().await {
                 if let Err(e) = stdin.write_all(msg.as_bytes()).await {
-                    error!("mcp stdin write error: {e}");
+                    error!(error = %e, "mcp stdin write error");
                     break;
                 }
                 if let Err(e) = stdin.write_all(b"\n").await {
-                    error!("mcp stdin newline error: {e}");
+                    error!(error = %e, "mcp stdin newline error");
                     break;
                 }
                 if let Err(e) = stdin.flush().await {
-                    error!("mcp stdin flush error: {e}");
+                    error!(error = %e, "mcp stdin flush error");
                     break;
                 }
             }
@@ -134,7 +134,7 @@ impl StdioTransport {
                         break;
                     }
                     Err(e) => {
-                        error!("mcp stdout read error: {e}");
+                        error!(error = %e, "mcp stdout read error");
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary

- Replace string-interpolated error values (`"message: {e}"`) with structured tracing fields (`error = %e, "message"`) in 7 files across 4 crates
- Add `backend` structured field to sandbox unavailability warnings in `execution.rs` for better filtering
- Promote MCP reconnection log from `warn!` to `info!` since reconnection is expected behavior
- Normalize `delivery.rs` to use unqualified `tracing` macro imports (`warn!` instead of `tracing::warn!`) matching the rest of the codebase

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes with zero warnings
- [x] `cargo test -p genesis-core -p genesis-gateway -p genesis-mcp -p genesis-auth` -- 46 tests pass
- No behavioral changes -- all log messages convey the same information, just structured for JSON log backends