### PR TITLE
feat(web): system bar glow + gradient branding + section divider fade

### DIFF
--- a/web/src/components/layout/system-bar.tsx
+++ b/web/src/components/layout/system-bar.tsx
@@ -13,7 +13,7 @@ function SystemClock() {
   }, [])
 
   return (
-    <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
+    <span className="font-mono text-[11px] tabular-nums text-foreground/60">
       {time.toLocaleTimeString('en-US', { hour12: false })}
     </span>
   )
@@ -32,7 +32,10 @@ export function SystemBar() {
   const isHealthy = isHealthyStatus(health?.status)
 
   return (
-    <header className="system-bar flex h-9 items-center justify-between border-b border-border/50 bg-[#0c0c0c] px-4">
+    <header className="system-bar relative flex h-9 items-center justify-between border-b border-border/30 bg-[#0a0a0a] px-4">
+      {/* Subtle bottom glow line */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-primary/20 to-transparent" />
+
       {/* Left: Branding + Connection */}
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
@@ -45,12 +48,12 @@ export function SystemBar() {
                   : 'bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.5)]'
             }`}
           />
-          <span className="font-mono text-[11px] font-semibold tracking-wider text-primary">
+          <span className="bg-gradient-to-r from-primary to-primary/60 bg-clip-text font-mono text-[11px] font-bold tracking-[0.2em] text-transparent">
             GENESIS
           </span>
         </div>
         {health && (
-          <span className="font-mono text-[10px] text-muted-foreground/60">
+          <span className="font-mono text-[9px] tabular-nums text-muted-foreground/40">
             v{health.version}
           </span>
         )}
@@ -80,13 +83,16 @@ export function SystemBar() {
       {/* Right: Latest event + status + clock */}
       <div className="flex items-center gap-3">
         {latestEvent && (
-          <span className="max-w-[200px] truncate font-mono text-[9px] text-muted-foreground/25" title={`${latestEvent.action} — ${formatRelativeTime(latestEvent.created_at)}`}>
+          <span className="max-w-[180px] truncate font-mono text-[8px] text-muted-foreground/20" title={`${latestEvent.action} — ${formatRelativeTime(latestEvent.created_at)}`}>
             {latestEvent.action}
           </span>
         )}
-        <span className="font-mono text-[10px] text-muted-foreground/40">
-          {isError ? 'OFFLINE' : health ? 'ONLINE' : '...'}
+        <span className={`font-mono text-[9px] font-medium tracking-wider ${
+          isError ? 'text-red-400' : health ? 'text-emerald-400/60' : 'text-muted-foreground/30'
+        }`}>
+          {isError ? 'OFFLINE' : health ? 'ONLINE' : '···'}
         </span>
+        <Divider />
         <SystemClock />
       </div>
     </header>
@@ -96,10 +102,10 @@ export function SystemBar() {
 function StatusChip({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-center gap-1.5 px-2">
-      <span className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground/50">
+      <span className="font-mono text-[8px] uppercase tracking-widest text-muted-foreground/30">
         {label}
       </span>
-      <span className="font-mono text-[11px] tabular-nums text-foreground/80">
+      <span className="font-mono text-[10px] tabular-nums text-foreground/70">
         {value}
       </span>
     </div>
@@ -107,5 +113,5 @@ function StatusChip({ label, value }: { label: string; value: string }) {
 }
 
 function Divider() {
-  return <div className="h-3 w-px bg-border/40" />
+  return <div className="h-3 w-px bg-border/20" />
 }

--- a/web/src/components/shared/section-header.tsx
+++ b/web/src/components/shared/section-header.tsx
@@ -4,7 +4,7 @@ export function SectionHeader({ title }: { title: string }) {
       <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground/50">
         {title}
       </span>
-      <div className="h-px flex-1 bg-border/20" />
+      <div className="section-divider h-px flex-1 opacity-20" />
     </div>
   )
 }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -160,6 +160,19 @@
 
 /* === Visual Polish === */
 
+/* Page title gradient — subtle fade from foreground to muted */
+.title-gradient {
+  background: linear-gradient(90deg, var(--foreground) 0%, var(--muted-foreground) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Section divider with gradient fade */
+.section-divider {
+  background: linear-gradient(90deg, var(--border) 0%, transparent 100%);
+}
+
 /* Flowing dash animation for topology connectors */
 @keyframes dash-flow {
   to { stroke-dashoffset: -12; }


### PR DESCRIPTION
## Summary
Premium visual refinements across the most persistent UI elements:

**System bar:**
- Gradient bottom glow line (primary color center fade) — gives the bar a floating, holographic edge
- GENESIS branding uses gradient text (primary → primary/60) with wider letter-spacing (0.2em)
- ONLINE/OFFLINE status with semantic colors (green/red) instead of generic gray
- Clock separated with divider for cleaner visual grouping
- Tighter status chip labels (8px/30% opacity)

**Section headers:**
- Divider line uses gradient fade from border to transparent instead of flat opacity — more refined

**CSS utilities:**
- `.title-gradient`: foreground → muted gradient for optional page headings
- `.section-divider`: gradient fade class for horizontal rules

## Test plan
- [ ] System bar shows gradient glow line at bottom
- [ ] GENESIS text has gradient from cyan to faded cyan
- [ ] ONLINE text is green, OFFLINE is red
- [ ] Section dividers fade from visible to transparent
- [ ] Build passes