### PR TITLE
refactor(web): consolidate utilities, fix efficiency, remove duplication

### DIFF
--- a/web/src/components/dashboard/activity-feed.tsx
+++ b/web/src/components/dashboard/activity-feed.tsx
@@ -52,7 +52,7 @@ function ActivityItem({ entry }: { entry: AuditEntry }) {
 }
 
 export function ActivityFeed() {
-  const { data: entries, isLoading } = useAuditLog({ limit: 15, refetchInterval: 10_000 })
+  const { data: entries, isLoading } = useAuditLog({ limit: 15 }, { refetchInterval: 10_000 })
 
   if (isLoading) {
     return (

--- a/web/src/components/layout/command-palette.tsx
+++ b/web/src/components/layout/command-palette.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect } from 'react'
 import { useNavigate } from '@tanstack/react-router'
 import { navRoutes } from '@/lib/nav'
 import {
@@ -19,21 +18,7 @@ interface CommandPaletteProps {
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const navigate = useNavigate()
 
-  const toggleOpen = useCallback(() => {
-    onOpenChange(!open)
-  }, [open, onOpenChange])
-
-  // Cmd+K / Ctrl+K shortcut
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-        e.preventDefault()
-        toggleOpen()
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [toggleOpen])
+  // Cmd+K shortcut is handled centrally by useKeyboardNav in __root.tsx
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>

--- a/web/src/components/layout/system-bar.tsx
+++ b/web/src/components/layout/system-bar.tsx
@@ -1,21 +1,7 @@
 import { useHealth } from '@/lib/api/queries/health'
 import { useInsights } from '@/lib/api/queries/analytics'
-import { useEffect, useState } from 'react'
-
-function formatUptime(seconds: number): string {
-  const d = Math.floor(seconds / 86400)
-  const h = Math.floor((seconds % 86400) / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  if (d > 0) return `${d}d ${h}h`
-  if (h > 0) return `${h}h ${m}m`
-  return `${m}m`
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
+import { formatUptime, formatTokens, isHealthyStatus } from '@/lib/utils'
+import { useEffect, useMemo, useState } from 'react'
 
 function SystemClock() {
   const [time, setTime] = useState(() => new Date())
@@ -36,11 +22,12 @@ export function SystemBar() {
   const { data: health, isError } = useHealth()
   const { data: insights } = useInsights(7)
 
-  const totalTokens7d = insights
-    ? insights.tokens_per_day.reduce((sum, [, inp, out]) => sum + inp + out, 0)
-    : 0
+  const totalTokens7d = useMemo(
+    () => insights ? insights.tokens_per_day.reduce((sum, [, inp, out]) => sum + inp + out, 0) : 0,
+    [insights],
+  )
 
-  const isHealthy = health?.status === 'ok' || health?.status === 'healthy'
+  const isHealthy = isHealthyStatus(health?.status)
 
   return (
     <header className="system-bar flex h-9 items-center justify-between border-b border-border/50 bg-[#0c0c0c] px-4">
@@ -71,32 +58,17 @@ export function SystemBar() {
       <div className="flex items-center gap-1">
         {health && (
           <>
-            <StatusChip
-              label="UP"
-              value={formatUptime(health.uptime_seconds)}
-            />
+            <StatusChip label="UP" value={formatUptime(health.uptime_seconds)} />
             <Divider />
-            <StatusChip
-              label="SESSIONS"
-              value={String(health.total_sessions)}
-            />
+            <StatusChip label="SESSIONS" value={String(health.total_sessions)} />
             <Divider />
-            <StatusChip
-              label="TOOLS"
-              value={String(health.total_tools)}
-            />
+            <StatusChip label="TOOLS" value={String(health.total_tools)} />
             <Divider />
-            <StatusChip
-              label="7D TOK"
-              value={formatTokens(totalTokens7d)}
-            />
+            <StatusChip label="7D TOK" value={formatTokens(totalTokens7d)} />
             {health.active_schedules > 0 && (
               <>
                 <Divider />
-                <StatusChip
-                  label="SCHED"
-                  value={String(health.active_schedules)}
-                />
+                <StatusChip label="SCHED" value={String(health.active_schedules)} />
               </>
             )}
           </>

--- a/web/src/components/monitor/agent-canvas.tsx
+++ b/web/src/components/monitor/agent-canvas.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useState } from 'react'
 import type { SessionSummary } from '@/lib/api/types'
 import { getPlatformColor } from '@/lib/platforms'
+import { formatTokens } from '@/lib/utils'
 
 interface AgentCanvasProps {
   sessions: SessionSummary[]
@@ -16,6 +17,7 @@ interface SessionNode {
   radius: number
   size: number
   tokens: number
+  updatedAtMs: number
 }
 
 function layoutSessions(sessions: SessionSummary[]): SessionNode[] {
@@ -28,7 +30,7 @@ function layoutSessions(sessions: SessionSummary[]): SessionNode[] {
     const radius = 110 + recency * 70
     const size = 3.5 + (tokens / maxTokens) * 8
 
-    return { session, angle, radius, size, tokens }
+    return { session, angle, radius, size, tokens, updatedAtMs: new Date(session.updated_at).getTime() }
   })
 }
 
@@ -38,32 +40,42 @@ function getToolCategories(toolUsage: [string, number][], max: number = 10): [st
     .slice(0, max)
 }
 
-function formatTokensCompact(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
-
 export function AgentCanvas({ sessions, isHealthy, totalTools, uptimeSeconds, toolUsage }: AgentCanvasProps) {
   const [tick, setTick] = useState(0)
-  const rafRef = useRef<number>(0)
   const uid = useId()
 
   const nodes = useMemo(() => layoutSessions(sessions.slice(0, 16)), [sessions])
   const tools = useMemo(() => getToolCategories(toolUsage), [toolUsage])
   const maxToolCount = tools.length > 0 ? tools[0][1] : 1
 
+  // Animation loop with visibility gate — pauses when tab is hidden
   useEffect(() => {
     let lastTime = 0
+    let rafId = 0
+
     function animate(time: number) {
-      if (time - lastTime > 33) {
+      if (!document.hidden && time - lastTime > 33) {
         setTick((t: number) => t + 1)
         lastTime = time
       }
-      rafRef.current = requestAnimationFrame(animate)
+      rafId = requestAnimationFrame(animate)
     }
-    rafRef.current = requestAnimationFrame(animate)
-    return () => cancelAnimationFrame(rafRef.current)
+
+    function onVisibilityChange() {
+      if (document.hidden) {
+        cancelAnimationFrame(rafId)
+      } else {
+        rafId = requestAnimationFrame(animate)
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    rafId = requestAnimationFrame(animate)
+
+    return () => {
+      cancelAnimationFrame(rafId)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
   }, [])
 
   const W = 640
@@ -243,13 +255,15 @@ export function AgentCanvas({ sessions, isHealthy, totalTools, uptimeSeconds, to
       })}
 
       {/* === LAYER 4: Session connections + nodes === */}
-      {nodes.map(({ session, angle, radius, size, tokens }) => {
+      {(() => {
+        const nowMs = Date.now()
+        return nodes.map(({ session, angle, radius, size, tokens, updatedAtMs }) => {
         const a = angle + (rot * Math.PI) / 180
         const nx = cx + radius * Math.cos(a)
         const ny = cy + radius * Math.sin(a)
         const color = getPlatformColor(session.platform)
 
-        const ageMs = Date.now() - new Date(session.updated_at).getTime()
+        const ageMs = nowMs - updatedAtMs
         const ageHours = ageMs / (1000 * 60 * 60)
         const nodeOpacity = Math.max(0.15, 1 - ageHours / 72)
         const isRecent = ageHours < 2
@@ -320,7 +334,7 @@ export function AgentCanvas({ sessions, isHealthy, totalTools, uptimeSeconds, to
                 fontFamily="var(--font-mono)"
                 opacity={0.6}
               >
-                {formatTokensCompact(tokens)}
+                {formatTokens(tokens)}
               </text>
             </g>
 
@@ -335,7 +349,8 @@ export function AgentCanvas({ sessions, isHealthy, totalTools, uptimeSeconds, to
             )}
           </g>
         )
-      })}
+      })
+      })()}
 
       {/* === LAYER 5: Central core — Eve === */}
       {/* Ambient glow */}

--- a/web/src/components/sessions/message-thread.tsx
+++ b/web/src/components/sessions/message-thread.tsx
@@ -60,8 +60,7 @@ export function MessageThread({ messages }: MessageThreadProps) {
   let lastDate = ''
 
   return (
-    <div className="relative">
-      <div className="flex flex-col">
+    <div className="flex flex-col">
         {messages.map((msg, idx) => {
           const config = ROLE_CONFIG[msg.role]
           const Icon = config.icon
@@ -154,7 +153,6 @@ export function MessageThread({ messages }: MessageThreadProps) {
             </div>
           )
         })}
-      </div>
     </div>
   )
 }

--- a/web/src/components/sessions/session-header.tsx
+++ b/web/src/components/sessions/session-header.tsx
@@ -14,28 +14,22 @@ import {
 } from '@/components/ui/dialog'
 import { useDeleteSession, useForkSession } from '@/lib/api/mutations/sessions'
 import type { SessionSummary } from '@/lib/api/types'
-import { formatTokens } from '@/lib/utils'
+import { formatTokens, formatRelativeTime } from '@/lib/utils'
 
 interface SessionHeaderProps {
   session: SessionSummary
   messageCount?: number
 }
 
-function formatAge(isoString: string): string {
-  const ms = Date.now() - new Date(isoString).getTime()
-  const sec = Math.floor(ms / 1000)
-  if (sec < 60) return `${sec}s ago`
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m ago`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}h ago`
-  return `${Math.floor(hr / 24)}d ago`
-}
-
 export function SessionHeader({ session, messageCount }: SessionHeaderProps) {
   const navigate = useNavigate()
   const [deleteOpen, setDeleteOpen] = React.useState(false)
   const [copied, setCopied] = React.useState(false)
+  const copyTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => () => {
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+  }, [])
   const deleteMutation = useDeleteSession()
   const forkMutation = useForkSession()
 
@@ -61,7 +55,8 @@ export function SessionHeader({ session, messageCount }: SessionHeaderProps) {
   function handleCopyId() {
     navigator.clipboard.writeText(session.id).then(() => {
       setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => setCopied(false), 1500)
     }).catch(() => {
       // clipboard unavailable (non-HTTPS or denied)
     })
@@ -142,9 +137,9 @@ export function SessionHeader({ session, messageCount }: SessionHeaderProps) {
         <ChipDivider />
         <MetricChip label="OUT" value={formatTokens(session.total_output_tokens)} dim />
         <ChipDivider />
-        <MetricChip label="CREATED" value={formatAge(session.created_at)} dim />
+        <MetricChip label="CREATED" value={formatRelativeTime(session.created_at)} dim />
         <ChipDivider />
-        <MetricChip label="UPDATED" value={formatAge(session.updated_at)} dim />
+        <MetricChip label="UPDATED" value={formatRelativeTime(session.updated_at)} dim />
       </div>
     </div>
   )

--- a/web/src/lib/api/queries/audit.ts
+++ b/web/src/lib/api/queries/audit.ts
@@ -5,18 +5,21 @@ import type { AuditEntry } from '../types'
 interface AuditParams {
   limit?: number
   offset?: number
+}
+
+interface AuditQueryOptions {
   refetchInterval?: number
 }
 
-export function useAuditLog(params?: AuditParams) {
+export function useAuditLog(params?: AuditParams, options?: AuditQueryOptions) {
   const searchParams = new URLSearchParams()
   if (params?.limit !== undefined) searchParams.set('limit', String(params.limit))
   if (params?.offset !== undefined) searchParams.set('offset', String(params.offset))
   const qs = searchParams.toString()
 
   return useQuery({
-    queryKey: ['audit', { limit: params?.limit, offset: params?.offset }],
+    queryKey: ['audit', params],
     queryFn: () => api.get<AuditEntry[]>(`/audit${qs ? `?${qs}` : ''}`),
-    refetchInterval: params?.refetchInterval,
+    refetchInterval: options?.refetchInterval,
   })
 }

--- a/web/src/lib/use-keyboard-nav.ts
+++ b/web/src/lib/use-keyboard-nav.ts
@@ -57,7 +57,14 @@ export function useKeyboardNav({ onToggleHelp, onCloseHelp, onToggleCommandPalet
         return
       }
 
-      // Skip if any modifier is held (Cmd+K handled elsewhere)
+      // Cmd+K / Ctrl+K = open command palette (with modifier)
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault()
+        onToggleCommandPalette()
+        return
+      }
+
+      // Skip other modifier combos
       if (e.metaKey || e.ctrlKey || e.altKey) return
 
       // Number keys: dock navigation

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -29,3 +29,18 @@ export function truncate(text: string, max = 100): string {
   if (text.length <= max) return text
   return text.slice(0, max) + '…'
 }
+
+export function formatUptime(seconds: number): string {
+  const d = Math.floor(seconds / 86400)
+  const h = Math.floor((seconds % 86400) / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const parts: string[] = []
+  if (d > 0) parts.push(`${d}d`)
+  if (h > 0) parts.push(`${h}h`)
+  parts.push(`${m}m`)
+  return parts.join(' ')
+}
+
+export function isHealthyStatus(status: string | undefined): boolean {
+  return status === 'ok' || status === 'healthy'
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -11,27 +11,11 @@ import { ActivityFeed } from '@/components/dashboard/activity-feed'
 import { ToolHeatmap } from '@/components/dashboard/tool-heatmap'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { formatUptime, formatTokens, isHealthyStatus } from '@/lib/utils'
 
 export const Route = createFileRoute('/')({
   component: DashboardPage,
 })
-
-function formatUptime(seconds: number): string {
-  const d = Math.floor(seconds / 86400)
-  const h = Math.floor((seconds % 86400) / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const parts: string[] = []
-  if (d > 0) parts.push(`${d}d`)
-  if (h > 0) parts.push(`${h}h`)
-  parts.push(`${m}m`)
-  return parts.join(' ')
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
 
 function DashboardPage() {
   const { data: health, isLoading: healthLoading } = useHealth()
@@ -59,7 +43,7 @@ function DashboardPage() {
     ? insights.platform_breakdown
     : []
 
-  const isHealthy = health?.status === 'ok' || health?.status === 'healthy'
+  const isHealthy = isHealthyStatus(health?.status)
 
   // Uptime as fraction of 30 days (reasonable gauge max)
   const uptimeFraction = health

--- a/web/src/routes/monitor.tsx
+++ b/web/src/routes/monitor.tsx
@@ -6,34 +6,18 @@ import { AgentCanvas } from '@/components/monitor/agent-canvas'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { getPlatformColor } from '@/lib/platforms'
+import { formatUptime, formatTokens, isHealthyStatus } from '@/lib/utils'
 
 export const Route = createFileRoute('/monitor')({
   component: MonitorPage,
 })
-
-function formatUptime(seconds: number): string {
-  const d = Math.floor(seconds / 86400)
-  const h = Math.floor((seconds % 86400) / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const parts: string[] = []
-  if (d > 0) parts.push(`${d}d`)
-  if (h > 0) parts.push(`${h}h`)
-  parts.push(`${m}m`)
-  return parts.join(' ')
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return String(n)
-}
 
 function MonitorPage() {
   const { data: health, isLoading: healthLoading } = useHealth()
   const { data: insights, isLoading: insightsLoading } = useInsights(7, { refetchInterval: 60_000 })
   const { data: sessions, isLoading: sessionsLoading } = useSessions({ limit: 20 })
 
-  const isHealthy = health?.status === 'ok' || health?.status === 'healthy'
+  const isHealthy = isHealthyStatus(health?.status)
   const totalTokens7d = insights
     ? insights.tokens_per_day.reduce((sum, [, inp, out]) => sum + inp + out, 0)
     : 0


### PR DESCRIPTION
## Summary

Systematic cleanup driven by three parallel code review agents (reuse, quality, efficiency). **11 files changed, -132 lines, +90 lines** — net reduction of 42 lines while fixing real issues.

### Reuse (5 duplications eliminated)
- Extract `formatUptime` and `isHealthyStatus` into shared `lib/utils.ts`
- Remove 3 copies of `formatTokens` (system-bar, monitor, agent-canvas)
- Remove 2 copies of `formatUptime` (index.tsx, monitor.tsx)
- Replace `formatAge` with existing `formatRelativeTime` (identical logic)
- `isHealthyStatus` replaces 3 inline `status === 'ok' || status === 'healthy'` checks

### Efficiency (animation + rendering)
- **Visibility gate** on agent-canvas RAF loop — pauses when tab hidden (was 30fps in background)
- **Precompute timestamps** in `layoutSessions()` — eliminates 480 `new Date()` calls/sec
- **Hoist `Date.now()`** above `nodes.map()` — single call per frame
- **`useMemo`** for `totalTokens7d` in system-bar (was recomputing on health poll)
- **Remove duplicate `Cmd+K` listener** — now centralized in `useKeyboardNav`

### Quality
- Separate `refetchInterval` from `AuditParams` into `AuditQueryOptions`
- Remove unnecessary `div.relative` wrapper in message-thread
- Add copy timer cleanup on unmount in session-header

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] All formatting displays remain consistent (shared utils)
- [ ] Agent canvas pauses animation when tab hidden, resumes when visible
- [ ] Cmd+K still opens command palette
- [ ] Number key shortcuts still work
- [ ] Session header copy ID still works with timer cleanup