### PR TITLE
feat(web): card hover lift + empty state redesign

### DIFF
--- a/web/src/components/shared/empty-state.tsx
+++ b/web/src/components/shared/empty-state.tsx
@@ -1,8 +1,22 @@
-export function EmptyState({ title, description }: { title: string; description?: string }) {
+import { InboxIcon } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+interface EmptyStateProps {
+  title: string
+  description?: string
+  icon?: LucideIcon
+}
+
+export function EmptyState({ title, description, icon: Icon = InboxIcon }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-center">
-      <p className="font-mono text-sm text-muted-foreground">{title}</p>
-      {description && <p className="mt-1 text-xs text-muted-foreground/60">{description}</p>}
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-muted/30 ring-1 ring-border/20">
+        <Icon className="h-4 w-4 text-muted-foreground/30" />
+      </div>
+      <p className="font-mono text-[11px] font-medium text-muted-foreground/60">{title}</p>
+      {description && (
+        <p className="mt-1 max-w-xs font-mono text-[10px] text-muted-foreground/30">{description}</p>
+      )}
     </div>
   )
 }

--- a/web/src/routes/memories.lazy.tsx
+++ b/web/src/routes/memories.lazy.tsx
@@ -22,7 +22,7 @@ function MemoryCard({ memory, onDelete }: { memory: Memory; onDelete: () => void
   const isLong = memory.content.length > 200
 
   return (
-    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-colors hover:border-border/50">
+    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-all duration-200 hover:border-border/50 hover:-translate-y-px hover:shadow-[0_2px_8px_rgba(0,0,0,0.25)]">
       {/* Header: source + time + actions */}
       <div className="mb-2 flex items-center gap-2">
         {memory.source && (

--- a/web/src/routes/schedules.lazy.tsx
+++ b/web/src/routes/schedules.lazy.tsx
@@ -64,9 +64,9 @@ function ScheduleCard({
   togglePending: boolean
 }) {
   return (
-    <div className={`group rounded-md border p-3 transition-colors ${
+    <div className={`group rounded-md border p-3 transition-all duration-200 ${
       schedule.enabled
-        ? 'border-border/40 bg-card/30'
+        ? 'border-border/40 bg-card/30 hover:border-border/50 hover:-translate-y-px hover:shadow-[0_2px_8px_rgba(0,0,0,0.25)]'
         : 'border-border/20 bg-card/10 opacity-60'
     }`}>
       {/* Header: ID + status + actions */}

--- a/web/src/routes/skills.lazy.tsx
+++ b/web/src/routes/skills.lazy.tsx
@@ -43,7 +43,7 @@ function SkillCard({
   const hasContent = skill.content && skill.content.length > 0
 
   return (
-    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-colors hover:border-border/50">
+    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-all duration-200 hover:border-border/50 hover:-translate-y-px hover:shadow-[0_2px_8px_rgba(0,0,0,0.25)]">
       {/* Header: name + tags + actions */}
       <div className="mb-1.5 flex items-start gap-2">
         <Brain className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/30" />

--- a/web/src/routes/tools.lazy.tsx
+++ b/web/src/routes/tools.lazy.tsx
@@ -59,7 +59,7 @@ function ToolCard({ tool }: { tool: ToolInfo }) {
   const isBuiltin = tool.source === 'builtin'
 
   return (
-    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-colors hover:border-border/50">
+    <div className="group rounded-md border border-border/30 bg-card/30 p-3 transition-all duration-200 hover:border-border/50 hover:-translate-y-px hover:shadow-[0_2px_8px_rgba(0,0,0,0.25)]">
       {/* Header: icon + name + source badge */}
       <div className="mb-1 flex items-start gap-2">
         <WrenchIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground/30" />


### PR DESCRIPTION
## Summary
- **Card hover lift** on tools, memories, skills, and schedules cards — subtle translateY(-1px) + shadow creates a tactile, physical feeling
- **Empty state redesign** — icon in a circular muted container, tighter text hierarchy, max-width description
- Enabled schedule cards lift on hover; disabled ones don't (intentional visual distinction)

## Test plan
- [ ] Hover over tool/memory/skill/schedule cards — verify subtle lift + shadow
- [ ] Verify disabled schedules don't have hover effect
- [ ] Check empty states show icon + styled text (filter to show 0 results)
- [ ] Build passes