### PR TITLE
feat(web): audit log redesign — event stream with typed action icons

### DIFF
--- a/web/src/routes/audit.lazy.tsx
+++ b/web/src/routes/audit.lazy.tsx
@@ -1,17 +1,85 @@
 import * as React from 'react'
 import { createLazyFileRoute, Link } from '@tanstack/react-router'
-import { type ColumnDef } from '@tanstack/react-table'
 import { useAuditLog } from '@/lib/api/queries/audit'
-import { DataTable } from '@/components/shared/data-table'
 import { EmptyState } from '@/components/shared/empty-state'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { AuditEntry } from '@/lib/api/types'
-import { formatRelativeTime, truncate } from '@/lib/utils'
+import { formatRelativeTime } from '@/lib/utils'
+import {
+  MessageSquare, Wrench, Brain, Database,
+  Clock, AlertTriangle, Activity, Zap, Shield, Settings,
+} from 'lucide-react'
 
 export const Route = createLazyFileRoute('/audit')({
   component: AuditPage,
 })
+
+function getActionIcon(action: string) {
+  if (action.includes('session')) return MessageSquare
+  if (action.includes('tool')) return Wrench
+  if (action.includes('skill')) return Brain
+  if (action.includes('memory')) return Database
+  if (action.includes('schedule')) return Clock
+  if (action.includes('error') || action.includes('fail')) return AlertTriangle
+  if (action.includes('llm') || action.includes('token')) return Zap
+  if (action.includes('auth') || action.includes('pair')) return Shield
+  if (action.includes('config') || action.includes('setting')) return Settings
+  return Activity
+}
+
+function getActionColor(action: string): string {
+  if (action.includes('error') || action.includes('fail')) return 'text-red-400 bg-red-400/10'
+  if (action.includes('create') || action.includes('new')) return 'text-emerald-400 bg-emerald-400/10'
+  if (action.includes('delete') || action.includes('remove')) return 'text-amber-400 bg-amber-400/10'
+  return 'text-muted-foreground bg-muted/30'
+}
+
+function AuditEntry({ entry }: { entry: AuditEntry }) {
+  const Icon = getActionIcon(entry.action)
+  const colorClass = getActionColor(entry.action)
+  const [iconColor, bgColor] = colorClass.split(' ')
+
+  return (
+    <div className="group flex items-start gap-3 py-2">
+      {/* Icon */}
+      <div className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded ${bgColor}`}>
+        <Icon className={`h-3 w-3 ${iconColor}`} strokeWidth={1.5} />
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[11px] font-medium text-foreground/80">
+            {entry.action}
+          </span>
+          {entry.session_id && (
+            <Link
+              to="/sessions/$id"
+              params={{ id: entry.session_id }}
+              className="font-mono text-[9px] text-primary/60 transition-colors hover:text-primary"
+            >
+              {entry.session_id.slice(0, 8)}
+            </Link>
+          )}
+        </div>
+        {entry.details && (
+          <p className="mt-0.5 line-clamp-2 font-mono text-[10px] leading-relaxed text-muted-foreground/40">
+            {entry.details}
+          </p>
+        )}
+      </div>
+
+      {/* Timestamp */}
+      <span
+        className="shrink-0 font-mono text-[9px] tabular-nums text-muted-foreground/30"
+        title={new Date(entry.created_at).toLocaleString()}
+      >
+        {formatRelativeTime(entry.created_at)}
+      </span>
+    </div>
+  )
+}
 
 function AuditPage() {
   const { data: entries, isLoading } = useAuditLog({ limit: 200 })
@@ -33,85 +101,35 @@ function AuditPage() {
         entry.action.toLowerCase().includes(search.toLowerCase()) ||
         (entry.session_id?.toLowerCase().includes(search.toLowerCase()) ?? false) ||
         (entry.details?.toLowerCase().includes(search.toLowerCase()) ?? false)
-      const matchesAction =
-        !actionFilter || entry.action === actionFilter
+      const matchesAction = !actionFilter || entry.action === actionFilter
       return matchesSearch && matchesAction
     })
   }, [entries, search, actionFilter])
 
-  const columns: ColumnDef<AuditEntry, unknown>[] = React.useMemo(
-    () => [
-      {
-        accessorKey: 'created_at',
-        header: 'Timestamp',
-        cell: ({ row }) => (
-          <span
-            className="font-mono text-xs text-muted-foreground"
-            title={new Date(row.original.created_at).toLocaleString()}
-          >
-            {formatRelativeTime(row.original.created_at)}
-          </span>
-        ),
-      },
-      {
-        accessorKey: 'action',
-        header: 'Action',
-        cell: ({ row }) => (
-          <span className="font-mono text-xs font-medium">{row.original.action}</span>
-        ),
-      },
-      {
-        accessorKey: 'session_id',
-        header: 'Session',
-        cell: ({ row }) => {
-          const sid = row.original.session_id
-          if (!sid) return <span className="font-mono text-xs text-muted-foreground">—</span>
-          const short = sid.slice(0, 8)
-          return (
-            <Link
-              to="/sessions/$id"
-              params={{ id: sid }}
-              className="font-mono text-xs text-primary underline-offset-4 hover:underline"
-            >
-              {short}…
-            </Link>
-          )
-        },
-      },
-      {
-        accessorKey: 'details',
-        header: 'Details',
-        cell: ({ row }) => {
-          const details = row.original.details
-          if (!details) return <span className="font-mono text-xs text-muted-foreground">—</span>
-          return (
-            <span className="font-mono text-xs text-muted-foreground" title={details}>
-              {truncate(details, 120)}
-            </span>
-          )
-        },
-      },
-    ],
-    [],
-  )
-
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between gap-3">
-        <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Audit Log
-        </h1>
+        <div className="flex items-center gap-3">
+          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Audit Log
+          </h1>
+          {!isLoading && (
+            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
+              {filtered.length} entries
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-2">
           <Input
-            placeholder="Search entries..."
+            placeholder="Search..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-48 font-mono text-xs"
+            className="w-48 font-mono text-[11px]"
           />
           <select
             value={actionFilter}
             onChange={(e) => setActionFilter(e.target.value)}
-            className="h-8 rounded-md border border-input bg-background px-2 font-mono text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            className="h-7 rounded-md border border-border/40 bg-card/30 px-2 font-mono text-[10px] text-foreground/60 focus:outline-none focus:ring-1 focus:ring-ring"
           >
             <option value="">All actions</option>
             {allActions.map((action) => (
@@ -125,8 +143,8 @@ function AuditPage() {
 
       {isLoading ? (
         <div className="flex flex-col gap-2">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <Skeleton key={i} className="h-10 w-full rounded" />
+          {Array.from({ length: 10 }).map((_, i) => (
+            <Skeleton key={i} className="h-12 w-full rounded" />
           ))}
         </div>
       ) : filtered.length === 0 ? (
@@ -139,7 +157,11 @@ function AuditPage() {
           }
         />
       ) : (
-        <DataTable columns={columns} data={filtered} />
+        <div className="divide-y divide-border/20">
+          {filtered.map((entry) => (
+            <AuditEntry key={entry.id} entry={entry} />
+          ))}
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

Replaces the audit log data table with an event stream layout that looks like a system event log / syslog viewer.

### Changes
- **Typed action icons**: Each event type has a specific icon (session, tool, skill, memory, schedule, error, auth, config) with color-coded backgrounds (green=create, amber=delete, red=error)
- **Event stream layout**: Divider-separated entries instead of table rows
- **Inline session links**: Clickable 8-char session IDs that navigate to session detail
- **Detail preview**: 2-line clamp for long detail text
- **Removed DataTable**: No longer needs TanStack Table overhead — uses simple div list
- **Entry count**: Shows filtered entry count in header

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] Audit entries show with correct icons per action type
- [ ] Session links navigate to session detail
- [ ] Search filtering works
- [ ] Action type dropdown filter works