### PR TITLE
fix(web): unwrap session messages API response

### DIFF
--- a/web/src/lib/api/queries/sessions.ts
+++ b/web/src/lib/api/queries/sessions.ts
@@ -45,10 +45,19 @@ export function useSession(id: string) {
   })
 }
 
+interface MessagesResponse {
+  session_id: string
+  messages: StoredMessage[]
+  count: number
+}
+
 export function useMessages(sessionId: string) {
   return useQuery({
     queryKey: ['sessions', sessionId, 'messages'],
-    queryFn: () => api.get<StoredMessage[]>(`/sessions/${sessionId}/messages`),
+    queryFn: async () => {
+      const res = await api.get<MessagesResponse>(`/sessions/${sessionId}/messages`)
+      return res.messages
+    },
     enabled: Boolean(sessionId),
   })
 }


### PR DESCRIPTION
## Summary
Fix session detail page showing "No messages" for every session. The `/sessions/{id}/messages` endpoint returns `{ session_id, messages: [...], count }` but `useMessages` expected `StoredMessage[]` directly.

Same envelope pattern as #226 (audit) and #227 (memories, schedules, tools, skills).

## Test plan
- [ ] Navigate to a session detail page — messages now display in the timeline
- [ ] Verify tool calls, user messages, and assistant messages all render
- [ ] Verify date separators appear between messages on different days
- [ ] Build passes with no errors