### PR TITLE
feat(web): visual polish — fonts, noise texture, dock magnify, focus glow

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -11,6 +11,11 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Genesis" />
 
+    <!-- Fonts: preconnect + load -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+
     <!-- Icons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 

--- a/web/src/components/layout/dock.tsx
+++ b/web/src/components/layout/dock.tsx
@@ -7,6 +7,15 @@ interface DockProps {
   onCommandPalette: () => void
 }
 
+/** macOS-style proximity scale: hovered item scales 1.25, neighbors scale 1.1 */
+function getDockScale(hoveredIndex: number | null, itemIndex: number): string {
+  if (hoveredIndex === null) return 'scale(1)'
+  const dist = Math.abs(hoveredIndex - itemIndex)
+  if (dist === 0) return 'scale(1.25) translateY(-3px)'
+  if (dist === 1) return 'scale(1.1) translateY(-1px)'
+  return 'scale(1)'
+}
+
 export function Dock({ onCommandPalette }: DockProps) {
   const router = useRouterState()
   const currentPath = router.location.pathname
@@ -20,13 +29,12 @@ export function Dock({ onCommandPalette }: DockProps) {
       <div className="flex items-center gap-1 overflow-x-auto px-2 no-scrollbar">
         {navRoutes.map(({ to, label, icon: Icon }, index) => {
           const isActive = to === '/' ? currentPath === '/' : currentPath.startsWith(to)
-          const isHovered = hoveredIndex === index
 
           return (
             <div key={to} className="relative shrink-0">
-              {/* Tooltip */}
-              {isHovered && (
-                <div className="absolute -top-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-card px-2 py-0.5 font-mono text-[10px] text-foreground/80 shadow-lg ring-1 ring-border/50 pointer-events-none" role="tooltip">
+              {/* Tooltip — animated fade-in */}
+              {hoveredIndex === index && (
+                <div className="dock-tooltip absolute -top-8 left-1/2 whitespace-nowrap rounded bg-card px-2 py-0.5 font-mono text-[10px] text-foreground/80 shadow-lg ring-1 ring-border/50 pointer-events-none" role="tooltip">
                   {label}
                   {navRoutes[index].shortcut && (
                     <span className="ml-1.5 text-muted-foreground/40">{navRoutes[index].shortcut}</span>
@@ -38,22 +46,20 @@ export function Dock({ onCommandPalette }: DockProps) {
                 to={to}
                 aria-label={label}
                 aria-current={isActive ? 'page' : undefined}
-                className={`dock-item relative flex h-9 w-9 items-center justify-center rounded-lg transition-all duration-200 ${
+                className={`dock-item relative flex h-9 w-9 items-center justify-center rounded-lg ${
                   isActive
                     ? 'text-primary'
                     : 'text-muted-foreground/60 hover:text-foreground/80'
                 }`}
-                style={{
-                  transform: isHovered ? 'scale(1.2) translateY(-2px)' : 'scale(1)',
-                }}
+                style={{ transform: getDockScale(hoveredIndex, index) }}
                 onMouseEnter={() => setHoveredIndex(index)}
                 onMouseLeave={() => setHoveredIndex(null)}
               >
                 <Icon className="h-[18px] w-[18px]" strokeWidth={isActive ? 2 : 1.5} />
 
-                {/* Active indicator dot */}
+                {/* Active indicator dot with glow */}
                 {isActive && (
-                  <div className="absolute -bottom-1 left-1/2 h-[3px] w-[3px] -translate-x-1/2 rounded-full bg-primary shadow-[0_0_4px_rgba(8,145,178,0.6)]" />
+                  <div className="absolute -bottom-1 left-1/2 h-[3px] w-[3px] -translate-x-1/2 rounded-full bg-primary shadow-[0_0_6px_rgba(8,145,178,0.8)]" />
                 )}
               </Link>
             </div>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -158,6 +158,63 @@
   }
 }
 
+/* === Visual Polish === */
+
+/* Input focus glow — cyan ring matching primary */
+input:focus, textarea:focus, select:focus {
+  box-shadow: 0 0 0 1px var(--ring), 0 0 8px rgba(8, 145, 178, 0.15);
+}
+
+/* Subtle noise texture on background for depth */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 128px;
+  opacity: 0.015;
+  mix-blend-mode: overlay;
+}
+
+/* Tooltip fade-in */
+@keyframes tooltip-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+.dock-tooltip {
+  animation: tooltip-enter 120ms ease-out both;
+}
+
+/* Card hover lift */
+.hover-lift {
+  transition: border-color 200ms ease, transform 150ms ease, box-shadow 200ms ease;
+}
+
+.hover-lift:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+/* Glow on primary-colored elements */
+.glow-primary {
+  box-shadow: 0 0 12px rgba(8, 145, 178, 0.2);
+}
+
+/* Smooth number transitions for metrics */
+.tabular-transition {
+  transition: color 200ms ease;
+}
+
 /* === OS-like System UI === */
 
 /* Status indicator pulse */
@@ -237,12 +294,21 @@
 
 /* Accessibility: disable all motion for users who prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
-  .page-enter {
+  .page-enter,
+  .dock-tooltip {
     animation: none;
   }
 
   .card-stagger > * {
     animation: none;
+  }
+
+  .hover-lift:hover {
+    transform: none;
+  }
+
+  body::before {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
Comprehensive visual polish pass focused on making the UI feel premium and alive:

**Typography**
- Load Inter + JetBrains Mono from Google Fonts with preconnect + swap
- Ensures consistent monospace rendering across all environments

**Texture & Depth**
- Subtle fractal noise overlay at 1.5% opacity with mix-blend overlay
- Gives the background organic depth instead of flat black

**Focus States**
- Cyan glow ring on focused inputs/textareas/selects matching primary color

**Dock Enhancements**
- macOS-style proximity magnification: hovered item scales 1.25x, neighbors 1.1x
- Animated tooltip fade-in (120ms ease-out)
- Stronger active indicator glow

**Utility Classes**
- `.hover-lift`: translateY(-1px) + shadow on hover for interactive cards
- `.glow-primary`: cyan glow shadow for emphasis
- `.tabular-transition`: smooth color changes for updating numbers

All animations respect `prefers-reduced-motion`.

## Test plan
- [ ] Fonts load correctly (verify JetBrains Mono in monospace elements)
- [ ] Subtle noise texture visible on background (zoom in to see grain)
- [ ] Dock icons magnify on hover (1.25x hovered, 1.1x neighbors)
- [ ] Dock tooltips fade in smoothly
- [ ] Input focus shows cyan glow ring
- [ ] Noise overlay + hover-lift disabled with prefers-reduced-motion
- [ ] Build passes with no errors