### PR TITLE
feat(web): tools page redesign — card-based registry with parameter schemas

### DIFF
--- a/web/src/routes/tools.lazy.tsx
+++ b/web/src/routes/tools.lazy.tsx
@@ -187,7 +187,10 @@ function ToolsPage() {
     })
   }, [filtered])
 
-  const allSources = Array.from(sourceCounts.keys()).sort()
+  const allSources = React.useMemo(
+    () => Array.from(sourceCounts.keys()).sort(),
+    [sourceCounts],
+  )
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- Replace flat DataTable with card-based layout matching the OS aesthetic of skills/memories/schedules pages
- Each tool rendered as a ToolCard with wrench icon, name, description, source badge, and param count
- Expandable parameter schema viewer showing types, required markers, enum values, and descriptions
- Source grouping with CPU (builtin) / Server (MCP) icons and visual divider lines
- Interactive filter chips replacing dropdown menu — toggle on/off with counts
- card-stagger animation, skeleton loading with grouped placeholders
- Removed unused DataTable, ColumnDef, DropdownMenu, Button dependencies (lighter bundle)

## Test plan
- [ ] Verify tools page loads and displays all registered tools
- [ ] Test search filtering works across tool names and descriptions
- [ ] Test source filter chips toggle correctly (All / builtin / MCP sources)
- [ ] Verify parameter schema expand/collapse works on tools with parameters
- [ ] Check card-stagger animation on page load
- [ ] Verify empty state shows when no tools match filters
- [ ] Build passes with no TypeScript errors