### PR TITLE
feat(web): DataTable pagination overhaul — page size selector + OS styling

### DIFF
--- a/web/src/components/shared/data-table.tsx
+++ b/web/src/components/shared/data-table.tsx
@@ -16,13 +16,15 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { Button } from '@/components/ui/button'
+
+const PAGE_SIZES = [25, 50, 100] as const
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
   onRowClick?: (row: TData) => void
   meta?: Record<string, unknown>
+  pageSize?: number
 }
 
 export function DataTable<TData, TValue>({
@@ -30,6 +32,7 @@ export function DataTable<TData, TValue>({
   data,
   onRowClick,
   meta,
+  pageSize = 25,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
 
@@ -41,21 +44,25 @@ export function DataTable<TData, TValue>({
     getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     state: { sorting },
-    initialState: { pagination: { pageSize: 10 } },
+    initialState: { pagination: { pageSize } },
     meta,
   })
 
+  const currentPage = table.getState().pagination.pageIndex + 1
+  const totalPages = table.getPageCount()
+  const currentPageSize = table.getState().pagination.pageSize
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="rounded-md border border-border">
+    <div className="flex flex-col gap-2">
+      <div className="rounded-md border border-border/30">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className="hover:bg-transparent">
+              <TableRow key={headerGroup.id} className="hover:bg-transparent border-border/20">
                 {headerGroup.headers.map((header) => (
                   <TableHead
                     key={header.id}
-                    className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground"
+                    className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground/50"
                     onClick={header.column.getCanSort() ? header.column.getToggleSortingHandler() : undefined}
                     style={{ cursor: header.column.getCanSort() ? 'pointer' : 'default' }}
                   >
@@ -75,10 +82,10 @@ export function DataTable<TData, TValue>({
                 <TableRow
                   key={row.id}
                   onClick={() => onRowClick?.(row.original)}
-                  className={onRowClick ? 'cursor-pointer hover:bg-accent' : 'hover:bg-accent'}
+                  className={`border-border/10 ${onRowClick ? 'cursor-pointer' : ''} hover:bg-card/40`}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="font-mono text-xs">
+                    <TableCell key={cell.id} className="py-2 font-mono text-xs">
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}
@@ -88,7 +95,7 @@ export function DataTable<TData, TValue>({
               <TableRow>
                 <TableCell
                   colSpan={columns.length}
-                  className="h-24 text-center font-mono text-xs text-muted-foreground"
+                  className="h-24 text-center font-mono text-[10px] text-muted-foreground/40"
                 >
                   No results.
                 </TableCell>
@@ -98,29 +105,65 @@ export function DataTable<TData, TValue>({
         </Table>
       </div>
 
-      {table.getPageCount() > 1 && (
-        <div className="flex items-center justify-between px-1">
-          <span className="font-mono text-[10px] text-muted-foreground">
-            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
-          </span>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              Previous
-            </Button>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              Next
-            </Button>
+      {(totalPages > 1 || data.length > PAGE_SIZES[0]) && (
+        <div className="flex items-center justify-between px-0.5">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-[9px] text-muted-foreground/30">
+              {data.length} total
+            </span>
+            <div className="flex items-center gap-1">
+              {PAGE_SIZES.map((size) => (
+                <button
+                  key={size}
+                  onClick={() => table.setPageSize(size)}
+                  className={`rounded px-1.5 py-0.5 font-mono text-[8px] transition-colors ${
+                    currentPageSize === size
+                      ? 'bg-primary/10 text-primary'
+                      : 'text-muted-foreground/30 hover:text-muted-foreground'
+                  }`}
+                >
+                  {size}
+                </button>
+              ))}
+            </div>
           </div>
+          {totalPages > 1 && (
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-[9px] tabular-nums text-muted-foreground/30">
+                {currentPage}/{totalPages}
+              </span>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={() => table.setPageIndex(0)}
+                  disabled={!table.getCanPreviousPage()}
+                  className="rounded px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/40 transition-colors hover:text-muted-foreground disabled:opacity-20"
+                >
+                  ««
+                </button>
+                <button
+                  onClick={() => table.previousPage()}
+                  disabled={!table.getCanPreviousPage()}
+                  className="rounded px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/40 transition-colors hover:text-muted-foreground disabled:opacity-20"
+                >
+                  «
+                </button>
+                <button
+                  onClick={() => table.nextPage()}
+                  disabled={!table.getCanNextPage()}
+                  className="rounded px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/40 transition-colors hover:text-muted-foreground disabled:opacity-20"
+                >
+                  »
+                </button>
+                <button
+                  onClick={() => table.setPageIndex(totalPages - 1)}
+                  disabled={!table.getCanNextPage()}
+                  className="rounded px-1.5 py-0.5 font-mono text-[9px] text-muted-foreground/40 transition-colors hover:text-muted-foreground disabled:opacity-20"
+                >
+                  »»
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Increase default page size from 10 to 25 — shows 2.5x more sessions without scrolling
- Add page size selector chips (25/50/100) matching the filter chip pattern used elsewhere
- Add first/last page navigation buttons (« »« »)
- Show total item count alongside page position
- Softer border styling (border/30, /20, /10) matching the OS aesthetic
- Tighter row padding and smaller header text
- Remove Button component dependency for pagination — use native buttons
- Accept configurable `pageSize` prop for per-page customization

## Test plan
- [ ] Sessions list shows 25 rows per page by default
- [ ] Page size selector switches between 25/50/100 correctly
- [ ] First/last page buttons navigate correctly
- [ ] Previous/next buttons are disabled at boundaries
- [ ] Sort indicators (↑↓) still work on column headers
- [ ] Row click navigation to session detail still works
- [ ] Total count and page info display correctly
- [ ] Build passes with no errors