### PR TITLE
fix: harden Batch API client — header, timeout, polling, and error handling

### DIFF
--- a/crates/genesis-provider/src/batch.rs
+++ b/crates/genesis-provider/src/batch.rs
@@ -153,7 +153,7 @@ impl BatchClient {
         );
 
         if let Some(ref error_file) = status.error_file_id {
-            tracing::warn!(error_file_id = %error_file, "batch has error file — check OpenAI dashboard for details");
+            tracing::warn!(error_file_id = %error_file, "batch completed with errors — download error file for details");
         }
 
         // 5. Download and parse results
@@ -396,16 +396,20 @@ pub fn parse_batch_results(
         })?;
 
         // Extract index from custom_id "req-N"
-        let index = result_line
+        let index = match result_line
             .custom_id
             .strip_prefix("req-")
-            .and_then(|s| s.parse::<usize>().ok());
-
-        if index.is_none() {
-            tracing::warn!(custom_id = %result_line.custom_id, "unrecognized custom_id in batch result");
-        }
-
-        let index = index.unwrap_or(usize::MAX);
+            .and_then(|s| s.parse::<usize>().ok())
+        {
+            Some(idx) => idx,
+            None => {
+                tracing::warn!(
+                    custom_id = %result_line.custom_id,
+                    "unrecognized custom_id in batch result — result will be discarded"
+                );
+                continue;
+            }
+        };
 
         if let Some(err) = result_line.error {
             result_map.insert(


### PR DESCRIPTION
## Summary
Six hardening fixes for the Batch API client in genesis-provider.

### Changes
1. **Remove Content-Type default header** — the hardcoded `application/json` at the client level conflicts with multipart file uploads; `.json()` and `.multipart()` set it correctly per-request
2. **Add `connect_timeout(30s)`** — match ChatClient behavior; prevents indefinite hangs on DNS/TCP issues
3. **Reorder poll loop** — poll before sleep instead of sleep before poll; eliminates mandatory 5-second delay for instantly-completed batches
4. **Improve error body serialization** — `unwrap_or_default()` → diagnostic message on serialization failure
5. **Log unrecognized `custom_id`** — warn when batch results have IDs that don't match `req-N` format instead of silently dropping them
6. **Log `error_file_id`** — warn when batch has an error file; remove `#[allow(dead_code)]` on the now-used field

## Test plan
- [x] `cargo clippy -p genesis-provider -- -D warnings` passes
- [x] All 208 genesis-provider tests pass