### PR TITLE
fix(core): move think tool registration to shared runtime builder

### DIFF
--- a/crates/genesis-core/src/agent_loop.rs
+++ b/crates/genesis-core/src/agent_loop.rs
@@ -2563,6 +2563,7 @@ mod tests {
             database_path: "/tmp/genesis/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         AgentLoop::with_history(
@@ -2601,6 +2602,7 @@ mod tests {
             database_path: "/tmp/genesis/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         AgentLoop::with_history(
@@ -3053,6 +3055,7 @@ mod tests {
             database_path: "/tmp/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         let mut agent = AgentLoop::with_history(
@@ -3113,6 +3116,7 @@ mod tests {
             database_path: "/tmp/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         let mut agent = AgentLoop::with_history(
@@ -3263,6 +3267,7 @@ mod tests {
             database_path: "/tmp/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         let mut agent = AgentLoop::new(
@@ -3602,6 +3607,7 @@ mod tests {
             database_path: "/tmp/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         let mut agent = AgentLoop::new(
@@ -3686,6 +3692,7 @@ mod tests {
             database_path: "/tmp/genesis.db".to_owned(),
             max_concurrency: 4,
             allow_destructive_tools: false,
+            provider_backend: "openai".to_owned(),
         });
 
         let mut agent = AgentLoop::new(

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -411,37 +411,6 @@ impl<'a> SessionExecutionService<'a> {
             build_execution_context_from_loaded(self.loaded, session_id, platform);
         let mut tool_runtime = build_default_tool_runtime(&execution_context);
 
-        // Auto-inject the think tool for Anthropic backends.
-        // The think tool is a zero-cost reasoning scratchpad that improves
-        // Claude's performance by 54% on complex tasks (Tau-Bench).
-        // Not injected for other providers to avoid wasting a tool slot.
-        if self.loaded.config.provider.backend == "anthropic" {
-            tool_runtime.registry.register(
-                genesis_types::ToolDefinition {
-                    name: "think".to_owned(),
-                    description:
-                        "Use this tool to think through a problem step-by-step before acting. \
-                         Write your reasoning in the `thought` parameter. The output is always \
-                         empty — the value is in organizing your thoughts, not the response. \
-                         Use this between tool calls when you need to plan, analyze results, \
-                         or reason about the next step."
-                            .to_owned(),
-                    parameters: Some(serde_json::json!({
-                        "type": "object",
-                        "properties": {
-                            "thought": {
-                                "type": "string",
-                                "description": "Your step-by-step reasoning, analysis, or plan."
-                            }
-                        },
-                        "required": ["thought"]
-                    })),
-                },
-                genesis_tools::ApprovalPolicy::Never,
-                genesis_tools::builtins::think::ThinkTool,
-            );
-        }
-
         // Attach MCP manager if we connected any servers at service creation
         if let Some(mcp) = &self.mcp {
             tool_runtime.set_mcp(Arc::clone(mcp));

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -94,6 +94,10 @@ pub struct ExecutionContext {
     pub database_path: String,
     pub max_concurrency: usize,
     pub allow_destructive_tools: bool,
+    /// Provider backend name (e.g. "anthropic", "openai") — used for
+    /// conditional tool injection (think tool for Anthropic).
+    #[serde(default)]
+    pub provider_backend: String,
 }
 
 #[derive(Clone)]
@@ -151,6 +155,7 @@ pub fn build_execution_context_from_loaded(
         database_path: loaded.config.storage.database_path.display().to_string(),
         max_concurrency: loaded.config.runtime.max_concurrency,
         allow_destructive_tools: loaded.config.runtime.allow_destructive_tools,
+        provider_backend: loaded.config.provider.backend.clone(),
     }
 }
 
@@ -192,6 +197,37 @@ pub fn build_default_tool_runtime(execution_context: &ExecutionContext) -> ToolR
         ApprovalPolicy::Never,
         MoaToolPlaceholder,
     );
+
+    // Auto-inject the think tool for Anthropic backends.
+    // Zero-cost reasoning scratchpad — 54% improvement on Tau-Bench.
+    // Not injected for other providers to avoid wasting a tool slot.
+    if execution_context.provider_backend == "anthropic" {
+        use genesis_tools::builtins::think::ThinkTool;
+        registry.register(
+            ToolDefinition {
+                name: "think".to_owned(),
+                description:
+                    "Use this tool to think through a problem step-by-step before acting. \
+                     Write your reasoning in the `thought` parameter. The output is always \
+                     empty — the value is in organizing your thoughts, not the response. \
+                     Use this between tool calls when you need to plan, analyze results, \
+                     or reason about the next step."
+                        .to_owned(),
+                parameters: Some(json!({
+                    "type": "object",
+                    "properties": {
+                        "thought": {
+                            "type": "string",
+                            "description": "Your step-by-step reasoning, analysis, or plan."
+                        }
+                    },
+                    "required": ["thought"]
+                })),
+            },
+            ApprovalPolicy::Never,
+            ThinkTool,
+        );
+    }
 
     ToolRuntime {
         registry,

--- a/crates/genesis-tools/src/builtins/think.rs
+++ b/crates/genesis-tools/src/builtins/think.rs
@@ -19,14 +19,22 @@ pub struct ThinkTool;
 
 impl ToolHandler for ThinkTool {
     fn run(&self, call: &ToolCall, _context: &ToolContext) -> Result<ToolOutput, ToolError> {
-        // Validate that the thought parameter is present.
-        let _thought =
+        let thought =
             call.arguments
                 .get("thought")
                 .ok_or_else(|| ToolError::MissingArgument {
                     tool: call.name.clone(),
                     argument: "thought",
                 })?;
+
+        // Log the thought at debug level for observability.
+        // The thought content lives in the tool call arguments in the
+        // conversation history, but having it in tracing makes it
+        // available to structured logging backends (OTLP, file, etc.).
+        tracing::debug!(
+            thought_len = thought.len(),
+            "think tool invoked"
+        );
 
         // Return empty content — the value is in the tool call itself,
         // not in the result. This is zero-cost for the output budget.


### PR DESCRIPTION
## Summary

Follow-up to #155 (think tool). Addresses P1 review feedback: think tool was registered only in `SessionExecutionService::build_agent_loop`, so batch.rs and other direct callers of `build_default_tool_runtime` never received it.

## Changes

- Add `provider_backend: String` to `ExecutionContext` (with `#[serde(default)]` for backwards compat)
- Move think tool registration from `execution.rs` → `build_default_tool_runtime` in `lib.rs`
- All code paths (CLI, batch, gateway, scheduler) now get the think tool when backend is Anthropic
- Add `tracing::debug` to ThinkTool::run for observability

## Test plan

- [x] All 635 genesis-core tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Full workspace `cargo check` passes