### PR TITLE
feat(web): shared PageHeader with icon + gradient text across all pages

### DIFF
--- a/web/src/components/shared/page-header.tsx
+++ b/web/src/components/shared/page-header.tsx
@@ -1,0 +1,31 @@
+import type { LucideIcon } from 'lucide-react'
+
+interface PageHeaderProps {
+  title: string
+  icon?: LucideIcon
+  count?: number | string
+  children?: React.ReactNode
+}
+
+export function PageHeader({ title, icon: Icon, count, children }: PageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center gap-3">
+        {Icon && (
+          <div className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/5 ring-1 ring-primary/10">
+            <Icon className="h-3 w-3 text-primary/60" />
+          </div>
+        )}
+        <h1 className="title-gradient font-mono text-sm font-semibold uppercase tracking-[0.15em]">
+          {title}
+        </h1>
+        {count != null && (
+          <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
+            {count}
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/web/src/routes/agents.lazy.tsx
+++ b/web/src/routes/agents.lazy.tsx
@@ -5,8 +5,9 @@ import { useInsights } from '@/lib/api/queries/analytics'
 import { Skeleton } from '@/components/ui/skeleton'
 import { formatUptime, isHealthyStatus } from '@/lib/utils'
 import { getPlatformColor } from '@/lib/platforms'
+import { PageHeader } from '@/components/shared/page-header'
 import {
-  Bot, Server, Clock, Cpu, Activity,
+  Bot, Server, Clock, Cpu, Activity, Network,
   MessageSquare, Globe,
 } from 'lucide-react'
 
@@ -124,9 +125,7 @@ function AgentsPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-        Agent Topology
-      </h1>
+      <PageHeader title="Agent Topology" icon={Network} />
 
       <div className="relative overflow-hidden rounded-lg border border-border/20 bg-[#0b0b0b] p-6">
         {/* Dot grid background */}

--- a/web/src/routes/analytics.lazy.tsx
+++ b/web/src/routes/analytics.lazy.tsx
@@ -15,6 +15,8 @@ import { Sparkline } from '@/components/dashboard/sparkline'
 import { Skeleton } from '@/components/ui/skeleton'
 import { getPlatformColor } from '@/lib/platforms'
 import { SectionHeader } from '@/components/shared/section-header'
+import { PageHeader } from '@/components/shared/page-header'
+import { BarChart3Icon } from 'lucide-react'
 
 export const Route = createLazyFileRoute('/analytics')({
   component: AnalyticsPage,
@@ -263,11 +265,7 @@ function AnalyticsPage() {
 
   return (
     <div className="flex flex-col gap-5">
-      {/* Header + period selector */}
-      <div className="flex items-center justify-between gap-3">
-        <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-          Analytics
-        </h1>
+      <PageHeader title="Analytics" icon={BarChart3Icon}>
         <div className="flex items-center gap-1">
           {PERIODS.map(({ label, value }) => (
             <button
@@ -283,7 +281,7 @@ function AnalyticsPage() {
             </button>
           ))}
         </div>
-      </div>
+      </PageHeader>
 
       {/* KPI metrics strip */}
       {insightsLoading || usageLoading ? (

--- a/web/src/routes/audit.lazy.tsx
+++ b/web/src/routes/audit.lazy.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { createLazyFileRoute, Link } from '@tanstack/react-router'
 import { useAuditLog } from '@/lib/api/queries/audit'
 import { EmptyState } from '@/components/shared/empty-state'
+import { PageHeader } from '@/components/shared/page-header'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { AuditEntry } from '@/lib/api/types'
@@ -135,25 +136,14 @@ function AuditPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Event Stream
-          </h1>
-          {!isLoading && (
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
-              {filtered.length}
-            </span>
-          )}
-        </div>
+      <PageHeader title="Event Stream" icon={Activity} count={isLoading ? undefined : filtered.length}>
         <Input
           placeholder="Search..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="w-48 font-mono text-[11px]"
         />
-      </div>
+      </PageHeader>
 
       {/* Category filter chips */}
       {!isLoading && activeCategories.length > 1 && (

--- a/web/src/routes/memories.lazy.tsx
+++ b/web/src/routes/memories.lazy.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import { useMemories, useSearchMemories } from '@/lib/api/queries/memories'
 import { useDeleteMemory, useEmbedAll } from '@/lib/api/mutations/memories'
 import { EmptyState } from '@/components/shared/empty-state'
+import { PageHeader } from '@/components/shared/page-header'
 import { ConfirmDeleteDialog } from '@/components/shared/confirm-delete-dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -122,18 +123,7 @@ function MemoriesPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Memories
-          </h1>
-          {!isLoading && (
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
-              {memories?.length ?? 0}
-            </span>
-          )}
-        </div>
+      <PageHeader title="Memories" icon={DatabaseIcon} count={isLoading ? undefined : (memories?.length ?? 0)}>
         <div className="flex items-center gap-2">
           <Input
             placeholder="Search..."
@@ -152,7 +142,7 @@ function MemoriesPage() {
             {embedAll.isPending ? 'Embedding...' : 'Embed All'}
           </Button>
         </div>
-      </div>
+      </PageHeader>
 
       {/* Source filter strip */}
       {!isLoading && sources.length > 1 && (

--- a/web/src/routes/schedules.lazy.tsx
+++ b/web/src/routes/schedules.lazy.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { PlusIcon, Trash2Icon, Clock, Play, Pause } from 'lucide-react'
+import { PageHeader } from '@/components/shared/page-header'
 import { toast } from 'sonner'
 import { useSchedules } from '@/lib/api/queries/schedules'
 import {
@@ -252,17 +253,7 @@ function SchedulesPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Schedules
-          </h1>
-          {!isLoading && (
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
-              {activeCount}/{totalCount} active
-            </span>
-          )}
-        </div>
+      <PageHeader title="Schedules" icon={Clock} count={isLoading ? undefined : `${activeCount}/${totalCount}`}>
         <Button
           size="sm"
           className="h-7 gap-1.5 px-2 font-mono text-[10px]"
@@ -271,7 +262,7 @@ function SchedulesPage() {
           <PlusIcon className="size-3" />
           New
         </Button>
-      </div>
+      </PageHeader>
 
       {isLoading ? (
         <div className="card-stagger grid grid-cols-1 gap-2 lg:grid-cols-2">

--- a/web/src/routes/sessions/index.lazy.tsx
+++ b/web/src/routes/sessions/index.lazy.tsx
@@ -6,9 +6,11 @@ import { DataTable } from '@/components/shared/data-table'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
+import { PageHeader } from '@/components/shared/page-header'
 import type { SessionSummary } from '@/lib/api/types'
 import { formatRelativeTime, formatTokens } from '@/lib/utils'
 import { getPlatformColor } from '@/lib/platforms'
+import { MessagesSquareIcon } from 'lucide-react'
 
 export const Route = createLazyFileRoute('/sessions/')({
   component: SessionsPage,
@@ -139,24 +141,14 @@ function SessionsPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Sessions
-          </h1>
-          {!isLoading && (
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
-              {totalCount}
-            </span>
-          )}
-        </div>
+      <PageHeader title="Sessions" icon={MessagesSquareIcon} count={isLoading ? undefined : totalCount}>
         <Input
           placeholder="Search..."
           value={inputValue}
           onChange={handleSearchChange}
           className="w-48 font-mono text-[11px]"
         />
-      </div>
+      </PageHeader>
 
       {isLoading ? (
         <div className="flex flex-col gap-1.5">

--- a/web/src/routes/settings.lazy.tsx
+++ b/web/src/routes/settings.lazy.tsx
@@ -16,6 +16,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { formatRelativeTime } from '@/lib/utils'
 import { getPlatformColor } from '@/lib/platforms'
 import { SectionHeader } from '@/components/shared/section-header'
+import { PageHeader } from '@/components/shared/page-header'
+import { Settings as SettingsIcon } from 'lucide-react'
 import type { ApprovedUser, PendingPairing } from '@/lib/api/types'
 
 export const Route = createLazyFileRoute('/settings')({
@@ -335,9 +337,7 @@ function PairingSection() {
 function SettingsPage() {
   return (
     <div className="flex flex-col gap-5">
-      <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-        Settings
-      </h1>
+      <PageHeader title="Settings" icon={SettingsIcon} />
 
       <SectionHeader title="Authentication" />
       <ApiKeySection />

--- a/web/src/routes/skills.lazy.tsx
+++ b/web/src/routes/skills.lazy.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import { useSkills } from '@/lib/api/queries/skills'
 import { useCreateSkill, useDeleteSkill } from '@/lib/api/mutations/skills'
 import { EmptyState } from '@/components/shared/empty-state'
+import { PageHeader } from '@/components/shared/page-header'
 import { ConfirmDeleteDialog } from '@/components/shared/confirm-delete-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -199,17 +200,7 @@ function SkillsPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Skills
-          </h1>
-          {!isLoading && (
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
-              {filtered.length}
-            </span>
-          )}
-        </div>
+      <PageHeader title="Skills" icon={Brain} count={isLoading ? undefined : filtered.length}>
         <div className="flex items-center gap-2">
           <Input
             placeholder="Search..."
@@ -240,7 +231,7 @@ function SkillsPage() {
             New
           </Button>
         </div>
-      </div>
+      </PageHeader>
 
       {isLoading ? (
         <div className="card-stagger grid grid-cols-1 gap-2 lg:grid-cols-2">

--- a/web/src/routes/tools.lazy.tsx
+++ b/web/src/routes/tools.lazy.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { createLazyFileRoute } from '@tanstack/react-router'
 import { useTools } from '@/lib/api/queries/tools'
 import { EmptyState } from '@/components/shared/empty-state'
+import { PageHeader } from '@/components/shared/page-header'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -194,25 +195,14 @@ function ToolsPage() {
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Header */}
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <h1 className="font-mono text-sm font-medium uppercase tracking-wider text-muted-foreground">
-            Tools Registry
-          </h1>
-          {!isLoading && (
-            <span className="font-mono text-[10px] tabular-nums text-muted-foreground/30">
-              {filtered.length}
-            </span>
-          )}
-        </div>
+      <PageHeader title="Tools Registry" icon={WrenchIcon} count={isLoading ? undefined : filtered.length}>
         <Input
           placeholder="Search..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="w-48 font-mono text-[11px]"
         />
-      </div>
+      </PageHeader>
 
       {/* Source filter chips */}
       {!isLoading && allSources.length > 1 && (


### PR DESCRIPTION
## Summary
Unified page headers across all 9 data pages with a shared `PageHeader` component featuring:

- **Icon badge**: Each page gets a matching Lucide icon in a primary-tinted container
- **Gradient title text**: Uses `.title-gradient` CSS for the foreground→muted fade effect
- **Consistent layout**: Icon + title + count on left, controls (search/buttons) on right
- **Net -28 lines**: Removes duplicated inline header markup across 9 files

Page icons: Tools=Wrench, Memories=Database, Skills=Brain, Schedules=Clock, Events=Activity, Analytics=BarChart3, Settings=Settings, Agents=Network, Sessions=MessagesSquare

## Test plan
- [ ] All 9 pages show icon + gradient title + count
- [ ] Search inputs and action buttons still work in header right slot
- [ ] Schedules shows "active/total" count format
- [ ] Build passes