### PR TITLE
feat(web): PWA support and mobile-native experience

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,9 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
+
+    <!-- PWA -->
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#0a0a0a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Genesis" />
+
+    <!-- Icons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web</title>
+
+    <!-- App info -->
+    <title>Genesis</title>
+    <meta name="description" content="Genesis agent admin & observability dashboard" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Genesis Dashboard",
+  "short_name": "Genesis",
+  "description": "Agent admin & observability dashboard",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -245,3 +245,36 @@
     animation: none;
   }
 }
+
+/* === PWA / Mobile === */
+
+/* Safe area insets for notched devices (iPhone X+) */
+@supports (padding: env(safe-area-inset-top)) {
+  .system-bar {
+    padding-top: env(safe-area-inset-top);
+  }
+
+  .dock {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
+/* Touch-friendly targets on mobile */
+@media (pointer: coarse) {
+  .dock-item {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+/* Prevent iOS rubber-band overscroll on the shell (but allow in main) */
+html, body {
+  overscroll-behavior: none;
+}
+
+/* Standalone PWA: hide browser chrome indicators */
+@media (display-mode: standalone) {
+  .system-bar {
+    padding-top: max(4px, env(safe-area-inset-top, 0px));
+  }
+}


### PR DESCRIPTION
## Summary

Makes the Genesis dashboard installable as a PWA and feel native on mobile devices.

### PWA Support
- **Web App Manifest**: `standalone` display mode, dark theme (#0a0a0a), SVG icon, Genesis branding
- **Apple meta tags**: `apple-mobile-web-app-capable`, `black-translucent` status bar, app title
- **Viewport**: `viewport-fit=cover` for notched devices

### Mobile Experience
- **Safe area insets**: System bar and dock respect `env(safe-area-inset-*)` for iPhone X+ notch/home indicator
- **Touch targets**: 44px minimum on `pointer: coarse` devices (WCAG guideline)
- **Overscroll**: Disabled on the shell to prevent rubber-banding (scroll still works in main content)
- **Standalone mode**: Extra top padding when running as installed PWA

### Other
- Page title changed from "web" to "Genesis"
- Added proper description meta tag

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Chrome DevTools → Application → Manifest shows valid manifest
- [ ] "Install app" prompt appears in Chrome/Edge
- [ ] On iOS Safari, "Add to Home Screen" creates a standalone app
- [ ] Dock doesn't overlap home indicator on iPhone X+
- [ ] System bar doesn't overlap notch area
- [ ] Touch targets are comfortable on mobile