### PR TITLE
feat(web): skeleton shimmer — scanning light effect replaces pulse

### DIFF
--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn("skeleton-shimmer rounded-md bg-muted/60", className)}
       {...props}
     />
   )

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -160,6 +160,25 @@
 
 /* === Visual Polish === */
 
+/* Skeleton shimmer — scanning light effect instead of plain pulse */
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.skeleton-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.03) 40%,
+    rgba(255, 255, 255, 0.06) 50%,
+    rgba(255, 255, 255, 0.03) 60%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s ease-in-out infinite;
+}
+
 /* Page title gradient — subtle fade from foreground to muted */
 .title-gradient {
   background: linear-gradient(90deg, var(--foreground) 0%, var(--muted-foreground) 100%);
@@ -329,7 +348,8 @@ body::before {
   .page-enter,
   .dock-tooltip,
   .connector-flow,
-  .node-pulse-primary {
+  .node-pulse-primary,
+  .skeleton-shimmer {
     animation: none;
   }
 


### PR DESCRIPTION
## Summary
Replace the default `animate-pulse` on all Skeleton loading states with a horizontal scanning shimmer effect:

- Gradient light sweep (transparent → white 6% → transparent) moves across at 2s intervals
- Softer base color (bg-muted/60) for subtlety against the dark background
- Respects `prefers-reduced-motion` (static fallback)
- Every loading state across all 12 pages benefits automatically

## Test plan
- [ ] Navigate to any page — skeleton shimmer visible during data load
- [ ] Shimmer moves horizontally left to right
- [ ] Verify with prefers-reduced-motion — should be static
- [ ] Build passes