### PR TITLE
feat(web): dashboard operations metrics — cache, webhooks, model readouts

### DIFF
--- a/web/src/lib/api/queries/health.ts
+++ b/web/src/lib/api/queries/health.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { api } from '../client'
-import type { HealthResponse, McpStatusResponse } from '../types'
+import type { HealthResponse, McpStatusResponse, CacheStatsResponse, WebhookStatusResponse } from '../types'
 
 export function useHealth() {
   return useQuery({
@@ -14,6 +14,22 @@ export function useMcpStatus() {
   return useQuery({
     queryKey: ['health', 'mcp'],
     queryFn: () => api.get<McpStatusResponse>('/health/mcp'),
+    refetchInterval: 30_000,
+  })
+}
+
+export function useCacheStats() {
+  return useQuery({
+    queryKey: ['cache', 'stats'],
+    queryFn: () => api.get<CacheStatsResponse>('/cache/stats'),
+    refetchInterval: 30_000,
+  })
+}
+
+export function useWebhookStatus() {
+  return useQuery({
+    queryKey: ['webhooks', 'status'],
+    queryFn: () => api.get<WebhookStatusResponse>('/webhooks/status'),
     refetchInterval: 30_000,
   })
 }

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -23,6 +23,20 @@ export interface McpStatusResponse {
   total_prompts: number
 }
 
+export interface CacheStatsResponse {
+  enabled: boolean
+  entries: number
+  total_hits: number
+}
+
+export interface WebhookStatusResponse {
+  configured: boolean
+  delivered: number
+  retried: number
+  failed: number
+  dead_letter_count: number
+}
+
 export interface MetricsJsonResponse {
   uptime_seconds: number
   requests_total: number

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useHealth } from '@/lib/api/queries/health'
+import { useHealth, useCacheStats, useWebhookStatus } from '@/lib/api/queries/health'
 import { useInsights } from '@/lib/api/queries/analytics'
 import { useSessions } from '@/lib/api/queries/sessions'
 import { HealthGauge } from '@/components/dashboard/health-gauge'
@@ -21,6 +21,8 @@ function DashboardPage() {
   const { data: health, isLoading: healthLoading } = useHealth()
   const { data: insights, isLoading: insightsLoading } = useInsights(7)
   const { data: sessions, isLoading: sessionsLoading } = useSessions({ limit: 10 })
+  const { data: cacheStats } = useCacheStats()
+  const { data: webhookStatus } = useWebhookStatus()
 
   // tokens_per_day is [date, input, output][] — extract totals for sparkline
   const tokensPerDayValues = insights
@@ -154,7 +156,56 @@ function DashboardPage() {
         </div>
       </div>
 
-      {/* Row 3: Activity feed + Platform breakdown + Recent sessions */}
+      {/* Row 3: Operations readouts */}
+      <SectionHeader title="Operations" />
+      <div className="card-stagger grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <div className="flex flex-col gap-1 rounded-md border border-border/20 bg-card/20 px-3 py-2">
+          <span className="font-mono text-[8px] uppercase tracking-widest text-muted-foreground/40">
+            Cache
+          </span>
+          <span className="font-mono text-sm font-bold tabular-nums text-foreground/90">
+            {cacheStats?.entries ?? 0}
+          </span>
+          <span className="font-mono text-[8px] text-muted-foreground/30">
+            {cacheStats?.total_hits ?? 0} hits · {cacheStats?.enabled ? 'on' : 'off'}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 rounded-md border border-border/20 bg-card/20 px-3 py-2">
+          <span className="font-mono text-[8px] uppercase tracking-widest text-muted-foreground/40">
+            Webhooks
+          </span>
+          <span className="font-mono text-sm font-bold tabular-nums text-foreground/90">
+            {webhookStatus?.delivered ?? 0}
+          </span>
+          <span className="font-mono text-[8px] text-muted-foreground/30">
+            delivered · {webhookStatus?.retried ?? 0} retried
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 rounded-md border border-border/20 bg-card/20 px-3 py-2">
+          <span className="font-mono text-[8px] uppercase tracking-widest text-muted-foreground/40">
+            Failures
+          </span>
+          <span className={`font-mono text-sm font-bold tabular-nums ${(webhookStatus?.failed ?? 0) > 0 ? 'text-destructive/80' : 'text-foreground/90'}`}>
+            {webhookStatus?.failed ?? 0}
+          </span>
+          <span className="font-mono text-[8px] text-muted-foreground/30">
+            {webhookStatus?.dead_letter_count ?? 0} dead letters
+          </span>
+        </div>
+        <div className="flex flex-col gap-1 rounded-md border border-border/20 bg-card/20 px-3 py-2">
+          <span className="font-mono text-[8px] uppercase tracking-widest text-muted-foreground/40">
+            Model
+          </span>
+          <span className="truncate font-mono text-sm font-bold text-foreground/90">
+            {health?.model ? health.model.split('/').pop() ?? health.model : '—'}
+          </span>
+          <span className="font-mono text-[8px] text-muted-foreground/30">
+            {health?.total_sessions ?? 0} total sessions
+          </span>
+        </div>
+      </div>
+
+      {/* Row 4: Activity feed + Platform breakdown + Recent sessions */}
       <SectionHeader title="Activity" />
       <div className="card-stagger grid grid-cols-1 gap-3 lg:grid-cols-3">
         <div className="rounded-md border border-border/20 bg-card/20 p-3">


### PR DESCRIPTION
## Summary
- **New operational metrics** on the dashboard surfacing previously unexposed backend endpoints
- Cache stats: entry count, hit count, enabled/disabled status (`/cache/stats`)
- Webhook metrics: delivered, retried, failed counts + dead letter count (`/webhooks/status`)
- Failure count highlighted in red when > 0 for immediate visibility
- Active model display: shows shortened model name + total session count
- New query hooks: `useCacheStats`, `useWebhookStatus` with 30s auto-refresh
- New types: `CacheStatsResponse`, `WebhookStatusResponse`
- "Operations" section with hairline divider between Throughput and Activity

## Test plan
- [ ] Dashboard loads with all 4 operations metric cells
- [ ] Cache stats show entry count and hit count
- [ ] Webhook stats show delivered/retried/failed counts
- [ ] Failed count appears in red when > 0
- [ ] Model name displays (shortened from full path if applicable)
- [ ] Auto-refresh works every 30s for new metrics
- [ ] Build passes with no errors