### PR TITLE
feat(web): dock glass effect + shortcut help overlay polish

### DIFF
--- a/web/src/components/layout/dock.tsx
+++ b/web/src/components/layout/dock.tsx
@@ -23,9 +23,12 @@ export function Dock({ onCommandPalette }: DockProps) {
 
   return (
     <nav
-      className="dock relative flex h-[52px] items-center justify-center border-t border-border/40 bg-[#0c0c0c]/95 backdrop-blur-sm"
+      className="dock relative flex h-[52px] items-center justify-center border-t border-border/20 bg-[#0a0a0a]/90 backdrop-blur-md"
       aria-label="Main navigation"
     >
+      {/* Top glow line — mirrors system bar bottom glow */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/15 to-transparent" />
+
       <div className="flex items-center gap-1 overflow-x-auto px-2 no-scrollbar">
         {navRoutes.map(({ to, label, icon: Icon }, index) => {
           const isActive = to === '/' ? currentPath === '/' : currentPath.startsWith(to)
@@ -34,10 +37,12 @@ export function Dock({ onCommandPalette }: DockProps) {
             <div key={to} className="relative shrink-0">
               {/* Tooltip — animated fade-in */}
               {hoveredIndex === index && (
-                <div className="dock-tooltip absolute -top-8 left-1/2 whitespace-nowrap rounded bg-card px-2 py-0.5 font-mono text-[10px] text-foreground/80 shadow-lg ring-1 ring-border/50 pointer-events-none" role="tooltip">
+                <div className="dock-tooltip absolute -top-9 left-1/2 whitespace-nowrap rounded-md bg-[#0d0d0d] px-2.5 py-1 font-mono text-[10px] text-foreground/80 shadow-xl ring-1 ring-border/30 pointer-events-none" role="tooltip">
                   {label}
                   {navRoutes[index].shortcut && (
-                    <span className="ml-1.5 text-muted-foreground/40">{navRoutes[index].shortcut}</span>
+                    <kbd className="ml-2 inline-flex h-4 min-w-[14px] items-center justify-center rounded border border-border/30 bg-muted/20 px-1 font-mono text-[8px] text-muted-foreground/50">
+                      {navRoutes[index].shortcut}
+                    </kbd>
                   )}
                 </div>
               )}
@@ -49,7 +54,7 @@ export function Dock({ onCommandPalette }: DockProps) {
                 className={`dock-item relative flex h-9 w-9 items-center justify-center rounded-lg ${
                   isActive
                     ? 'text-primary'
-                    : 'text-muted-foreground/60 hover:text-foreground/80'
+                    : 'text-muted-foreground/50 hover:text-foreground/80'
                 }`}
                 style={{ transform: getDockScale(hoveredIndex, index) }}
                 onMouseEnter={() => setHoveredIndex(index)}
@@ -67,17 +72,17 @@ export function Dock({ onCommandPalette }: DockProps) {
         })}
 
         {/* Separator */}
-        <div className="mx-1.5 h-5 w-px shrink-0 bg-border/30" />
+        <div className="mx-1.5 h-5 w-px shrink-0 bg-border/20" />
 
         {/* Command palette trigger */}
         <button
           onClick={onCommandPalette}
-          className="dock-item flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-muted-foreground/40 transition-all duration-200 hover:text-foreground/60"
+          className="dock-item flex h-9 shrink-0 items-center gap-1.5 rounded-lg px-2.5 text-muted-foreground/30 transition-all duration-200 hover:text-foreground/60"
           aria-label="Open command palette"
           title="Command Palette (⌘K)"
         >
           <Command className="h-3.5 w-3.5" />
-          <span className="hidden font-mono text-[9px] tracking-wider sm:inline">⌘K</span>
+          <span className="hidden font-mono text-[8px] tracking-widest sm:inline">⌘K</span>
         </button>
       </div>
     </nav>

--- a/web/src/components/layout/shortcut-help.tsx
+++ b/web/src/components/layout/shortcut-help.tsx
@@ -10,25 +10,26 @@ export function ShortcutHelp({ open, onClose }: ShortcutHelpProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-md"
       onClick={onClose}
       role="dialog"
       aria-label="Keyboard shortcuts"
     >
       <div
-        className="w-full max-w-md rounded-lg border border-border/40 bg-[#0d0d0d] p-5 shadow-2xl"
+        className="page-enter w-full max-w-sm rounded-xl border border-border/30 bg-[#0b0b0b] p-6 shadow-2xl shadow-black/50"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="font-mono text-xs font-semibold uppercase tracking-widest text-foreground/80">
+        {/* Header with gradient line */}
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="bg-gradient-to-r from-foreground to-muted-foreground bg-clip-text font-mono text-[11px] font-bold uppercase tracking-[0.15em] text-transparent">
             Keyboard Shortcuts
           </h2>
-          <span className="font-mono text-[9px] text-muted-foreground/40">
-            Press ? to toggle
-          </span>
+          <kbd className="flex items-center gap-0.5 rounded border border-border/30 bg-muted/10 px-1.5 py-0.5 font-mono text-[8px] text-muted-foreground/40">
+            ? to toggle
+          </kbd>
         </div>
 
-        <div className="space-y-4">
+        <div className="space-y-5">
           {/* Navigation */}
           <Section title="Navigation">
             {navRoutes.filter(r => r.shortcut).map(r => (
@@ -39,7 +40,7 @@ export function ShortcutHelp({ open, onClose }: ShortcutHelpProps) {
           {/* Actions */}
           <Section title="Actions">
             <Row keys={['⌘', 'K']} label="Command palette" />
-            <Row keys={['K']} label="Command palette (no modifier)" />
+            <Row keys={['K']} label="Quick command (no modifier)" />
             <Row keys={['/']} label="Focus search" />
             <Row keys={['?']} label="This help" />
             <Row keys={['Esc']} label="Close overlay" />
@@ -53,23 +54,26 @@ export function ShortcutHelp({ open, onClose }: ShortcutHelpProps) {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <h3 className="mb-2 font-mono text-[9px] uppercase tracking-widest text-muted-foreground/40">
-        {title}
-      </h3>
-      <div className="space-y-1">{children}</div>
+      <div className="mb-2 flex items-center gap-2">
+        <h3 className="font-mono text-[8px] uppercase tracking-widest text-muted-foreground/30">
+          {title}
+        </h3>
+        <div className="section-divider h-px flex-1 opacity-15" />
+      </div>
+      <div className="space-y-0.5">{children}</div>
     </div>
   )
 }
 
 function Row({ keys, label }: { keys: string[]; label: string }) {
   return (
-    <div className="flex items-center justify-between py-0.5">
-      <span className="font-mono text-[11px] text-foreground/60">{label}</span>
+    <div className="flex items-center justify-between rounded px-1.5 py-1 transition-colors hover:bg-muted/10">
+      <span className="font-mono text-[10px] text-foreground/50">{label}</span>
       <div className="flex items-center gap-0.5">
         {keys.map((key, i) => (
           <kbd
             key={i}
-            className="flex h-5 min-w-[20px] items-center justify-center rounded border border-border/40 bg-muted/30 px-1.5 font-mono text-[9px] text-foreground/50"
+            className="flex h-5 min-w-[18px] items-center justify-center rounded border border-border/30 bg-muted/20 px-1.5 font-mono text-[8px] text-foreground/40"
           >
             {key}
           </kbd>


### PR DESCRIPTION
## Summary
**Dock:**
- Top glow line mirroring the system bar's bottom glow — creates symmetric framing
- Glass morphism with backdrop-blur-md
- Tooltips show shortcut as kbd badges instead of plain text
- Softer inactive icon opacity

**Shortcut help overlay:**
- Modal slides in with page-enter animation
- Gradient text header matching GENESIS branding
- Section headers use gradient divider lines
- Rows highlight on hover for interactive feel
- Deeper backdrop blur and stronger shadow

## Test plan
- [ ] Dock shows subtle cyan glow line at top
- [ ] Dock tooltips show kbd-styled shortcut badges
- [ ] Press ? to open shortcut help — verify slide-in animation
- [ ] Hover over shortcut rows — verify highlight
- [ ] Build passes