### PR TITLE
feat(web): command palette actions + fix duplicate nav shortcut

### DIFF
--- a/web/src/components/layout/command-palette.tsx
+++ b/web/src/components/layout/command-palette.tsx
@@ -1,5 +1,11 @@
 import { useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import { navRoutes } from '@/lib/nav'
+import { api } from '@/lib/api/client'
+import {
+  PlusIcon, Trash2Icon, RefreshCwIcon, DownloadIcon,
+} from 'lucide-react'
 import {
   CommandDialog,
   Command,
@@ -8,6 +14,7 @@ import {
   CommandEmpty,
   CommandGroup,
   CommandItem,
+  CommandSeparator,
 } from '@/components/ui/command'
 
 interface CommandPaletteProps {
@@ -15,15 +22,92 @@ interface CommandPaletteProps {
   onOpenChange: (open: boolean) => void
 }
 
+interface ActionCommand {
+  label: string
+  keywords: string
+  icon: typeof PlusIcon
+  action: (ctx: { navigate: ReturnType<typeof useNavigate>; queryClient: ReturnType<typeof useQueryClient>; close: () => void }) => void
+}
+
+const actions: ActionCommand[] = [
+  {
+    label: 'New Skill',
+    keywords: 'create add skill',
+    icon: PlusIcon,
+    action: ({ navigate, close }) => {
+      navigate({ to: '/skills' })
+      close()
+      // The skills page has its own "New" button — navigate there
+    },
+  },
+  {
+    label: 'New Schedule',
+    keywords: 'create add schedule cron job',
+    icon: PlusIcon,
+    action: ({ navigate, close }) => {
+      navigate({ to: '/schedules' })
+      close()
+    },
+  },
+  {
+    label: 'Purge Old Sessions',
+    keywords: 'delete clean sessions purge',
+    icon: Trash2Icon,
+    action: async ({ queryClient, close }) => {
+      close()
+      try {
+        await api.delete<void>('/sessions/purge?older_than_days=30')
+        queryClient.invalidateQueries({ queryKey: ['sessions'] })
+        toast.success('Purged sessions older than 30 days')
+      } catch (err) {
+        toast.error(`Purge failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      }
+    },
+  },
+  {
+    label: 'Refresh All Data',
+    keywords: 'reload refetch invalidate cache',
+    icon: RefreshCwIcon,
+    action: ({ queryClient, close }) => {
+      queryClient.invalidateQueries()
+      toast.success('Refreshing all data')
+      close()
+    },
+  },
+  {
+    label: 'Export Health Report',
+    keywords: 'download health status json',
+    icon: DownloadIcon,
+    action: async ({ close }) => {
+      close()
+      try {
+        const health = await api.get<Record<string, unknown>>('/health')
+        const blob = new Blob([JSON.stringify(health, null, 2)], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `genesis-health-${new Date().toISOString().slice(0, 10)}.json`
+        a.click()
+        URL.revokeObjectURL(url)
+        toast.success('Health report downloaded')
+      } catch (err) {
+        toast.error(`Export failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      }
+    },
+  },
+]
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
-  // Cmd+K shortcut is handled centrally by useKeyboardNav in __root.tsx
+  const close = () => onOpenChange(false)
+  const ctx = { navigate, queryClient, close }
 
   return (
     <CommandDialog open={open} onOpenChange={onOpenChange}>
       <Command className="border-none bg-[#0d0d0d]">
-        <CommandInput placeholder="Navigate to..." className="font-mono text-xs" />
+        <CommandInput placeholder="Search commands..." className="font-mono text-xs" />
         <CommandList>
           <CommandEmpty className="font-mono text-xs text-muted-foreground">
             No results found.
@@ -35,7 +119,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 value={`${label} ${keywords}`}
                 onSelect={() => {
                   navigate({ to })
-                  onOpenChange(false)
+                  close()
                 }}
                 className="gap-3 py-2"
               >
@@ -51,6 +135,20 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                     {to}
                   </span>
                 </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Actions">
+            {actions.map((cmd) => (
+              <CommandItem
+                key={cmd.label}
+                value={`${cmd.label} ${cmd.keywords}`}
+                onSelect={() => cmd.action(ctx)}
+                className="gap-3 py-2"
+              >
+                <cmd.icon className="h-4 w-4 text-muted-foreground" />
+                <span className="font-mono text-xs">{cmd.label}</span>
               </CommandItem>
             ))}
           </CommandGroup>

--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -23,6 +23,6 @@ export const navRoutes: NavRoute[] = [
   { to: '/schedules', label: 'Schedules', icon: Clock, keywords: 'cron timer jobs automation', shortcut: '7' },
   { to: '/tools', label: 'Tools', icon: Wrench, keywords: 'functions registry mcp', shortcut: '8' },
   { to: '/analytics', label: 'Analytics', icon: BarChart3, keywords: 'stats usage tokens charts', shortcut: '9' },
-  { to: '/audit', label: 'Audit Log', icon: FileText, keywords: 'history actions log events', shortcut: '9' },
+  { to: '/audit', label: 'Event Stream', icon: FileText, keywords: 'history actions log events audit' },
   { to: '/settings', label: 'Settings', icon: Settings, keywords: 'config preferences', shortcut: '0' },
 ]


### PR DESCRIPTION
## Summary
- **Command palette actions**: 5 new action commands accessible via Cmd+K
  - New Skill / New Schedule: navigate to respective pages
  - Purge Old Sessions: calls DELETE /sessions/purge (>30 days)
  - Refresh All Data: invalidates all React Query caches
  - Export Health Report: downloads health endpoint as JSON file
- **Fix duplicate shortcut**: Analytics and Audit both had shortcut "9" — Audit (renamed "Event Stream") now has no shortcut
- CommandSeparator between Navigation and Actions groups
- Placeholder text updated from "Navigate to..." to "Search commands..."

## Test plan
- [ ] Open Cmd+K and verify Navigation section shows all routes
- [ ] Verify "Event Stream" has no shortcut key badge
- [ ] Search for "purge" and confirm Purge Old Sessions action appears
- [ ] Search for "refresh" and confirm Refresh All Data action appears
- [ ] Search for "export" and confirm Export Health Report action appears
- [ ] Execute Refresh All Data and verify toast notification
- [ ] Verify pressing "9" navigates to Analytics (not Audit)
- [ ] Build passes with no errors