### PR TITLE
fix: propagate remaining silenced bootstrap errors and clippy lint

### DIFF
--- a/crates/genesis-cli/src/lib.rs
+++ b/crates/genesis-cli/src/lib.rs
@@ -3708,7 +3708,7 @@ async fn run_serve(
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
-        .map_err(|e| CliError::Io(e))?;
+        .map_err(CliError::Io)?;
 
     // Start background scheduler
     let db_path = state.loaded.config.storage.database_path.clone();
@@ -5877,7 +5877,7 @@ async fn run_init_wizard(config_path: Option<PathBuf>) -> Result<String, CliErro
             std::fs::write(&paths.config_path, &yaml).map_err(CliError::Io)?;
         }
         std::fs::create_dir_all(&paths.data_dir).map_err(CliError::Io)?;
-        let _ = bootstrap(&paths.database_path)?;
+        bootstrap(&paths.database_path)?;
 
         return run_login(config_path).await;
     }

--- a/crates/genesis-core/src/nudge.rs
+++ b/crates/genesis-core/src/nudge.rs
@@ -27,7 +27,14 @@ skills capture durable patterns — not one-off details.";
 /// then composes a prompt that asks the agent to reflect and consolidate.
 pub fn build_nudge_prompt(loaded: &LoadedConfig) -> String {
     let db_path = &loaded.config.storage.database_path;
-    let _ = bootstrap(db_path);
+    if let Err(e) = bootstrap(db_path) {
+        tracing::warn!(error = %e, "failed to bootstrap database for nudge prompt");
+        return String::from(
+            "Perform a self-reflection on your accumulated knowledge.\n\n\
+             No accumulated knowledge yet. This is normal for early sessions. \
+             Focus on learning about the user and their needs as you interact.\n",
+        );
+    }
 
     let memories_section = load_memories_section(db_path);
     let user_model_section = load_user_model_section(db_path);


### PR DESCRIPTION
## Summary
Fix the last 2 silenced bootstrap errors and a clippy lint on main.

### Changes
- **`genesis-core/src/nudge.rs`** — Replace `let _ = bootstrap(db_path)` with logged early return on failure (function returns `String`, not `Result`, so `?` isn't available). Bootstrap failures now produce a `warn!` log instead of being silently swallowed
- **`genesis-cli/src/lib.rs`** — Remove redundant `let _ =` from `let _ = bootstrap(...)?;` (the `?` already propagates errors)
- **`genesis-cli/src/lib.rs`** — Fix `clippy::redundant_closure` lint: `.map_err(|e| CliError::Io(e))` → `.map_err(CliError::Io)`

Note: The genesis-tools bootstrap errors were already fixed by a previous PR (#114) that did land on main — only these 2 spots in core/cli remained.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] genesis-tools: 382 tests pass
- [x] genesis-core: 628 tests pass
- [x] genesis-cli: 217 tests pass