### PR TITLE
feat(web): settings redesign with working pairing UI

### DIFF
--- a/web/src/lib/api/mutations/pairing.ts
+++ b/web/src/lib/api/mutations/pairing.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { api } from '../client'
+
+export function useApprovePairing() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { platform: string; code: string }) =>
+      api.post<void>('/pairing/approve', params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pairing'] })
+    },
+  })
+}
+
+export function useRevokePairing() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: { platform: string; user_id: string }) =>
+      api.post<void>('/pairing/revoke', params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pairing'] })
+    },
+  })
+}
+
+export function useClearPending() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (platform?: string) =>
+      api.post<void>('/pairing/clear-pending', platform ? { platform } : {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pairing'] })
+    },
+  })
+}

--- a/web/src/lib/api/queries/pairing.ts
+++ b/web/src/lib/api/queries/pairing.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../client'
+import type { ApprovedListResponse, PendingListResponse } from '../types'
+
+export function useApprovedUsers() {
+  return useQuery({
+    queryKey: ['pairing', 'approved'],
+    queryFn: () => api.get<ApprovedListResponse>('/pairing/approved'),
+    refetchInterval: 30_000,
+  })
+}
+
+export function usePendingPairings() {
+  return useQuery({
+    queryKey: ['pairing', 'pending'],
+    queryFn: () => api.get<PendingListResponse>('/pairing/pending'),
+    refetchInterval: 10_000,
+  })
+}

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -131,6 +131,31 @@ export interface AuditEntry {
   created_at: string
 }
 
+export interface ApprovedUser {
+  platform: string
+  user_id: string
+  user_name: string
+  approved_at: string
+}
+
+export interface PendingPairing {
+  platform: string
+  code: string
+  user_id: string
+  user_name: string
+  created_at: string
+}
+
+export interface ApprovedListResponse {
+  approved: ApprovedUser[]
+  count: number
+}
+
+export interface PendingListResponse {
+  pending: PendingPairing[]
+  count: number
+}
+
 export interface ToolParameter {
   type: string
   description?: string

--- a/web/src/routes/settings.lazy.tsx
+++ b/web/src/routes/settings.lazy.tsx
@@ -1,25 +1,36 @@
 import * as React from 'react'
 import { createLazyFileRoute } from '@tanstack/react-router'
-import { EyeIcon, EyeOffIcon, CheckIcon, Trash2Icon } from 'lucide-react'
+import {
+  EyeIcon, EyeOffIcon, CheckIcon, Trash2Icon,
+  ShieldCheckIcon, ShieldAlertIcon, XIcon,
+} from 'lucide-react'
+import { toast } from 'sonner'
 import { useMcpStatus } from '@/lib/api/queries/health'
+import { useApprovedUsers, usePendingPairings } from '@/lib/api/queries/pairing'
+import { useApprovePairing, useRevokePairing, useClearPending } from '@/lib/api/mutations/pairing'
 import { setApiKey, clearApiKey, hasApiKey } from '@/lib/api/client'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Skeleton } from '@/components/ui/skeleton'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
+import { formatRelativeTime } from '@/lib/utils'
+import { getPlatformColor } from '@/lib/platforms'
+import type { ApprovedUser, PendingPairing } from '@/lib/api/types'
 
 export const Route = createLazyFileRoute('/settings')({
   component: SettingsPage,
 })
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/50">
+        {title}
+      </span>
+      <div className="h-px flex-1 bg-border/20" />
+    </div>
+  )
+}
 
 // --- API Key section ---
 
@@ -46,63 +57,52 @@ function ApiKeySection() {
   }
 
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-          API Key
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="flex flex-col gap-4 pb-4">
-        <p className="font-mono text-xs text-muted-foreground">
-          Set a Bearer token for authenticated requests to the Genesis gateway.
-          Stored in <code className="text-foreground">localStorage</code>.
-        </p>
+    <div className="rounded-md border border-border/20 bg-card/20 p-3">
+      <div className="mb-2 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/40">
+        API Key
+      </div>
+      <p className="mb-3 font-mono text-[10px] text-muted-foreground/40">
+        Bearer token for authenticated gateway requests. Stored in{' '}
+        <code className="text-foreground/50">localStorage</code>.
+      </p>
 
-        {hasKey && (
-          <div className="flex items-center gap-2 rounded-md border border-border bg-muted px-3 py-2">
-            <CheckIcon className="size-3 text-green-500" />
-            <span className="font-mono text-xs text-muted-foreground">API key is configured</span>
-            <Button
-              variant="ghost"
-              size="xs"
-              className="ml-auto font-mono text-xs text-destructive hover:text-destructive"
-              onClick={handleClear}
-            >
-              <Trash2Icon className="size-3" />
-              Clear
-            </Button>
-          </div>
-        )}
-
-        <form onSubmit={handleSave} className="flex items-center gap-2">
-          <div className="relative flex-1">
-            <Input
-              type={showKey ? 'text' : 'password'}
-              value={keyInput}
-              onChange={(e) => setKeyInput(e.target.value)}
-              placeholder={hasKey ? 'Enter new key to replace…' : 'Paste your API key…'}
-              className="font-mono text-xs pr-10"
-            />
-            <button
-              type="button"
-              onClick={() => setShowKey((v) => !v)}
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              aria-label={showKey ? 'Hide key' : 'Show key'}
-            >
-              {showKey ? <EyeOffIcon className="size-3.5" /> : <EyeIcon className="size-3.5" />}
-            </button>
-          </div>
-          <Button
-            type="submit"
-            size="sm"
-            className="font-mono text-xs"
-            disabled={!keyInput.trim()}
+      {hasKey && (
+        <div className="mb-3 flex items-center gap-2 rounded border border-border/15 bg-muted/10 px-2.5 py-1.5">
+          <CheckIcon className="size-3 text-emerald-400" />
+          <span className="font-mono text-[10px] text-muted-foreground/50">Key configured</span>
+          <button
+            onClick={handleClear}
+            className="ml-auto flex items-center gap-1 font-mono text-[9px] text-destructive/60 transition-colors hover:text-destructive"
           >
-            {saved ? 'Saved!' : 'Save'}
-          </Button>
-        </form>
-      </CardContent>
-    </Card>
+            <Trash2Icon className="size-2.5" />
+            Clear
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            type={showKey ? 'text' : 'password'}
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            placeholder={hasKey ? 'Enter new key to replace…' : 'Paste your API key…'}
+            className="pr-8 font-mono text-[10px]"
+          />
+          <button
+            type="button"
+            onClick={() => setShowKey((v) => !v)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/30 hover:text-muted-foreground"
+            aria-label={showKey ? 'Hide key' : 'Show key'}
+          >
+            {showKey ? <EyeOffIcon className="size-3" /> : <EyeIcon className="size-3" />}
+          </button>
+        </div>
+        <Button type="submit" size="sm" className="h-7 px-3 font-mono text-[10px]" disabled={!keyInput.trim()}>
+          {saved ? 'Saved!' : 'Save'}
+        </Button>
+      </form>
+    </div>
   )
 }
 
@@ -112,78 +112,229 @@ function McpServersSection() {
   const { data: mcpStatus, isLoading } = useMcpStatus()
 
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
-          MCP Servers
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pb-4">
-        {isLoading ? (
-          <div className="flex flex-col gap-2">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-8 w-full rounded" />
-            ))}
+    <div className="rounded-md border border-border/20 bg-card/20 p-3">
+      <div className="mb-2 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/40">
+        MCP Servers
+      </div>
+      {isLoading ? (
+        <div className="flex flex-col gap-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-7 w-full rounded" />
+          ))}
+        </div>
+      ) : !mcpStatus || mcpStatus.servers.length === 0 ? (
+        <p className="font-mono text-[10px] text-muted-foreground/40">No MCP servers configured.</p>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          {mcpStatus.servers.map((server) => (
+            <div
+              key={server.name}
+              className="flex items-center justify-between rounded border border-border/10 px-2.5 py-1.5"
+            >
+              <span className="font-mono text-[10px] font-medium text-foreground/70">
+                {server.name}
+              </span>
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={`h-1.5 w-1.5 rounded-full ${
+                    server.connected ? 'bg-emerald-400' : 'bg-red-400'
+                  }`}
+                />
+                <span className="font-mono text-[8px] uppercase tracking-wider text-muted-foreground/30">
+                  {server.connected ? 'connected' : 'disconnected'}
+                </span>
+              </div>
+            </div>
+          ))}
+          <div className="mt-1 flex items-center gap-3 font-mono text-[8px] text-muted-foreground/25">
+            <span>{mcpStatus.total_tools} tools</span>
+            <span>{mcpStatus.total_resources} resources</span>
+            <span>{mcpStatus.total_prompts} prompts</span>
           </div>
-        ) : !mcpStatus || mcpStatus.servers.length === 0 ? (
-          <p className="font-mono text-xs text-muted-foreground">No MCP servers configured.</p>
-        ) : (
-          <div className="rounded-md border border-border">
-            <Table>
-              <TableHeader>
-                <TableRow className="hover:bg-transparent">
-                  <TableHead className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                    Name
-                  </TableHead>
-                  <TableHead className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-                    Status
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {mcpStatus.servers.map((server) => (
-                  <TableRow key={server.name} className="hover:bg-accent">
-                    <TableCell className="font-mono text-xs font-medium">
-                      {server.name}
-                    </TableCell>
-                    <TableCell>
-                      <Badge
-                        variant={server.connected ? 'secondary' : 'destructive'}
-                        className="font-mono text-[10px]"
-                      >
-                        {server.connected ? 'connected' : 'disconnected'}
-                      </Badge>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+        </div>
+      )}
+    </div>
   )
 }
 
-// --- Pairing section (placeholder — no hooks yet) ---
+// --- Pairing section ---
+
+function ApprovedUserRow({
+  user,
+  onRevoke,
+  isPending,
+}: {
+  user: ApprovedUser
+  onRevoke: () => void
+  isPending: boolean
+}) {
+  const color = getPlatformColor(user.platform)
+
+  return (
+    <div className="group flex items-center gap-2 rounded border border-border/10 px-2.5 py-1.5">
+      <ShieldCheckIcon className="h-3 w-3 shrink-0 text-emerald-400/60" />
+      <span
+        className="font-mono text-[8px] uppercase tracking-wider"
+        style={{ color }}
+      >
+        {user.platform}
+      </span>
+      <span className="font-mono text-[10px] text-foreground/70">
+        {user.user_name || user.user_id}
+      </span>
+      <span className="ml-auto font-mono text-[8px] tabular-nums text-muted-foreground/25">
+        {formatRelativeTime(user.approved_at)}
+      </span>
+      <button
+        onClick={onRevoke}
+        disabled={isPending}
+        className="flex h-4 w-4 items-center justify-center rounded text-muted-foreground/20 opacity-0 transition-all hover:text-destructive group-hover:opacity-100"
+        title="Revoke"
+      >
+        <XIcon className="h-2.5 w-2.5" />
+      </button>
+    </div>
+  )
+}
+
+function PendingPairingRow({
+  pairing,
+  onApprove,
+  isPending,
+}: {
+  pairing: PendingPairing
+  onApprove: () => void
+  isPending: boolean
+}) {
+  const color = getPlatformColor(pairing.platform)
+
+  return (
+    <div className="flex items-center gap-2 rounded border border-amber-400/10 bg-amber-400/5 px-2.5 py-1.5">
+      <ShieldAlertIcon className="h-3 w-3 shrink-0 text-amber-400/60" />
+      <span
+        className="font-mono text-[8px] uppercase tracking-wider"
+        style={{ color }}
+      >
+        {pairing.platform}
+      </span>
+      <span className="font-mono text-[10px] text-foreground/70">
+        {pairing.user_name || pairing.user_id}
+      </span>
+      <Badge variant="outline" className="font-mono text-[8px] tabular-nums">
+        {pairing.code}
+      </Badge>
+      <span className="ml-auto font-mono text-[8px] tabular-nums text-muted-foreground/25">
+        {formatRelativeTime(pairing.created_at)}
+      </span>
+      <Button
+        size="sm"
+        className="h-5 px-2 font-mono text-[8px]"
+        onClick={onApprove}
+        disabled={isPending}
+      >
+        Approve
+      </Button>
+    </div>
+  )
+}
 
 function PairingSection() {
+  const { data: approvedData, isLoading: loadingApproved } = useApprovedUsers()
+  const { data: pendingData, isLoading: loadingPending } = usePendingPairings()
+  const approveMut = useApprovePairing()
+  const revokeMut = useRevokePairing()
+  const clearMut = useClearPending()
+
+  const approved = approvedData?.approved ?? []
+  const pending = pendingData?.pending ?? []
+  const isLoading = loadingApproved || loadingPending
+
   return (
-    <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="font-mono text-xs uppercase tracking-wider text-muted-foreground">
+    <div className="rounded-md border border-border/20 bg-card/20 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground/40">
           Platform Pairing
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="pb-4">
-        <p className="font-mono text-xs text-muted-foreground">
-          Pairing management is available via the gateway API at{' '}
-          <code className="text-foreground">/api/pairing/approved</code> and{' '}
-          <code className="text-foreground">/api/pairing/pending</code>.
-          UI controls coming soon.
+        </div>
+        {pending.length > 0 && (
+          <button
+            onClick={() => {
+              clearMut.mutate(undefined, {
+                onSuccess: () => toast.success('Pending codes cleared'),
+                onError: (err: Error) => toast.error(`Failed: ${err.message}`),
+              })
+            }}
+            disabled={clearMut.isPending}
+            className="font-mono text-[8px] text-muted-foreground/30 transition-colors hover:text-muted-foreground"
+          >
+            Clear pending
+          </button>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col gap-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-7 w-full rounded" />
+          ))}
+        </div>
+      ) : approved.length === 0 && pending.length === 0 ? (
+        <p className="font-mono text-[10px] text-muted-foreground/40">
+          No paired users. Send a message on a platform to start pairing.
         </p>
-      </CardContent>
-    </Card>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {/* Pending approvals */}
+          {pending.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <span className="font-mono text-[8px] uppercase tracking-widest text-amber-400/50">
+                Pending ({pending.length})
+              </span>
+              {pending.map((p) => (
+                <PendingPairingRow
+                  key={`${p.platform}:${p.code}`}
+                  pairing={p}
+                  onApprove={() => {
+                    approveMut.mutate(
+                      { platform: p.platform, code: p.code },
+                      {
+                        onSuccess: () => toast.success(`Approved ${p.user_name || p.user_id}`),
+                        onError: (err: Error) => toast.error(`Failed: ${err.message}`),
+                      },
+                    )
+                  }}
+                  isPending={approveMut.isPending}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Approved users */}
+          {approved.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <span className="font-mono text-[8px] uppercase tracking-widest text-emerald-400/50">
+                Approved ({approved.length})
+              </span>
+              {approved.map((u) => (
+                <ApprovedUserRow
+                  key={`${u.platform}:${u.user_id}`}
+                  user={u}
+                  onRevoke={() => {
+                    revokeMut.mutate(
+                      { platform: u.platform, user_id: u.user_id },
+                      {
+                        onSuccess: () => toast.success(`Revoked ${u.user_name || u.user_id}`),
+                        onError: (err: Error) => toast.error(`Failed: ${err.message}`),
+                      },
+                    )
+                  }}
+                  isPending={revokeMut.isPending}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -191,13 +342,18 @@ function PairingSection() {
 
 function SettingsPage() {
   return (
-    <div className="flex flex-col gap-6">
+    <div className="flex flex-col gap-5">
       <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
         Settings
       </h1>
 
+      <SectionHeader title="Authentication" />
       <ApiKeySection />
+
+      <SectionHeader title="Infrastructure" />
       <McpServersSection />
+
+      <SectionHeader title="Access Control" />
       <PairingSection />
     </div>
   )


### PR DESCRIPTION
## Summary
- **Working pairing UI** replacing placeholder — approve/revoke users, clear pending codes
- ApprovedUserRow: platform-colored labels, shield icon, hover-reveal revoke button
- PendingPairingRow: amber warning style with pairing code badge and approve action
- Three new mutation hooks: `useApprovePairing`, `useRevokePairing`, `useClearPending`
- Two new query hooks: `useApprovedUsers` (30s refresh), `usePendingPairings` (10s refresh)
- New types: `ApprovedUser`, `PendingPairing`, response wrappers
- **OS-style treatment**: replaced Card/Table wrappers with `border/bg-card` sections
- Section headers with hairline dividers (Authentication, Infrastructure, Access Control)
- MCP servers: dot status indicators + tool/resource/prompt counts
- Main bundle reduced by ~3.4 KB (removed Card/Table imports)

## Test plan
- [ ] Verify settings page loads with all three sections
- [ ] Test API key save/clear flow still works
- [ ] Confirm MCP servers show with dot status indicators
- [ ] Verify pairing section shows "No paired users" when empty
- [ ] Test approve/revoke actions work with toast notifications
- [ ] Verify platform colors render correctly on pairing rows
- [ ] Build passes with no errors