### PR TITLE
fix(tui): add Alt+Enter and Ctrl+J as newline fallbacks for multi-line input

### DIFF
--- a/crates/genesis-tui/src/terminal.rs
+++ b/crates/genesis-tui/src/terminal.rs
@@ -28,12 +28,15 @@ pub fn init() -> io::Result<()> {
     let _ = execute!(stdout(), EnterAlternateScreen);
     execute!(stdout(), EnableBracketedPaste)?;
 
-    // Best-effort keyboard enhancement (not supported on all terminals)
+    // Best-effort keyboard enhancement (not supported on all terminals).
+    // DISAMBIGUATE_ESCAPE_CODES enables Shift+Enter detection in Kitty/WezTerm.
+    // REPORT_ALL_KEYS_AS_ESCAPE_CODES improves modifier detection for Enter/Tab.
     let _ = execute!(
         stdout(),
         PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                 | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+                | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
         )
     );
 

--- a/crates/genesis-tui/src/widgets/input_widget.rs
+++ b/crates/genesis-tui/src/widgets/input_widget.rs
@@ -120,21 +120,44 @@ impl InputWidget {
     // ── Event handling ────────────────────────────────────────────────────
 
     /// Handle a keyboard event and return the resulting [`InputAction`].
+    ///
+    /// ## Newline insertion
+    ///
+    /// Multiple keybindings are supported for inserting newlines, since
+    /// Shift+Enter requires the Kitty keyboard protocol which many
+    /// terminals don't support:
+    ///
+    /// - **Shift+Enter** — works in Kitty, WezTerm, foot, and other
+    ///   terminals supporting the keyboard enhancement protocol
+    /// - **Alt+Enter** (Option+Enter on macOS) — works in most terminals
+    ///   when iTerm2 "Option sends Esc+" is enabled
+    /// - **Ctrl+J** — universal fallback (ASCII newline, works everywhere)
     pub fn handle_key(&mut self, key: KeyEvent) -> InputAction {
         match (key.code, key.modifiers) {
-            // ── Submit (Enter without Shift) ─────────────────────────────
-            (KeyCode::Enter, mods) if !mods.contains(KeyModifiers::SHIFT) => {
+            // ── Newline insertion (must be checked BEFORE plain Enter) ────
+            // Shift+Enter — requires Kitty keyboard protocol
+            (KeyCode::Enter, mods) if mods.contains(KeyModifiers::SHIFT) => {
+                self.insert_char('\n');
+                InputAction::None
+            }
+            // Alt+Enter — works in terminals with "Option sends Esc+"
+            (KeyCode::Enter, mods) if mods.contains(KeyModifiers::ALT) => {
+                self.insert_char('\n');
+                InputAction::None
+            }
+            // Ctrl+J — universal ASCII newline, works in all terminals
+            (KeyCode::Char('j'), KeyModifiers::CONTROL) => {
+                self.insert_char('\n');
+                InputAction::None
+            }
+
+            // ── Submit (plain Enter) ─────────────────────────────────────
+            (KeyCode::Enter, _) => {
                 let text = std::mem::take(&mut self.buffer);
                 self.cursor = 0;
                 self.history_index = None;
                 self.saved_input = None;
                 InputAction::Submit(text)
-            }
-
-            // ── Newline (Shift+Enter) ────────────────────────────────────
-            (KeyCode::Enter, mods) if mods.contains(KeyModifiers::SHIFT) => {
-                self.insert_char('\n');
-                InputAction::None
             }
 
             // ── Interrupt / Exit ─────────────────────────────────────────
@@ -810,6 +833,26 @@ mod tests {
         w.handle_key(key(KeyCode::Char('b')));
         assert_eq!(w.text(), "a\nb");
         assert!(w.is_multiline());
+    }
+
+    #[test]
+    fn alt_enter_inserts_newline() {
+        let mut w = InputWidget::new();
+        w.handle_key(key(KeyCode::Char('a')));
+        let action = w.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+        assert_eq!(action, InputAction::None);
+        w.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(w.text(), "a\nb");
+    }
+
+    #[test]
+    fn ctrl_j_inserts_newline() {
+        let mut w = InputWidget::new();
+        w.handle_key(key(KeyCode::Char('a')));
+        let action = w.handle_key(ctrl('j'));
+        assert_eq!(action, InputAction::None);
+        w.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(w.text(), "a\nb");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Shift+Enter for multi-line input (#154) requires the Kitty keyboard enhancement protocol, which most macOS terminals don't support. On Terminal.app and iTerm2, Shift+Enter is reported as plain Enter — making multi-line input impossible.

## Fix

Add two universal fallback keybindings:
- **Alt+Enter** (Option+Enter on macOS) — works in terminals with "Option sends Esc+" enabled
- **Ctrl+J** — universal ASCII newline, works in ALL terminals (this is the traditional Unix "literal newline" key)

Also enable `REPORT_ALL_KEYS_AS_ESCAPE_CODES` in the keyboard enhancement flags for better modifier detection.

## Keybinding priority

1. Shift+Enter → newline (Kitty/WezTerm only)
2. Alt+Enter → newline (most terminals with Esc+ config)
3. Ctrl+J → newline (universal, works everywhere)
4. Enter → submit

## Test plan

- [x] 207 tests pass (2 new: `alt_enter_inserts_newline`, `ctrl_j_inserts_newline`)
- [x] clippy clean