### PR TITLE
feat(provider): expand model metadata with per-model capability flags

### DIFF
--- a/crates/genesis-provider/src/model_metadata.rs
+++ b/crates/genesis-provider/src/model_metadata.rs
@@ -149,6 +149,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_token_efficient_tools: true,
                 supports_citations: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -162,6 +163,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_token_efficient_tools: true,
                 supports_citations: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -175,6 +177,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_token_efficient_tools: true,
                 supports_citations: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -188,6 +191,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_token_efficient_tools: true,
                 supports_citations: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -201,6 +205,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_token_efficient_tools: true,
                 supports_citations: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -212,6 +217,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_vision: true,
                 supports_citations: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -225,6 +231,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_thinking: true,
                 requires_thought_signatures: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -237,6 +244,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
                 supports_thinking: true,
                 requires_thought_signatures: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -247,6 +255,7 @@ pub fn known_metadata() -> HashMap<&'static str, ModelMetadata> {
             capabilities: ModelCapabilities {
                 supports_vision: true,
                 supports_context_caching: true,
+                supports_batch_api: true,
                 ..cap()
             },
         },
@@ -473,10 +482,17 @@ mod tests {
     }
 
     #[test]
-    fn openai_models_support_batch_api() {
+    fn batch_api_flagged_for_supported_providers() {
         let db = known_metadata();
+        // OpenAI
         assert!(db["gpt-4.1"].capabilities.supports_batch_api);
         assert!(db["o4-mini"].capabilities.supports_batch_api);
+        // Anthropic (Message Batches API)
+        assert!(db["claude-sonnet-4-20250514"].capabilities.supports_batch_api);
+        assert!(db["claude-haiku-4-5"].capabilities.supports_batch_api);
+        // Google (Batch API)
+        assert!(db["gemini-2.5-pro"].capabilities.supports_batch_api);
+        assert!(db["gemini-2.0-flash"].capabilities.supports_batch_api);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Expands the model metadata system with fine-grained per-model capability flags, enabling the agent loop and provider client to auto-adapt behavior without model-specific if/else chains.

**New `ModelCapabilities` struct** with 11 feature flags:

| Flag | Purpose | Models |
|------|---------|--------|
| `supports_tools` | Tool/function calling | Most models (not deepseek-r1) |
| `supports_vision` | Image input processing | GPT-4.1, Claude, Gemini, Llama 4 |
| `supports_thinking` | Extended thinking/CoT | o4-mini, Claude 4.x, Gemini 2.5, DeepSeek-R1, Qwen 3 |
| `supports_parallel_tools` | Parallel tool calls | Most (disabled for nano/reasoning) |
| `supports_strict_mode` | OpenAI strict function calling | GPT-4.1 family, o4-mini |
| `requires_thought_signatures` | Echo thought signatures | Gemini 2.5 thinking models |
| `supports_token_efficient_tools` | Anthropic tool use beta | All Claude 4.x models |
| `supports_predicted_outputs` | OpenAI predicted outputs | GPT-4.1, GPT-4.1-mini |
| `supports_citations` | Anthropic citations API | All Claude 4.x models |
| `supports_context_caching` | Explicit prompt caching | Claude (cache_control), Gemini |
| `supports_batch_api` | Batch/async bulk processing | OpenAI models |

**Backwards compatible**: Existing `supports_tools`/`supports_vision`/`supports_thinking` are now inside `capabilities` with convenience methods on `ModelMetadata` that delegate.

## Changes

| File | Change |
|------|--------|
| `model_metadata.rs` | Add `ModelCapabilities` struct, refactor `ModelMetadata`, populate all 22 models, 10 new tests |

## Test plan

- [x] All 17 model_metadata tests pass (7 existing + 10 new)
- [x] `cargo clippy -p genesis-provider -- -D warnings` clean
- [x] Full workspace `cargo check` passes
- [x] Claude models have Anthropic-specific flags set
- [x] OpenAI models have strict_mode + batch + predicted_outputs
- [x] Nano model disables parallel_tools
- [x] Gemini thinking models require thought signatures
- [x] Default capabilities are conservative (tools + parallel only)

Closes #91