### PR TITLE
refactor: remove misleading zero token counts from streaming logs

### DIFF
--- a/crates/genesis-provider/src/client.rs
+++ b/crates/genesis-provider/src/client.rs
@@ -433,10 +433,6 @@ impl ChatClient {
             endpoint = self.endpoint.as_str(),
             model = request.model.as_str(),
             elapsed_ms = started_at.elapsed().as_millis() as u64,
-            prompt_tokens = 0u32,
-            completion_tokens = 0u32,
-            total_tokens = 0u32,
-            token_counts_available = false,
             "streaming chat completion request accepted"
         );
 
@@ -467,10 +463,6 @@ impl ChatClient {
                                 endpoint = endpoint.as_str(),
                                 model = model.as_str(),
                                 elapsed_ms = stream_started_at.elapsed().as_millis() as u64,
-                                prompt_tokens = 0u32,
-                                completion_tokens = 0u32,
-                                total_tokens = 0u32,
-                                token_counts_available = false,
                                 chunk_count,
                                 "streaming chat completion finished"
                             );
@@ -491,10 +483,6 @@ impl ChatClient {
                 endpoint = endpoint.as_str(),
                 model = model.as_str(),
                 elapsed_ms = stream_started_at.elapsed().as_millis() as u64,
-                prompt_tokens = 0u32,
-                completion_tokens = 0u32,
-                total_tokens = 0u32,
-                token_counts_available = false,
                 chunk_count,
                 "streaming chat completion stream closed"
             );
@@ -519,10 +507,6 @@ impl ChatClient {
             endpoint = self.endpoint.as_str(),
             model = request.model.as_str(),
             elapsed_ms = started_at.elapsed().as_millis() as u64,
-            prompt_tokens = 0u32,
-            completion_tokens = 0u32,
-            total_tokens = 0u32,
-            token_counts_available = false,
             "anthropic streaming request accepted"
         );
 


### PR DESCRIPTION
## Summary
Remove hardcoded `prompt_tokens = 0, completion_tokens = 0, total_tokens = 0, token_counts_available = false` fields from 4 streaming log statements.

These fields produced structured log entries that looked like real usage data but were always zero — misleading for observability tools consuming JSON logs. The Gemini streaming path already lacked these fields; this makes all streaming paths consistent.

### Statements cleaned up
1. OpenAI "streaming chat completion request accepted"
2. OpenAI "streaming chat completion finished"
3. OpenAI "streaming chat completion stream closed"
4. Anthropic "anthropic streaming request accepted"

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] All 153 genesis-provider tests pass