### PR TITLE
feat(tui): per-tool rendering dispatch — specialized display per tool type

### DIFF
--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -421,8 +421,11 @@ impl ToolCell {
         // don't already embed output in their content lines.
         if let Some(output) = &self.output {
             let category = tool_category(&self.tool_name);
-            let already_shows_output =
-                matches!(category, ToolCategory::FileWrite | ToolCategory::Search);
+            // FileWrite already renders diffs inline; Search shows result count.
+            // Only skip verbose output when content_lines actually showed it.
+            let already_shows_output = matches!(category, ToolCategory::Search)
+                || (matches!(category, ToolCategory::FileWrite)
+                    && diff::is_unified_diff(output));
             if !already_shows_output {
                 if diff::is_unified_diff(output) {
                     // Render unified diff with colors, gutter, and line numbers.


### PR DESCRIPTION
## Summary

- Per-tool rendering dispatch: tools display specialized content based on category
- Shell tools show `$ command` with bold prompt, file tools show underlined paths, search tools show `/pattern/` with result count, web tools show URL in blue
- Verbose mode deduplication: tools that embed output in content skip redundant output section
- 14 new tests covering all categories, helpers, and edge cases

### Rendering by Category

| Category | Tools | Display |
|----------|-------|---------|
| Shell | shell_exec, docker_exec, ssh_exec | `$ ls -la` (bold red prompt) |
| FileRead | read_file, list_dir | `src/main.rs` (underlined, gray) |
| FileWrite | write_file, patch_file, git_* | `src/main.rs` (underlined, amber) + inline diff |
| Search | glob, grep, tree, find_tools | `/pattern/` (italic) + (N results) |
| Web | web_fetch, browse, browser_* | `https://...` (blue) |
| Default | everything else | `args: ...` (unchanged) |

### Files Changed

- `crates/genesis-tui/src/history/tool_cell.rs` — ToolCategory enum, tool_content_lines() dispatch, extract_path/extract_pattern/count_results helpers, 14 new tests

## Test Plan

- [x] `cargo test -p genesis-tui` — 324 tests pass
- [x] `cargo clippy -p genesis-tui -- -D warnings` — zero warnings
- [x] All existing tests still pass (no regressions)

Partially addresses #179 (Phase 2 per-tool dispatch done; Phase 3 collapsible groups deferred)