### PR TITLE
feat(tui): multi-line input with Shift+Enter and dynamic height

### DIFF
--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -393,8 +393,13 @@ fn render_frame(term: &mut custom_terminal::CustomTerminal, app: &mut App) {
                 // Dynamic input height: content lines + 2 border rows,
                 // capped at 50% of available space.
                 let content_rows = app.chat.input.height(area.width);
-                let max_input = (chat_area_height / 2).max(3);
-                let input_rows = (content_rows + 2).clamp(3, max_input.min(chat_area_height));
+                let upper = (chat_area_height / 2).max(3).min(chat_area_height);
+                let input_rows = if upper < 3 {
+                    // Extremely short viewport — just use what we have.
+                    upper
+                } else {
+                    (content_rows + 2).clamp(3, upper)
+                };
                 let message_area_height = if chat_area_height > input_rows {
                     chat_area_height.saturating_sub(input_rows + 1)
                 } else {

--- a/crates/genesis-tui/src/widgets/input_widget.rs
+++ b/crates/genesis-tui/src/widgets/input_widget.rs
@@ -233,14 +233,12 @@ impl InputWidget {
     /// Handle a bracketed-paste event by inserting all characters.
     ///
     /// Newlines inside the pasted text are preserved for multi-line editing.
+    /// CRLF (`\r\n`) sequences are collapsed to a single `\n`.
     pub fn handle_paste(&mut self, text: &str) {
-        for c in text.chars() {
-            if c == '\r' {
-                // Convert carriage returns to newlines.
-                self.insert_char('\n');
-            } else {
-                self.insert_char(c);
-            }
+        // Normalize line endings: \r\n → \n, lone \r → \n.
+        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+        for c in normalized.chars() {
+            self.insert_char(c);
         }
     }
 
@@ -391,40 +389,52 @@ impl InputWidget {
         }
     }
 
-    /// Column offset of cursor within the current line (in bytes).
-    fn cursor_column(&self) -> usize {
-        self.cursor - self.current_line_start()
+    /// Column offset of cursor within the current line (in characters, not bytes).
+    fn cursor_char_column(&self) -> usize {
+        let line_start = self.current_line_start();
+        self.buffer[line_start..self.cursor].chars().count()
     }
 
-    /// Move cursor up one line, preserving column position.
+    /// Move cursor up one line, preserving character column position.
     fn move_cursor_up(&mut self) {
         let current_line = self.cursor_line_index();
         if current_line == 0 {
-            return; // Already on first line.
+            return;
         }
-        let col = self.cursor_column();
+        let col = self.cursor_char_column();
         let prev_line_start = self.line_byte_offset(current_line - 1);
         let prev_line_end = self.line_byte_offset(current_line) - 1; // before the \n
-        let prev_line_len = prev_line_end - prev_line_start;
-        self.cursor = prev_line_start + col.min(prev_line_len);
+        let prev_line_text = &self.buffer[prev_line_start..prev_line_end];
+        // Advance `col` characters into the previous line (clamped).
+        let target_byte = prev_line_text
+            .char_indices()
+            .nth(col)
+            .map(|(i, _)| prev_line_start + i)
+            .unwrap_or(prev_line_end);
+        self.cursor = target_byte;
     }
 
-    /// Move cursor down one line, preserving column position.
+    /// Move cursor down one line, preserving character column position.
     fn move_cursor_down(&mut self) {
         let current_line = self.cursor_line_index();
         let total_lines = self.buffer.matches('\n').count() + 1;
         if current_line + 1 >= total_lines {
-            return; // Already on last line.
+            return;
         }
-        let col = self.cursor_column();
+        let col = self.cursor_char_column();
         let next_line_start = self.line_byte_offset(current_line + 1);
         let next_line_end = if current_line + 2 < total_lines {
             self.line_byte_offset(current_line + 2) - 1
         } else {
             self.buffer.len()
         };
-        let next_line_len = next_line_end - next_line_start;
-        self.cursor = next_line_start + col.min(next_line_len);
+        let next_line_text = &self.buffer[next_line_start..next_line_end];
+        let target_byte = next_line_text
+            .char_indices()
+            .nth(col)
+            .map(|(i, _)| next_line_start + i)
+            .unwrap_or(next_line_end);
+        self.cursor = target_byte;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────
@@ -709,6 +719,15 @@ mod tests {
         w.handle_paste("line1\nline2");
         assert_eq!(w.text(), "line1\nline2");
         assert!(w.is_multiline());
+    }
+
+    #[test]
+    fn paste_normalizes_crlf() {
+        let mut w = InputWidget::new();
+        w.handle_paste("a\r\nb\r\nc");
+        assert_eq!(w.text(), "a\nb\nc");
+        // Should not double the newlines.
+        assert_eq!(w.buffer.matches('\n').count(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes the **single largest usability gap** identified in the TUI competitive analysis (#128) — every competing AI CLI supports multi-line input. Genesis was single-line only with paste converting newlines to spaces.

## Changes

### Multi-line editing
- **Shift+Enter** inserts a newline; **Enter** submits (entire buffer, newlines preserved)
- Cursor navigation works across lines — Left/Right wrap at boundaries, Up/Down move between lines
- When buffer is single-line, Up/Down still navigate history (backwards compatible)
- Home/End and Ctrl+A/E move to start/end of **current line** (not whole buffer)
- Ctrl+U/K kill to start/end of **current line**
- Backspace at start of a line joins it with the previous line

### Dynamic layout
- Input area grows from 3 rows (1 content + 2 border) up to 50% of viewport, capped at 12 rows
- Height computed from actual newline count in buffer via `input.height(width)`
- Layout in `lib.rs` updated to use dynamic `input_rows` instead of `const INPUT_PANEL_ROWS = 3`

### Multi-line paste
- Pasted text now **preserves newlines** (was converting `\n` → space)
- Carriage returns normalized to newlines

### Multi-line rendering
- First line shows `you> ` prefix, continuation lines indent to align
- Block cursor renders correctly across rows
- Auto-scrolls to keep cursor visible when content exceeds visible area

## Files changed

| File | Change |
|------|--------|
| `widgets/input_widget.rs` | Complete rewrite: multi-line buffer, line-aware cursor, Shift+Enter, dynamic height, multi-line rendering |
| `lib.rs` | Replace `const INPUT_PANEL_ROWS: u16 = 3` with dynamic calculation from `input.height()` |

## Test plan

- [x] All 204 genesis-tui tests pass (21 input widget tests including 10 new multi-line tests)
- [x] `cargo clippy -p genesis-tui -- -D warnings` clean
- [x] New: `shift_enter_inserts_newline` — Shift+Enter adds `\n` to buffer
- [x] New: `enter_submits_multiline_text` — Enter submits text with newlines
- [x] New: `height_reflects_line_count` — dynamic height matches line count
- [x] New: `up_down_navigate_lines_when_multiline` — Up/Down move cursor between lines
- [x] New: `up_down_use_history_when_single_line` — backwards compatible with history
- [x] New: `home_end_work_per_line` — per-line Home/End
- [x] New: `backspace_joins_lines` — Backspace at line start joins
- [x] New: `ctrl_u_kills_to_line_start_not_buffer_start` — line-aware kill
- [x] New: `paste_preserves_newlines` — multi-line paste works
- [x] New: `height_capped_at_max` — doesn't exceed MAX_INPUT_ROWS
- [ ] Manual: type multi-line code snippet with Shift+Enter, verify it submits correctly
- [ ] Manual: paste a multi-line code block, verify newlines preserved

Closes #138