### PR TITLE
feat(web): memories page redesign — card-based knowledge base layout

### DIFF
--- a/web/src/routes/memories.tsx
+++ b/web/src/routes/memories.tsx
@@ -1,23 +1,70 @@
 import * as React from 'react'
 import { createFileRoute } from '@tanstack/react-router'
-import { type ColumnDef } from '@tanstack/react-table'
-import { TrashIcon, DatabaseIcon } from 'lucide-react'
+import { TrashIcon, DatabaseIcon, ChevronDown, ChevronRight } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMemories, useSearchMemories } from '@/lib/api/queries/memories'
 import { useDeleteMemory, useEmbedAll } from '@/lib/api/mutations/memories'
-import { DataTable } from '@/components/shared/data-table'
 import { EmptyState } from '@/components/shared/empty-state'
 import { ConfirmDeleteDialog } from '@/components/shared/confirm-delete-dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
+import { Badge } from '@/components/ui/badge'
 import type { Memory } from '@/lib/api/types'
-import { formatRelativeTime, truncate } from '@/lib/utils'
+import { formatRelativeTime } from '@/lib/utils'
 
 export const Route = createFileRoute('/memories')({
   component: MemoriesPage,
 })
 
+function MemoryCard({ memory, onDelete }: { memory: Memory; onDelete: () => void }) {
+  const [expanded, setExpanded] = React.useState(false)
+  const isLong = memory.content.length > 200
+
+  return (
+    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-colors hover:border-border/50">
+      {/* Header: source + time + actions */}
+      <div className="mb-2 flex items-center gap-2">
+        {memory.source && (
+          <Badge variant="outline" className="font-mono text-[9px] uppercase">
+            {memory.source}
+          </Badge>
+        )}
+        <span className="font-mono text-[9px] tabular-nums text-muted-foreground/40">
+          {memory.id.slice(0, 8)}
+        </span>
+        <span className="ml-auto font-mono text-[9px] tabular-nums text-muted-foreground/30">
+          {formatRelativeTime(memory.created_at)}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="h-5 w-5 opacity-0 transition-opacity group-hover:opacity-100"
+          onClick={onDelete}
+        >
+          <TrashIcon className="size-3 text-muted-foreground hover:text-destructive" />
+          <span className="sr-only">Delete</span>
+        </Button>
+      </div>
+
+      {/* Content */}
+      <p className={`whitespace-pre-wrap font-mono text-[11px] leading-relaxed text-foreground/70 ${!expanded && isLong ? 'line-clamp-3' : ''}`}>
+        {memory.content}
+      </p>
+
+      {/* Expand toggle */}
+      {isLong && (
+        <button
+          onClick={() => setExpanded(v => !v)}
+          className="mt-1.5 flex items-center gap-1 font-mono text-[9px] text-muted-foreground/40 transition-colors hover:text-muted-foreground"
+        >
+          {expanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+          {expanded ? 'collapse' : 'expand'}
+        </button>
+      )}
+    </div>
+  )
+}
 
 function MemoriesPage() {
   const [search, setSearch] = React.useState('')
@@ -48,6 +95,15 @@ function MemoriesPage() {
   const isSearching = Boolean(debouncedSearch)
   const { data: memories, isLoading } = isSearching ? searchQuery : memoriesQuery
 
+  const sources = React.useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const m of memories ?? []) {
+      const src = m.source || 'unknown'
+      counts.set(src, (counts.get(src) ?? 0) + 1)
+    }
+    return Array.from(counts.entries()).sort(([, a], [, b]) => b - a)
+  }, [memories])
+
   function handleEmbedAll() {
     const contents = (memories ?? []).map((m) => m.content)
     if (contents.length === 0) {
@@ -64,79 +120,31 @@ function MemoriesPage() {
     })
   }
 
-  const columns: ColumnDef<Memory, unknown>[] = React.useMemo(
-    () => [
-      {
-        accessorKey: 'id',
-        header: 'ID',
-        cell: ({ row }) => (
-          <span className="font-mono text-xs text-muted-foreground">
-            {row.original.id.slice(0, 8)}
-          </span>
-        ),
-      },
-      {
-        accessorKey: 'content',
-        header: 'Content',
-        cell: ({ row }) => (
-          <span className="font-mono text-xs">{truncate(row.original.content)}</span>
-        ),
-      },
-      {
-        accessorKey: 'source',
-        header: 'Source',
-        cell: ({ row }) => (
-          <span className="font-mono text-xs text-muted-foreground">
-            {row.original.source || '—'}
-          </span>
-        ),
-      },
-      {
-        accessorKey: 'created_at',
-        header: 'Created',
-        cell: ({ row }) => (
-          <span className="font-mono text-xs text-muted-foreground">
-            {formatRelativeTime(row.original.created_at)}
-          </span>
-        ),
-      },
-      {
-        id: 'actions',
-        header: '',
-        cell: ({ row }) => (
-          <div className="flex justify-end">
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => setDeleteTarget(row.original)}
-            >
-              <TrashIcon className="size-3.5 text-muted-foreground hover:text-destructive" />
-              <span className="sr-only">Delete</span>
-            </Button>
-          </div>
-        ),
-      },
-    ],
-    [],
-  )
-
   return (
     <div className="flex flex-col gap-4">
+      {/* Header */}
       <div className="flex items-center justify-between gap-3">
-        <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Memories
-        </h1>
+        <div className="flex items-center gap-3">
+          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Memories
+          </h1>
+          {!isLoading && (
+            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
+              {memories?.length ?? 0}
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-2">
           <Input
-            placeholder="Search memories..."
+            placeholder="Search..."
             value={search}
             onChange={handleSearchChange}
-            className="w-56 font-mono text-xs"
+            className="w-48 font-mono text-[11px]"
           />
           <Button
             variant="outline"
             size="sm"
-            className="font-mono text-xs gap-1.5"
+            className="h-7 gap-1.5 px-2 font-mono text-[10px]"
             onClick={handleEmbedAll}
             disabled={embedAll.isPending}
           >
@@ -146,10 +154,25 @@ function MemoriesPage() {
         </div>
       </div>
 
+      {/* Source filter strip */}
+      {!isLoading && sources.length > 1 && (
+        <div className="flex items-center gap-1.5">
+          <span className="font-mono text-[9px] uppercase tracking-widest text-muted-foreground/30">
+            Sources
+          </span>
+          {sources.map(([source, count]) => (
+            <span key={source} className="font-mono text-[9px] text-muted-foreground/40">
+              {source} ({count})
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Memory cards */}
       {isLoading ? (
-        <div className="flex flex-col gap-2">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full rounded" />
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-md" />
           ))}
         </div>
       ) : (memories ?? []).length === 0 ? (
@@ -158,7 +181,15 @@ function MemoriesPage() {
           description={isSearching ? 'No results for your search.' : 'No memories stored yet.'}
         />
       ) : (
-        <DataTable columns={columns} data={memories ?? []} />
+        <div className="card-stagger grid grid-cols-1 gap-2 lg:grid-cols-2">
+          {(memories ?? []).map((memory) => (
+            <MemoryCard
+              key={memory.id}
+              memory={memory}
+              onDelete={() => setDeleteTarget(memory)}
+            />
+          ))}
+        </div>
       )}
 
       <ConfirmDeleteDialog


### PR DESCRIPTION
## Summary

Redesigns the memories page from a plain data table into a card-based knowledge base layout. Text content doesn't belong in narrow table cells — cards give each memory room to breathe and are scannable at a glance.

### Changes
- **Card layout**: Each memory as a bordered card with content preview, source badge, ID, timestamp
- **Expandable**: Long memories (>200 chars) show 3-line clamp with expand/collapse toggle
- **2-column grid**: Responsive (1 col mobile, 2 col lg+) with `card-stagger` animation
- **Source summary**: Shows source distribution strip when multiple sources exist
- **Memory count**: Displayed in header
- **Hover-reveal delete**: Delete icon only shows on card hover (less visual noise)
- **Compact styling**: Matches the OS monospace aesthetic established in other pages

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Memories render as cards in 2-column grid
- [ ] Long memories show "expand" toggle, click to reveal full content
- [ ] Delete works via hover-reveal trash icon
- [ ] Search filters cards in real-time
- [ ] Embed All button still works
- [ ] Empty state shows when no memories exist