### PR TITLE
feat(web): add auto-refresh to all data queries for live monitoring feel

### DIFF
--- a/web/src/lib/api/queries/analytics.ts
+++ b/web/src/lib/api/queries/analytics.ts
@@ -10,7 +10,7 @@ export function useInsights(days: number = 30, options?: InsightsOptions) {
   return useQuery({
     queryKey: ['insights', days],
     queryFn: () => api.get<InsightsData>(`/insights?days=${days}`),
-    refetchInterval: options?.refetchInterval,
+    refetchInterval: options?.refetchInterval ?? 60_000,
   })
 }
 
@@ -18,5 +18,6 @@ export function useUsage() {
   return useQuery({
     queryKey: ['usage'],
     queryFn: () => api.get<UsageStats>('/usage'),
+    refetchInterval: 60_000,
   })
 }

--- a/web/src/lib/api/queries/memories.ts
+++ b/web/src/lib/api/queries/memories.ts
@@ -28,6 +28,7 @@ export function useMemories(params?: MemoriesParams) {
       const res = await api.get<MemoriesResponse>(`/memories${qs ? `?${qs}` : ''}`)
       return res.memories
     },
+    refetchInterval: 60_000,
   })
 }
 

--- a/web/src/lib/api/queries/schedules.ts
+++ b/web/src/lib/api/queries/schedules.ts
@@ -14,5 +14,6 @@ export function useSchedules() {
       const res = await api.get<SchedulesResponse>('/schedules')
       return res.schedules
     },
+    refetchInterval: 30_000,
   })
 }

--- a/web/src/lib/api/queries/skills.ts
+++ b/web/src/lib/api/queries/skills.ts
@@ -20,6 +20,7 @@ export function useSkills() {
       const res = await api.get<SkillsResponse>('/skills')
       return res.skills
     },
+    refetchInterval: 60_000,
   })
 }
 

--- a/web/src/lib/api/queries/tools.ts
+++ b/web/src/lib/api/queries/tools.ts
@@ -20,5 +20,6 @@ export function useTools() {
       const mcp = (res.mcp_tools ?? []).map((t) => ({ ...t, source: t.source || 'mcp' }))
       return [...builtin, ...mcp] as ToolInfo[]
     },
+    refetchInterval: 60_000,
   })
 }

--- a/web/src/routes/audit.lazy.tsx
+++ b/web/src/routes/audit.lazy.tsx
@@ -100,7 +100,7 @@ function AuditRow({ entry, isLast }: { entry: AuditEntry; isLast: boolean }) {
 }
 
 function AuditPage() {
-  const { data: entries, isLoading } = useAuditLog({ limit: 200 })
+  const { data: entries, isLoading } = useAuditLog({ limit: 200 }, { refetchInterval: 15_000 })
   const [search, setSearch] = React.useState('')
   const [categoryFilter, setCategoryFilter] = React.useState<ActionCategory | null>(null)
 


### PR DESCRIPTION
## Summary
All data pages now refresh automatically for a live monitoring experience:
- Schedules: 30s | Audit: 15s | Analytics/Usage: 60s | Skills/Memories/Tools: 60s

Previously only sessions, health, pairing, and MCP had auto-refresh. The portal now feels alive across all pages.

## Test plan
- [ ] Event stream page auto-refreshes every 15s
- [ ] Schedules page picks up new schedule executions
- [ ] Analytics data refreshes when period stays open
- [ ] Build passes