### PR TITLE
feat(tui): Ctrl+P command palette — universal command access

### DIFF
--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -364,6 +364,17 @@ impl App {
             return;
         }
 
+        // Ctrl+P — open command palette (accessible anytime).
+        if key.code == KeyCode::Char('p') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            if !self.command_popup.is_visible() {
+                self.command_popup.show();
+            } else {
+                self.command_popup.hide();
+            }
+            self.frame_requester.schedule_frame();
+            return;
+        }
+
         // When the command popup is visible, route keys to it first.
         if self.command_popup.is_visible() {
             // Keep the slash command query synced with the actual input widget so

--- a/crates/genesis-tui/src/widgets/help_overlay.rs
+++ b/crates/genesis-tui/src/widgets/help_overlay.rs
@@ -86,12 +86,15 @@ impl HelpOverlay {
 
         let bindings: &[(&str, &str)] = &[
             ("Enter", "Submit message"),
+            ("Ctrl+J", "Insert newline (multi-line input)"),
             ("Ctrl+C", "Interrupt running turn"),
             ("Ctrl+D", "Exit Eve"),
-            ("Ctrl+T", "Toggle transcript overlay"),
-            ("Up/Down", "Navigate input history"),
-            ("Home/End", "Move cursor to start/end of line"),
+            ("Ctrl+P", "Open command palette"),
             ("Ctrl+K", "Delete from cursor to end of line"),
+            ("Ctrl+T", "Toggle transcript overlay"),
+            ("@", "File path completion"),
+            ("Up/Down", "Navigate input history / lines"),
+            ("Home/End", "Move cursor to start/end of line"),
             ("Ctrl+U", "Delete from cursor to start of line"),
             ("Esc", "Close overlay / dismiss popup"),
         ];


### PR DESCRIPTION
## Summary

Add Ctrl+P to open the command palette from anywhere in the chat. Currently commands are only accessible by typing `/` as the first character — this adds a universal shortcut.

## Changes

- **Ctrl+P** toggles the existing CommandPopup widget (same fuzzy search, same commands)
- Updated help overlay with new keybindings: Ctrl+J (newline), Ctrl+P (palette), @ (file completion)
- Used Ctrl+P instead of Ctrl+K because Ctrl+K is already kill-to-end-of-line

## Test plan

- [x] 223 tests pass
- [x] clippy clean

Closes #175