### PR TITLE
fix(web): apply tuple type fixes to monitor page and agent canvas

### DIFF
--- a/web/src/components/monitor/agent-canvas.tsx
+++ b/web/src/components/monitor/agent-canvas.tsx
@@ -7,7 +7,7 @@ interface AgentCanvasProps {
   isHealthy: boolean
   totalTools: number
   uptimeSeconds: number
-  toolUsage: Record<string, number>
+  toolUsage: [string, number][]
 }
 
 interface SessionNode {
@@ -32,8 +32,8 @@ function layoutSessions(sessions: SessionSummary[]): SessionNode[] {
   })
 }
 
-function getToolCategories(toolUsage: Record<string, number>, max: number = 10): [string, number][] {
-  return Object.entries(toolUsage)
+function getToolCategories(toolUsage: [string, number][], max: number = 10): [string, number][] {
+  return [...toolUsage]
     .sort(([, a], [, b]) => b - a)
     .slice(0, max)
 }

--- a/web/src/routes/monitor.tsx
+++ b/web/src/routes/monitor.tsx
@@ -35,7 +35,7 @@ function MonitorPage() {
 
   const isHealthy = health?.status === 'ok' || health?.status === 'healthy'
   const totalTokens7d = insights
-    ? Object.values(insights.tokens_per_day).reduce((sum, v) => sum + v, 0)
+    ? insights.tokens_per_day.reduce((sum, [, inp, out]) => sum + inp + out, 0)
     : 0
 
   const isLoading = healthLoading || insightsLoading || sessionsLoading
@@ -52,7 +52,7 @@ function MonitorPage() {
             isHealthy={isHealthy}
             totalTools={health?.total_tools ?? 0}
             uptimeSeconds={health?.uptime_seconds ?? 0}
-            toolUsage={insights?.tool_usage ?? {}}
+            toolUsage={insights?.tool_usage ?? []}
           />
         )}
       </div>
@@ -109,7 +109,7 @@ function MonitorPage() {
           </CardHeader>
           <CardContent className="pb-3">
             <div className="flex flex-wrap gap-2">
-              {Object.entries(insights?.platform_breakdown ?? {}).map(([platform, count]) => (
+              {(insights?.platform_breakdown ?? []).map(([platform, count]) => (
                 <div key={platform} className="flex items-center gap-1.5">
                   <div
                     className="h-2 w-2 rounded-full"


### PR DESCRIPTION
## Summary

Quick follow-up fix after merging PRs #173, #178, #167, #172. The monitor page and agent canvas (#173) were merged before the InsightsData tuple type corrections (#178) were fully applied to their code.

### Changes
- `monitor.tsx`: Sum tokens from `[date, input, output]` tuples, use tuple array for platform legend, pass `[]` default for toolUsage
- `agent-canvas.tsx`: Accept `[string, number][]` for `toolUsage` prop

### Verification
`npm run build` passes with zero TypeScript errors after this fix.