### PR TITLE
fix(web): audit query response unwrap + system bar activity ticker

### DIFF
--- a/web/src/components/layout/system-bar.tsx
+++ b/web/src/components/layout/system-bar.tsx
@@ -1,6 +1,7 @@
 import { useHealth } from '@/lib/api/queries/health'
 import { useInsights } from '@/lib/api/queries/analytics'
-import { formatUptime, formatTokens, isHealthyStatus } from '@/lib/utils'
+import { useLatestAuditEvent } from '@/lib/api/queries/audit'
+import { formatUptime, formatTokens, isHealthyStatus, formatRelativeTime } from '@/lib/utils'
 import { useEffect, useMemo, useState } from 'react'
 
 function SystemClock() {
@@ -21,6 +22,7 @@ function SystemClock() {
 export function SystemBar() {
   const { data: health, isError } = useHealth()
   const { data: insights } = useInsights(7)
+  const { data: latestEvent } = useLatestAuditEvent()
 
   const totalTokens7d = useMemo(
     () => insights ? insights.tokens_per_day.reduce((sum, [, inp, out]) => sum + inp + out, 0) : 0,
@@ -75,8 +77,13 @@ export function SystemBar() {
         )}
       </div>
 
-      {/* Right: Clock */}
+      {/* Right: Latest event + status + clock */}
       <div className="flex items-center gap-3">
+        {latestEvent && (
+          <span className="max-w-[200px] truncate font-mono text-[9px] text-muted-foreground/25" title={`${latestEvent.action} — ${formatRelativeTime(latestEvent.created_at)}`}>
+            {latestEvent.action}
+          </span>
+        )}
         <span className="font-mono text-[10px] text-muted-foreground/40">
           {isError ? 'OFFLINE' : health ? 'ONLINE' : '...'}
         </span>

--- a/web/src/lib/api/queries/audit.ts
+++ b/web/src/lib/api/queries/audit.ts
@@ -11,6 +11,11 @@ interface AuditQueryOptions {
   refetchInterval?: number
 }
 
+interface AuditResponse {
+  entries: AuditEntry[]
+  count: number
+}
+
 export function useAuditLog(params?: AuditParams, options?: AuditQueryOptions) {
   const searchParams = new URLSearchParams()
   if (params?.limit !== undefined) searchParams.set('limit', String(params.limit))
@@ -19,7 +24,22 @@ export function useAuditLog(params?: AuditParams, options?: AuditQueryOptions) {
 
   return useQuery({
     queryKey: ['audit', params],
-    queryFn: () => api.get<AuditEntry[]>(`/audit${qs ? `?${qs}` : ''}`),
+    queryFn: async () => {
+      const res = await api.get<AuditResponse>(`/audit${qs ? `?${qs}` : ''}`)
+      return res.entries
+    },
     refetchInterval: options?.refetchInterval,
+  })
+}
+
+/** Fetch just the latest audit entry for the system bar ticker */
+export function useLatestAuditEvent() {
+  return useQuery({
+    queryKey: ['audit', 'latest'],
+    queryFn: async () => {
+      const res = await api.get<AuditResponse>('/audit?limit=1')
+      return res.entries[0] ?? null
+    },
+    refetchInterval: 10_000,
   })
 }


### PR DESCRIPTION
## Summary
- **Fix audit page data loading** — API returns `{ entries: [...], count: N }` but the query expected `AuditEntry[]` directly. Without this fix, the Event Stream page showed no entries because `.filter()` was called on a plain object.
- **System bar activity ticker** — shows the most recent audit event action in the right section of the status bar, polling every 10s. Truncated with tooltip for long action names. Makes the system bar feel alive with real-time activity.
- New `useLatestAuditEvent` hook fetches a single entry efficiently (`/audit?limit=1`)

## Test plan
- [ ] Event Stream page now loads and displays audit entries correctly
- [ ] Category filter chips work on the event stream page
- [ ] System bar shows latest audit event action text on the right
- [ ] Audit event tooltip shows full action + relative time on hover
- [ ] System bar ticker updates every 10 seconds
- [ ] Build passes with no errors