### PR TITLE
fix: resolve clippy warnings and harden WhatsApp media handling

### DIFF
--- a/crates/genesis-cli/src/lib.rs
+++ b/crates/genesis-cli/src/lib.rs
@@ -15,8 +15,6 @@ use genesis_core::agent_loop::AgentError;
 use genesis_core::replay::load_and_report;
 use genesis_core::execution::SessionExecutionError;
 use genesis_core::run_doctor;
-use genesis_core::scheduler::{check_due_schedules, CronTime};
-use genesis_gateway::{build_router, AppState};
 use genesis_provider::ProviderError;
 use genesis_storage::{
     bootstrap, MemoryStore, ScheduleStore, SessionStore,
@@ -4678,7 +4676,7 @@ storage:
         std::fs::write(&right, serde_json::to_string_pretty(&right_trajectory).unwrap())
             .expect("write right");
 
-        let comparison = crate::commands::eval::compare_replay_reports(
+        let _comparison = crate::commands::eval::compare_replay_reports(
             left.to_str().unwrap(),
             right.to_str().unwrap(),
         )

--- a/crates/genesis-gateway/src/platforms/whatsapp.rs
+++ b/crates/genesis-gateway/src/platforms/whatsapp.rs
@@ -434,8 +434,11 @@ mod tests {
         assert_eq!(change.field, "messages");
         assert_eq!(change.value.messages[0].from, "15551234567");
         assert_eq!(
-            change.value.messages[0].text.as_ref().unwrap().body,
-            "Hello Eve"
+            change.value.messages[0]
+                .text
+                .as_ref()
+                .map(|t| t.body.as_str()),
+            Some("Hello Eve")
         );
         assert_eq!(change.value.contacts[0].profile.name, "Cole");
     }
@@ -474,6 +477,36 @@ mod tests {
         assert!(json.contains("\"messaging_product\":\"whatsapp\""));
         assert!(json.contains("\"to\":\"15551234567\""));
         assert!(json.contains("\"body\":\"Hello!\""));
+    }
+
+    #[test]
+    fn webhook_payload_handles_media_only_message() {
+        let json = r#"{
+            "object": "whatsapp_business_account",
+            "entry": [{
+                "id": "123",
+                "changes": [{
+                    "field": "messages",
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "contacts": [{
+                            "profile": {"name": "Cole"},
+                            "wa_id": "15551234567"
+                        }],
+                        "messages": [{
+                            "from": "15551234567",
+                            "id": "msg-2",
+                            "type": "image",
+                            "timestamp": "1709875200"
+                        }]
+                    }
+                }]
+            }]
+        }"#;
+        let payload: WebhookPayload = serde_json::from_str(json).expect("should parse");
+        let msg = &payload.entry[0].changes[0].value.messages[0];
+        assert_eq!(msg.msg_type, "image");
+        assert!(msg.text.is_none(), "media-only messages have no text field");
     }
 
     #[test]

--- a/crates/genesis-tools/src/builtins/mixture.rs
+++ b/crates/genesis-tools/src/builtins/mixture.rs
@@ -246,7 +246,7 @@ mod tests {
             .split(',')
             .filter_map(|s| {
                 let s = s.trim();
-                s.split_once('/').or_else(|| Some(("openai", s)))
+                s.split_once('/').or(Some(("openai", s)))
             })
             .take(MAX_MODELS)
             .collect();

--- a/crates/genesis-tools/src/cache.rs
+++ b/crates/genesis-tools/src/cache.rs
@@ -422,7 +422,7 @@ pub fn extract_tracked_path(
         "search_files" => arguments
             .get("path")
             .map(PathBuf::from)
-            .or_else(|| Some(PathBuf::from("."))),
+            .or(Some(PathBuf::from("."))),
         "glob" => {
             // Extract base directory from glob pattern.
             arguments.get("pattern").map(|pattern| {


### PR DESCRIPTION
## Summary
Fix all clippy warnings on main and harden WhatsApp webhook test safety.

### Changes
- **Remove unused imports** in `genesis-cli/src/lib.rs` — `build_router`, `AppState`, `check_due_schedules`, `CronTime` (used in serve.rs which has its own imports)
- **Fix WhatsApp test unwrap** — replace `.text.as_ref().unwrap()` with safe `.map()` pattern; add `webhook_payload_handles_media_only_message` test for image messages where `text` is None
- **Fix clippy `or_else` warnings** in `genesis-tools` — replace unnecessary lazy `or_else(|| Some(...))` with `or(Some(...))`  in mixture.rs and cache.rs
- **Fix unused variable** — rename `comparison` to `_comparison` in CLI test

Note: The production WhatsApp handler already handled `text: None` safely via a `match` with `_ => continue`.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] All 171 gateway tests pass
- [x] All 217 CLI tests pass
- [x] New test covers media-only message deserialization