### PR TITLE
test: add coverage for critical untested functions

### DIFF
--- a/crates/genesis-gateway/src/platforms/mod.rs
+++ b/crates/genesis-gateway/src/platforms/mod.rs
@@ -156,3 +156,97 @@ pub fn pairing_reply(code: &str) -> String {
 pub fn pairing_capacity_reply() -> &'static str {
     "Too many pending pairing requests. Please try again later or contact the agent owner."
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_truthy_env_recognizes_true_values() {
+        std::env::set_var("_TEST_TRUTHY_1", "1");
+        std::env::set_var("_TEST_TRUTHY_TRUE", "true");
+        std::env::set_var("_TEST_TRUTHY_TRUE_UPPER", "TRUE");
+        std::env::set_var("_TEST_TRUTHY_YES", "yes");
+        std::env::set_var("_TEST_TRUTHY_ON", "on");
+        std::env::set_var("_TEST_TRUTHY_0", "0");
+        std::env::set_var("_TEST_TRUTHY_FALSE", "false");
+        std::env::set_var("_TEST_TRUTHY_NO", "no");
+        std::env::set_var("_TEST_TRUTHY_EMPTY", "");
+        std::env::set_var("_TEST_TRUTHY_RANDOM", "random");
+
+        assert!(is_truthy_env("_TEST_TRUTHY_1"));
+        assert!(is_truthy_env("_TEST_TRUTHY_TRUE"));
+        assert!(is_truthy_env("_TEST_TRUTHY_TRUE_UPPER"));
+        assert!(is_truthy_env("_TEST_TRUTHY_YES"));
+        assert!(is_truthy_env("_TEST_TRUTHY_ON"));
+        assert!(!is_truthy_env("_TEST_TRUTHY_0"));
+        assert!(!is_truthy_env("_TEST_TRUTHY_FALSE"));
+        assert!(!is_truthy_env("_TEST_TRUTHY_NO"));
+        assert!(!is_truthy_env("_TEST_TRUTHY_EMPTY"));
+        assert!(!is_truthy_env("_TEST_TRUTHY_RANDOM"));
+        assert!(!is_truthy_env(""));
+    }
+
+    #[test]
+    fn parse_env_id_set_splits_comma_delimited() {
+        let set = parse_env_id_set("123,456,789");
+        assert_eq!(set.len(), 3);
+        assert!(set.contains("123"));
+        assert!(set.contains("456"));
+        assert!(set.contains("789"));
+    }
+
+    #[test]
+    fn parse_env_id_set_handles_empty_string() {
+        let set = parse_env_id_set("");
+        assert!(set.is_empty());
+    }
+
+    #[test]
+    fn parse_env_id_set_trims_whitespace() {
+        let set = parse_env_id_set("  abc , def , ghi  ");
+        assert_eq!(set.len(), 3);
+        assert!(set.contains("abc"));
+        assert!(set.contains("def"));
+        assert!(set.contains("ghi"));
+    }
+
+    #[test]
+    fn is_user_in_allowlist_matches_exact_id() {
+        let allowed: HashSet<String> = ["user1", "user2"].iter().map(|s| s.to_string()).collect();
+        assert!(is_user_in_allowlist(&allowed, "user1"));
+        assert!(is_user_in_allowlist(&allowed, "user2"));
+        assert!(!is_user_in_allowlist(&allowed, "user3"));
+    }
+
+    #[test]
+    fn is_user_in_allowlist_matches_short_id_before_at() {
+        let allowed: HashSet<String> = ["alice"].iter().map(|s| s.to_string()).collect();
+        assert!(is_user_in_allowlist(&allowed, "alice@example.com"));
+        assert!(!is_user_in_allowlist(&allowed, "bob@example.com"));
+    }
+
+    #[test]
+    fn is_user_in_allowlist_ignores_empty_short_id() {
+        let allowed: HashSet<String> = [""].iter().map(|s| s.to_string()).collect();
+        // "@domain.com" has an empty short id — should not match the empty string in the set
+        assert!(!is_user_in_allowlist(&allowed, "@domain.com"));
+    }
+
+    #[test]
+    fn platform_allowlist_env_maps_known_platforms() {
+        assert_eq!(platform_allowlist_env("telegram"), "TELEGRAM_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_env("discord"), "DISCORD_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_env("whatsapp"), "WHATSAPP_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_env("slack"), "SLACK_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_env("signal"), "SIGNAL_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_env("unknown"), "");
+    }
+
+    #[test]
+    fn pairing_reply_contains_code() {
+        let reply = pairing_reply("ABCD1234");
+        assert!(reply.contains("ABCD1234"));
+        assert!(reply.contains("genesis pairing approve"));
+    }
+}

--- a/crates/genesis-storage/src/lib.rs
+++ b/crates/genesis-storage/src/lib.rs
@@ -271,6 +271,106 @@ mod session_store_tests {
             .expect("lookup should succeed");
         assert!(missing.is_none());
     }
+
+    #[test]
+    fn truncate_messages_keeps_only_recent() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+        bootstrap(&database_path).expect("bootstrap should succeed");
+
+        let store = SessionStore::new(&database_path);
+        store
+            .create_session("session-trunc", "cli", None)
+            .expect("session should be created");
+
+        for i in 1..=5 {
+            store
+                .append_message(
+                    "session-trunc",
+                    "user",
+                    Some(&format!("message {i}")),
+                    None,
+                    None,
+                )
+                .expect("message should be stored");
+        }
+
+        let deleted = store
+            .truncate_messages("session-trunc", 2)
+            .expect("truncate should succeed");
+        assert_eq!(deleted, 3);
+
+        let messages = store
+            .load_messages("session-trunc")
+            .expect("messages should load");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content.as_deref(), Some("message 4"));
+        assert_eq!(messages[1].content.as_deref(), Some("message 5"));
+    }
+
+    #[test]
+    fn truncate_messages_noop_when_fewer_than_limit() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+        bootstrap(&database_path).expect("bootstrap should succeed");
+
+        let store = SessionStore::new(&database_path);
+        store
+            .create_session("session-few", "cli", None)
+            .expect("session should be created");
+
+        for i in 1..=3 {
+            store
+                .append_message(
+                    "session-few",
+                    "user",
+                    Some(&format!("message {i}")),
+                    None,
+                    None,
+                )
+                .expect("message should be stored");
+        }
+
+        let deleted = store
+            .truncate_messages("session-few", 10)
+            .expect("truncate should succeed");
+        assert_eq!(deleted, 0);
+
+        let messages = store
+            .load_messages("session-few")
+            .expect("messages should load");
+        assert_eq!(messages.len(), 3);
+    }
+
+    #[test]
+    fn search_messages_finds_matching_content() {
+        let dir = tempdir().expect("tempdir should exist");
+        let database_path = dir.path().join("genesis.db");
+        bootstrap(&database_path).expect("bootstrap should succeed");
+
+        let store = SessionStore::new(&database_path);
+        store
+            .create_session("session-search", "cli", Some("Search Test"))
+            .expect("session should be created");
+
+        store
+            .append_message("session-search", "user", Some("hello world"), None, None)
+            .expect("first message should be stored");
+        store
+            .append_message("session-search", "assistant", Some("goodbye moon"), None, None)
+            .expect("second message should be stored");
+        store
+            .append_message("session-search", "user", Some("hello again"), None, None)
+            .expect("third message should be stored");
+
+        let results = store
+            .search_messages("hello", 10)
+            .expect("search should succeed");
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.session_id == "session-search"));
+        assert!(results.iter().all(|r| r.content.contains("hello")));
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Add tests for `SessionStore::truncate_messages` (keeps only N most recent messages, noop when count is under limit)
- Add tests for `SessionStore::search_messages` (FTS5 full-text search returns matching messages)
- Add test module for gateway platform helpers: `is_truthy_env`, `parse_env_id_set`, `is_user_in_allowlist`, `platform_allowlist_env`, `pairing_reply`
- RateLimiter tests were already present -- no changes needed

No production code was modified. All 12 new tests pass and clippy is clean.

## Test plan

- [x] `cargo test -p genesis-storage -- truncate_messages search_messages` (3 tests pass)
- [x] `cargo test -p genesis-gateway -- platforms::tests` (9 tests pass)
- [x] `cargo clippy --workspace -- -D warnings` (zero warnings)