### PR TITLE
fix(tui): prevent CODE_BG background color from bleeding into non-code text

### DIFF
--- a/crates/genesis-tui/src/render/markdown.rs
+++ b/crates/genesis-tui/src/render/markdown.rs
@@ -589,10 +589,15 @@ fn highlight_code(code: &str, lang: &str) -> Vec<Line<'static>> {
 
         if ranges.is_empty() {
             let content = line.trim_end_matches('\n').to_owned();
-            result.push(Line::from(vec![Span::styled(
-                content,
-                Style::default().fg(CODE_FG).bg(CODE_BG),
-            )]));
+            // Set Line::style to reset bg — prevents CODE_BG from bleeding
+            // into trailing buffer cells that ratatui doesn't overwrite.
+            result.push(
+                Line::from(vec![Span::styled(
+                    content,
+                    Style::default().fg(CODE_FG).bg(CODE_BG),
+                )])
+                .style(Style::default()),
+            );
             continue;
         }
 
@@ -609,7 +614,9 @@ fn highlight_code(code: &str, lang: &str) -> Vec<Line<'static>> {
             })
             .collect();
 
-        result.push(Line::from(spans));
+        // Line::style with default bg ensures trailing cells are cleared,
+        // preventing CODE_BG from bleeding past the code content.
+        result.push(Line::from(spans).style(Style::default()));
     }
 
     result


### PR DESCRIPTION
## Bug

Code fence lines display with `CODE_BG` (dark gray background) that bleeds past the actual code content into trailing buffer cells. This causes numbered lists, bullet lists, and other content near code blocks to render with an unwanted gray background.

## Root Cause

`highlight_code()` applies `bg(CODE_BG)` on every span in code fence lines. When ratatui renders these Lines and the content is shorter than the render area width, trailing cells retain the CODE_BG from the last span — ratatui doesn't always reset unused cells.

## Fix

Set `Line::style(Style::default())` on every code fence line. This tells ratatui to use the default style (no background) for any trailing cells that the content spans don't cover, preventing CODE_BG from bleeding.

Applied to both the plain fallback path and the syntect-highlighted path.

## Test plan

- [x] 212 tests pass
- [x] clippy clean

Closes #162