### PR TITLE
refactor: extract shared truncate_at helper to deduplicate UTF-8 truncation

### DIFF
--- a/crates/genesis-tools/src/builtins/browse.rs
+++ b/crates/genesis-tools/src/builtins/browse.rs
@@ -69,17 +69,8 @@ impl ToolHandler for BrowseTool {
         };
 
         // Truncate at char boundary
-        let truncated = if text.len() > MAX_RESPONSE_BYTES {
-            let mut end = MAX_RESPONSE_BYTES;
-            while end > 0 && !text.is_char_boundary(end) {
-                end -= 1;
-            }
-            let mut t = text[..end].to_string();
-            t.push_str("\n... (content truncated)");
-            t
-        } else {
-            text
-        };
+        let truncated =
+            crate::truncate_at(&text, MAX_RESPONSE_BYTES, "\n... (content truncated)");
 
         let content = {
             let raw = format!("URL: {url}\nHTTP {status}\n\n{truncated}");

--- a/crates/genesis-tools/src/builtins/fs.rs
+++ b/crates/genesis-tools/src/builtins/fs.rs
@@ -23,18 +23,8 @@ impl ToolHandler for ReadFileTool {
             reason: format!("failed to read `{path}`: {e}"),
         })?;
 
-        let content = if content.len() > MAX_READ_BYTES {
-            // Walk back from MAX_READ_BYTES to find a valid UTF-8 char boundary
-            let mut end = MAX_READ_BYTES;
-            while end > 0 && !content.is_char_boundary(end) {
-                end -= 1;
-            }
-            let mut truncated = content[..end].to_string();
-            truncated.push_str("\n... (file truncated)");
-            truncated
-        } else {
-            content
-        };
+        let content =
+            crate::truncate_at(&content, MAX_READ_BYTES, "\n... (file truncated)");
 
         Ok(ToolOutput {
             content,

--- a/crates/genesis-tools/src/builtins/send_message.rs
+++ b/crates/genesis-tools/src/builtins/send_message.rs
@@ -218,15 +218,7 @@ fn send_discord(
         })?;
 
     // Discord has a 2000 character limit
-    let truncated = if content.len() > 2000 {
-        let mut end = 1997;
-        while end > 0 && !content.is_char_boundary(end) {
-            end -= 1;
-        }
-        format!("{}...", &content[..end])
-    } else {
-        content.to_owned()
-    };
+    let truncated = crate::truncate_at(content, 1997, "...");
 
     let resp = platform_client()
         .post(format!(
@@ -288,15 +280,7 @@ fn send_whatsapp(
         })?;
 
     // WhatsApp has a 4096 character limit
-    let truncated = if text.len() > 4096 {
-        let mut end = 4093;
-        while end > 0 && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-        format!("{}...", &text[..end])
-    } else {
-        text.to_owned()
-    };
+    let truncated = crate::truncate_at(text, 4093, "...");
 
     let url = format!(
         "https://graph.facebook.com/v21.0/{phone_number_id}/messages"

--- a/crates/genesis-tools/src/builtins/web.rs
+++ b/crates/genesis-tools/src/builtins/web.rs
@@ -110,18 +110,8 @@ impl ToolHandler for WebRequestTool {
             reason: format!("failed to read response body: {e}"),
         })?;
 
-        let truncated = if response_body.len() > MAX_RESPONSE_BYTES {
-            // Find the nearest char boundary at or before the byte limit
-            let mut end = MAX_RESPONSE_BYTES;
-            while end > 0 && !response_body.is_char_boundary(end) {
-                end -= 1;
-            }
-            let mut t = response_body[..end].to_string();
-            t.push_str("\n... (response truncated)");
-            t
-        } else {
-            response_body
-        };
+        let truncated =
+            crate::truncate_at(&response_body, MAX_RESPONSE_BYTES, "\n... (response truncated)");
 
         let mut content = format!("HTTP {status}\n");
         for header in &headers {

--- a/crates/genesis-tools/src/lib.rs
+++ b/crates/genesis-tools/src/lib.rs
@@ -21,6 +21,22 @@ pub const NOISE_DIRS: &[&str] = &[
 /// Maximum output size for tool results (64 KiB).
 pub const MAX_OUTPUT_BYTES: usize = 64 * 1024;
 
+/// Truncate a string to at most `limit` bytes on a valid UTF-8 boundary,
+/// appending `suffix` if truncation occurred.
+pub fn truncate_at(s: &str, limit: usize, suffix: &str) -> String {
+    if s.len() <= limit {
+        return s.to_owned();
+    }
+    // Walk back to char boundary
+    let mut end = limit;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut result = s[..end].to_owned();
+    result.push_str(suffix);
+    result
+}
+
 /// Truncate output to MAX_OUTPUT_BYTES, cutting at a newline boundary
 /// and ensuring safe UTF-8 boundaries.
 pub fn truncate_output(output: &str) -> String {
@@ -49,17 +65,7 @@ pub fn truncate_output(output: &str) -> String {
 /// character boundaries.
 pub fn truncate_output_bytes(bytes: &[u8]) -> String {
     let s = String::from_utf8_lossy(bytes);
-    if s.len() > MAX_OUTPUT_BYTES {
-        let mut end = MAX_OUTPUT_BYTES;
-        while end > 0 && !s.is_char_boundary(end) {
-            end -= 1;
-        }
-        let mut truncated = s[..end].to_string();
-        truncated.push_str("\n... (output truncated)");
-        truncated
-    } else {
-        s.into_owned()
-    }
+    truncate_at(&s, MAX_OUTPUT_BYTES, "\n... (output truncated)")
 }
 
 #[derive(Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
Extract a parameterized `truncate_at(s, limit, suffix)` helper to replace 5 independent inline UTF-8-safe truncation implementations across genesis-tools. Net: **-39 lines** (25 insertions, 64 deletions).

### New helper
```rust
pub fn truncate_at(s: &str, limit: usize, suffix: &str) -> String
```
Walks back to a valid UTF-8 char boundary and appends a caller-specified suffix.

### Deduplicated sites
| File | Limit | Suffix |
|------|-------|--------|
| `lib.rs` (`truncate_output_bytes`) | 64 KiB | `"\n... (output truncated)"` |
| `builtins/web.rs` | 128 KiB | `"\n... (response truncated)"` |
| `builtins/browse.rs` | 64 KiB | `"\n... (content truncated)"` |
| `builtins/fs.rs` | 128 KiB | `"\n... (file truncated)"` |
| `builtins/send_message.rs` | 1997/4093 bytes | `"..."` |

`truncate_output` (line-boundary version) is preserved as-is since it has distinct newline-splitting behavior.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] All 381 genesis-tools tests pass