### PR TITLE
fix(web): correct InsightsData types to match Rust Vec<tuple> serialization

### DIFF
--- a/web/src/components/dashboard/token-chart.tsx
+++ b/web/src/components/dashboard/token-chart.tsx
@@ -28,11 +28,12 @@ function formatDateLabel(dateStr: string): string {
 }
 
 export function TokenChart({ tokensPerDay }: TokenChartProps) {
-  const data: ChartDataPoint[] = Object.entries(tokensPerDay)
+  // tokensPerDay is [date, input_tokens, output_tokens][]
+  const data: ChartDataPoint[] = [...tokensPerDay]
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([date, tokens]) => ({
+    .map(([date, inp, out]) => ({
       date: formatDateLabel(date),
-      tokens,
+      tokens: inp + out,
     }))
 
   if (data.length === 0) {

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -105,10 +105,14 @@ export interface InsightsData {
   sessions_count: number
   total_input_tokens: number
   total_output_tokens: number
-  sessions_per_day: Record<string, number>
-  platform_breakdown: Record<string, number>
-  tokens_per_day: Record<string, number>
-  tool_usage: Record<string, number>
+  /** [date, count] tuples — Rust Vec<(String, u64)> */
+  sessions_per_day: [string, number][]
+  /** [platform, count] tuples — Rust Vec<(String, u64)> */
+  platform_breakdown: [string, number][]
+  /** [date, input_tokens, output_tokens] tuples — Rust Vec<(String, u64, u64)> */
+  tokens_per_day: [string, number, number][]
+  /** [tool_name, count] tuples — Rust Vec<(String, u64)> */
+  tool_usage: [string, number][]
   avg_input_tokens: number
   avg_output_tokens: number
 }

--- a/web/src/routes/analytics.tsx
+++ b/web/src/routes/analytics.tsx
@@ -32,8 +32,8 @@ function formatDateLabel(dateStr: string): string {
   }
 }
 
-function SessionsPerDayChart({ sessionsPerDay }: { sessionsPerDay: Record<string, number> }) {
-  const data = Object.entries(sessionsPerDay)
+function SessionsPerDayChart({ sessionsPerDay }: { sessionsPerDay: [string, number][] }) {
+  const data = [...sessionsPerDay]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([date, sessions]) => ({
       date: formatDateLabel(date),
@@ -86,8 +86,8 @@ function SessionsPerDayChart({ sessionsPerDay }: { sessionsPerDay: Record<string
   )
 }
 
-function ToolUsageChart({ toolUsage }: { toolUsage: Record<string, number> }) {
-  const data = Object.entries(toolUsage)
+function ToolUsageChart({ toolUsage }: { toolUsage: [string, number][] }) {
+  const data = [...toolUsage]
     .sort(([, a], [, b]) => b - a)
     .slice(0, 20)
     .map(([tool, count]) => ({ tool, count }))
@@ -156,7 +156,7 @@ function AnalyticsPage() {
   const { data: usage, isLoading: usageLoading } = useUsage()
 
   const platformEntries: [string, number][] = insights
-    ? Object.entries(insights.platform_breakdown)
+    ? insights.platform_breakdown
     : []
 
   const avgTokensPerSession =
@@ -235,7 +235,7 @@ function AnalyticsPage() {
             {insightsLoading ? (
               <Skeleton className="h-[200px] w-full rounded" />
             ) : (
-              <TokenChart tokensPerDay={insights?.tokens_per_day ?? {}} />
+              <TokenChart tokensPerDay={insights?.tokens_per_day ?? []} />
             )}
           </CardContent>
         </Card>
@@ -250,7 +250,7 @@ function AnalyticsPage() {
             {insightsLoading ? (
               <Skeleton className="h-[200px] w-full rounded" />
             ) : (
-              <SessionsPerDayChart sessionsPerDay={insights?.sessions_per_day ?? {}} />
+              <SessionsPerDayChart sessionsPerDay={insights?.sessions_per_day ?? []} />
             )}
           </CardContent>
         </Card>
@@ -287,7 +287,7 @@ function AnalyticsPage() {
             {insightsLoading ? (
               <Skeleton className="h-[300px] w-full rounded" />
             ) : (
-              <ToolUsageChart toolUsage={insights?.tool_usage ?? {}} />
+              <ToolUsageChart toolUsage={insights?.tool_usage ?? []} />
             )}
           </CardContent>
         </Card>

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -35,12 +35,14 @@ function DashboardPage() {
   const { data: insights, isLoading: insightsLoading } = useInsights(7)
   const { data: sessions, isLoading: sessionsLoading } = useSessions({ limit: 10 })
 
+  // tokens_per_day is [date, input, output][] — sum input + output
   const totalTokens7d = insights
-    ? Object.values(insights.tokens_per_day).reduce((sum, v) => sum + v, 0)
+    ? insights.tokens_per_day.reduce((sum, [, inp, out]) => sum + inp + out, 0)
     : 0
 
+  // platform_breakdown is already [platform, count][]
   const platformEntries: [string, number][] = insights
-    ? Object.entries(insights.platform_breakdown)
+    ? insights.platform_breakdown
     : []
 
   const isHealthy = health?.status === 'ok' || health?.status === 'healthy'
@@ -92,7 +94,7 @@ function DashboardPage() {
             {insightsLoading ? (
               <Skeleton className="h-[200px] w-full rounded" />
             ) : (
-              <TokenChart tokensPerDay={insights?.tokens_per_day ?? {}} />
+              <TokenChart tokensPerDay={insights?.tokens_per_day ?? []} />
             )}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary

**Critical data integrity fix.** The Rust `InsightsData` struct uses `Vec<(String, u64)>` and `Vec<(String, u64, u64)>` tuples which serde serializes as JSON arrays of arrays (e.g. `[["2026-03-01", 1234, 5678]]`), not as JSON objects (`{"2026-03-01": 1234}`).

The TypeScript types incorrectly declared these fields as `Record<string, number>`, causing `Object.entries()`/`Object.values()` to produce `NaN` or garbage when processing real API responses. This bug affects the dashboard, analytics page, and token chart.

### What was wrong
```typescript
// BEFORE (wrong): treats API data as { key: value } objects
tokens_per_day: Record<string, number>  // actual API: [["2026-03-01", 100, 200], ...]
tool_usage: Record<string, number>       // actual API: [["bash", 42], ...]
```

### What's fixed
```typescript
// AFTER (correct): matches Rust Vec<tuple> serialization
tokens_per_day: [string, number, number][]  // [date, input_tokens, output_tokens]
tool_usage: [string, number][]              // [tool_name, count]
sessions_per_day: [string, number][]        // [date, count]
platform_breakdown: [string, number][]      // [platform, count]
```

### Files Changed
| File | Change |
|------|--------|
| `web/src/lib/api/types.ts` | Fix 4 InsightsData field types from Record to tuple arrays |
| `web/src/routes/index.tsx` | Sum input+output from 3-tuples, use tuples for platform breakdown |
| `web/src/components/dashboard/token-chart.tsx` | Destructure [date, inp, out] tuples |
| `web/src/routes/analytics.tsx` | Update chart component props and default values |

## Test plan
- [ ] `npm run build` passes (verified: zero TypeScript errors)
- [ ] Dashboard token count shows correct sum of input+output tokens
- [ ] Token chart renders bars with correct values
- [ ] Platform breakdown shows platform names (not array indices)
- [ ] Analytics page tool usage chart renders correctly
- [ ] Sessions per day chart works with tuple data