### PR TITLE
feat(core): add think tool — Anthropic reasoning scratchpad

### DIFF
--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -411,6 +411,37 @@ impl<'a> SessionExecutionService<'a> {
             build_execution_context_from_loaded(self.loaded, session_id, platform);
         let mut tool_runtime = build_default_tool_runtime(&execution_context);
 
+        // Auto-inject the think tool for Anthropic backends.
+        // The think tool is a zero-cost reasoning scratchpad that improves
+        // Claude's performance by 54% on complex tasks (Tau-Bench).
+        // Not injected for other providers to avoid wasting a tool slot.
+        if self.loaded.config.provider.backend == "anthropic" {
+            tool_runtime.registry.register(
+                genesis_types::ToolDefinition {
+                    name: "think".to_owned(),
+                    description:
+                        "Use this tool to think through a problem step-by-step before acting. \
+                         Write your reasoning in the `thought` parameter. The output is always \
+                         empty — the value is in organizing your thoughts, not the response. \
+                         Use this between tool calls when you need to plan, analyze results, \
+                         or reason about the next step."
+                            .to_owned(),
+                    parameters: Some(serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "thought": {
+                                "type": "string",
+                                "description": "Your step-by-step reasoning, analysis, or plan."
+                            }
+                        },
+                        "required": ["thought"]
+                    })),
+                },
+                genesis_tools::ApprovalPolicy::Never,
+                genesis_tools::builtins::think::ThinkTool,
+            );
+        }
+
         // Attach MCP manager if we connected any servers at service creation
         if let Some(mcp) = &self.mcp {
             tool_runtime.set_mcp(Arc::clone(mcp));

--- a/crates/genesis-tools/src/builtins/mod.rs
+++ b/crates/genesis-tools/src/builtins/mod.rs
@@ -25,6 +25,7 @@ pub mod skill;
 pub mod skill_file;
 pub mod ssh;
 pub mod subagent;
+pub mod think;
 pub mod todo;
 pub mod trajectory;
 pub mod transcribe;

--- a/crates/genesis-tools/src/builtins/think.rs
+++ b/crates/genesis-tools/src/builtins/think.rs
@@ -1,0 +1,79 @@
+//! Think tool — structured reasoning scratchpad for Claude models.
+//!
+//! A zero-cost tool that lets the model reason between tool calls without
+//! the output affecting the conversation. Returns an empty result.
+//!
+//! **54% improvement on Tau-Bench airline domain** per Anthropic Engineering:
+//! <https://www.anthropic.com/engineering/claude-think-tool>
+
+use std::collections::BTreeMap;
+
+use crate::{ToolCall, ToolContext, ToolError, ToolHandler, ToolOutput};
+
+/// Tool that provides a structured reasoning scratchpad.
+///
+/// The model uses `think` to organize its thoughts between tool calls.
+/// The thought content is captured in the tool call arguments but the
+/// result is always empty — no tokens are wasted on a response.
+pub struct ThinkTool;
+
+impl ToolHandler for ThinkTool {
+    fn run(&self, call: &ToolCall, _context: &ToolContext) -> Result<ToolOutput, ToolError> {
+        // Validate that the thought parameter is present.
+        let _thought =
+            call.arguments
+                .get("thought")
+                .ok_or_else(|| ToolError::MissingArgument {
+                    tool: call.name.clone(),
+                    argument: "thought",
+                })?;
+
+        // Return empty content — the value is in the tool call itself,
+        // not in the result. This is zero-cost for the output budget.
+        Ok(ToolOutput {
+            content: String::new(),
+            metadata: BTreeMap::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        crate::test_utils::test_ctx_destructive()
+    }
+
+    #[test]
+    fn think_returns_empty_content() {
+        let tool = ThinkTool;
+        let call = ToolCall {
+            name: "think".to_owned(),
+            arguments: BTreeMap::from([(
+                "thought".to_owned(),
+                "I need to consider the file structure before editing.".to_owned(),
+            )]),
+        };
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert!(output.content.is_empty(), "think tool should return empty content");
+        assert!(output.metadata.is_empty());
+    }
+
+    #[test]
+    fn think_requires_thought_parameter() {
+        let tool = ThinkTool;
+        let call = ToolCall {
+            name: "think".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "thought",
+                ..
+            }
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a zero-cost "think" tool that provides a structured reasoning scratchpad for Claude models. **54% improvement on Tau-Bench airline domain** per [Anthropic Engineering](https://www.anthropic.com/engineering/claude-think-tool).

The model calls `think(thought: "...")` to organize its thoughts between tool calls. The result is always empty — no tokens wasted on a response.

## Changes

| File | Change |
|------|--------|
| `builtins/think.rs` | New: ThinkTool struct, returns empty ToolOutput |
| `builtins/mod.rs` | Register think module |
| `execution.rs` | Auto-inject when `provider.backend == "anthropic"` |

## Design

- **Zero-cost**: Returns empty string, not "ok" — no output tokens consumed
- **Conditional**: Only injected for Anthropic backends (wastes a tool slot for other providers)
- **Guided**: Tool description instructs model to use it for planning, analysis, and reasoning between tool calls

## Test plan

- [x] `think_returns_empty_content` — returns empty string with no metadata
- [x] `think_requires_thought_parameter` — validates required param
- [x] `cargo clippy -p genesis-tools -p genesis-core -- -D warnings` clean
- [ ] Manual: use with Claude model, verify think calls appear in tool history

Closes #77