### PR TITLE
fix(web): mount Toaster and style toast notifications for OS aesthetic

### DIFF
--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,43 +1,21 @@
-import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="dark"
       className="toaster group"
+      position="bottom-right"
       icons={{
-        success: (
-          <CircleCheckIcon className="size-4" />
-        ),
-        info: (
-          <InfoIcon className="size-4" />
-        ),
-        warning: (
-          <TriangleAlertIcon className="size-4" />
-        ),
-        error: (
-          <OctagonXIcon className="size-4" />
-        ),
-        loading: (
-          <Loader2Icon className="size-4 animate-spin" />
-        ),
+        success: <CircleCheckIcon className="size-3.5" />,
+        info: <InfoIcon className="size-3.5" />,
+        warning: <TriangleAlertIcon className="size-3.5" />,
+        error: <OctagonXIcon className="size-3.5" />,
+        loading: <Loader2Icon className="size-3.5 animate-spin" />,
       }}
-      style={
-        {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
-        } as React.CSSProperties
-      }
       toastOptions={{
-        classNames: {
-          toast: "cn-toast",
-        },
+        className: "font-mono text-[11px] !bg-[#111111] !border-border/50 !text-foreground/80",
       }}
       {...props}
     />

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { Dock } from '@/components/layout/dock'
 import { CommandPalette } from '@/components/layout/command-palette'
 import { ShortcutHelp } from '@/components/layout/shortcut-help'
 import { ConnectionBanner } from '@/components/shared/connection-banner'
+import { Toaster } from '@/components/ui/sonner'
 import { useKeyboardNav } from '@/lib/use-keyboard-nav'
 import { useCallback, useState } from 'react'
 
@@ -41,6 +42,7 @@ function RootLayout() {
       <Dock onCommandPalette={() => setCommandOpen(true)} />
       <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} />
       <ShortcutHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
+      <Toaster />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

**Bug fix:** The `<Toaster />` component from Sonner was never mounted in the app. All `toast.success()`, `toast.error()`, and `toast.info()` calls throughout the dashboard (schedules, memories, skills, settings pages) were silently failing — users got no feedback on actions like create/delete/embed.

### Changes
- **Mount Toaster** in root layout (`__root.tsx`)
- **Force dark theme** — removed `useTheme()` from `next-themes` (we're always dark mode, no theme switching)
- **OS-styled toasts**: monospace font, 11px text, `#111111` background, subtle border
- **Bottom-right position** (away from the dock)
- **Compact icons** (3.5px instead of 4px)

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Create a schedule → see "Schedule created" toast
- [ ] Delete a memory → see "Memory deleted" toast
- [ ] Embed all memories → see "Embedded N memories" toast
- [ ] Error actions show red error toast
- [ ] Toast matches terminal dark theme