### PR TITLE
fix: resolve clippy redundant_closure warning on main

### DIFF
--- a/crates/genesis-cli/src/lib.rs
+++ b/crates/genesis-cli/src/lib.rs
@@ -3708,7 +3708,7 @@ async fn run_serve(
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
-        .map_err(|e| CliError::Io(e))?;
+        .map_err(CliError::Io)?;
 
     // Start background scheduler
     let db_path = state.loaded.config.storage.database_path.clone();


### PR DESCRIPTION
## Summary
One-liner fix for a clippy `redundant_closure` error on main introduced by a recent merge.

Replace `|e| CliError::Io(e)` with `CliError::Io` in serve bind.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes (was failing before this fix)