### PR TITLE
feat(tui): insta snapshot testing for widget visual regression

### DIFF
--- a/crates/genesis-tui/Cargo.toml
+++ b/crates/genesis-tui/Cargo.toml
@@ -27,3 +27,4 @@ tachyonfx.workspace = true
 tui-big-text.workspace = true
 
 [dev-dependencies]
+insta.workspace = true

--- a/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_grouped_failed_tool.snap
+++ b/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_grouped_failed_tool.snap
@@ -1,0 +1,9 @@
+---
+source: crates/genesis-tui/src/history/tool_cell.rs
+expression: buffer_to_string(&buf)
+---
+  ┌─ shell_exec ─┐                                
+  │ $ rm -rf /tmp/test                            
+  │ 0.5s FAIL │                                   
+  │ permission denied │                           
+  └────────────┘

--- a/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_grouped_shell_tool.snap
+++ b/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_grouped_shell_tool.snap
@@ -1,0 +1,8 @@
+---
+source: crates/genesis-tui/src/history/tool_cell.rs
+expression: buffer_to_string(&buf)
+---
+  ┌─ shell_exec ─┐                                
+  │ $ ls -la                                      
+  │ 1.2s ok │                                     
+  └────────────┘

--- a/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_summary_tool.snap
+++ b/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_summary_tool.snap
@@ -1,0 +1,5 @@
+---
+source: crates/genesis-tui/src/history/tool_cell.rs
+expression: buffer_to_string(&buf)
+---
+  [read_file] 0.1s ok

--- a/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_verbose_tool_with_output.snap
+++ b/crates/genesis-tui/src/history/snapshots/genesis_tui__history__tool_cell__tests__snapshot_verbose_tool_with_output.snap
@@ -1,0 +1,9 @@
+---
+source: crates/genesis-tui/src/history/tool_cell.rs
+expression: buffer_to_string(&buf)
+---
+  ┌─ shell_exec ─┐                                
+  │ $ echo hello                                  
+  │ output: hello │                               
+  │ 0.1s ok │                                     
+  └────────────┘

--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -1245,4 +1245,81 @@ diff --git a/src/main.rs b/src/main.rs
             "search should show result count"
         );
     }
+
+    // ── Snapshot tests ────────────────────────────────────────────────
+
+    /// Render a buffer to a string for snapshot testing.
+    fn buffer_to_string(buf: &Buffer) -> String {
+        let area = buf.area();
+        let mut output = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                let cell = buf.cell((x, y)).unwrap();
+                output.push_str(cell.symbol());
+            }
+            output.push('\n');
+        }
+        output
+    }
+
+    #[test]
+    fn snapshot_grouped_shell_tool() {
+        let cell =
+            ToolCell::new("shell_exec", "call_1", "ls -la", true, Duration::from_millis(1200))
+                .with_display_mode(ToolDisplayMode::Grouped);
+        let area = Rect::new(0, 0, 50, 10);
+        let mut buf = Buffer::empty(area);
+        cell.render(area, &mut buf);
+        insta::assert_snapshot!(buffer_to_string(&buf));
+    }
+
+    #[test]
+    fn snapshot_summary_tool() {
+        let cell = ToolCell::new(
+            "read_file",
+            "call_1",
+            r#"path: "src/main.rs""#,
+            true,
+            Duration::from_millis(50),
+        )
+        .with_display_mode(ToolDisplayMode::Summary);
+        let area = Rect::new(0, 0, 60, 1);
+        let mut buf = Buffer::empty(area);
+        cell.render(area, &mut buf);
+        insta::assert_snapshot!(buffer_to_string(&buf));
+    }
+
+    #[test]
+    fn snapshot_grouped_failed_tool() {
+        let cell = ToolCell::new(
+            "shell_exec",
+            "call_1",
+            "rm -rf /tmp/test",
+            false,
+            Duration::from_millis(500),
+        )
+        .with_display_mode(ToolDisplayMode::Grouped)
+        .with_output("permission denied");
+        let area = Rect::new(0, 0, 50, 10);
+        let mut buf = Buffer::empty(area);
+        cell.render(area, &mut buf);
+        insta::assert_snapshot!(buffer_to_string(&buf));
+    }
+
+    #[test]
+    fn snapshot_verbose_tool_with_output() {
+        let cell = ToolCell::new(
+            "shell_exec",
+            "call_1",
+            "echo hello",
+            true,
+            Duration::from_millis(100),
+        )
+        .with_display_mode(ToolDisplayMode::Verbose)
+        .with_output("hello");
+        let area = Rect::new(0, 0, 50, 10);
+        let mut buf = Buffer::empty(area);
+        cell.render(area, &mut buf);
+        insta::assert_snapshot!(buffer_to_string(&buf));
+    }
 }

--- a/crates/genesis-tui/src/widgets/help_overlay.rs
+++ b/crates/genesis-tui/src/widgets/help_overlay.rs
@@ -346,4 +346,29 @@ mod tests {
         assert!(text.contains("Ctrl+C"), "should list Ctrl+C");
         assert!(text.contains("/help"), "should list /help command");
     }
+
+    // ── Snapshot tests ────────────────────────────────────────────────
+
+    /// Render a buffer to a string for snapshot testing.
+    fn buffer_to_string(buf: &Buffer) -> String {
+        let area = buf.area();
+        let mut output = String::new();
+        for y in area.y..area.y + area.height {
+            for x in area.x..area.x + area.width {
+                let cell = buf.cell((x, y)).unwrap();
+                output.push_str(cell.symbol());
+            }
+            output.push('\n');
+        }
+        output
+    }
+
+    #[test]
+    fn snapshot_help_overlay() {
+        let overlay = HelpOverlay::new();
+        let area = Rect::new(0, 0, 60, 30);
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+        insta::assert_snapshot!(buffer_to_string(&buf));
+    }
 }

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
@@ -1,0 +1,34 @@
+---
+source: crates/genesis-tui/src/widgets/help_overlay.rs
+expression: buffer_to_string(&buf)
+---
+ Help — j/k scroll, Ctrl+D/U page, g/G top/bottom, q to clos
+                                                            
+  ◆ Eve — Genesis TUI Help                                  
+                                                            
+  Keybindings                                               
+  ───────────                                               
+  Enter         Submit message                              
+  Ctrl+J        Insert newline (multi-line input)           
+  Ctrl+C        Interrupt running turn                      
+  Ctrl+D        Exit Eve                                    
+  Ctrl+P        Open command palette                        
+  Ctrl+K        Delete from cursor to end of line           
+  Ctrl+T        Toggle transcript overlay                   
+  Tab           Toggle Plan/Act mode                        
+  @             File path completion                        
+  Up/Down       Navigate input history / lines              
+  Home/End      Move cursor to start/end of line            
+  Ctrl+U        Delete from cursor to start of line         
+  Esc           Close overlay / dismiss popup               
+                                                            
+  Slash Commands                                            
+  ──────────────                                            
+  /clear        Clear conversation history                  
+  /compact      Compress context window                     
+  /exit         Exit Eve                                    
+  /help         Show this help screen                       
+  /plan         Toggle Plan/Act mode                        
+  /theme        Cycle through built-in themes               
+                                                            
+  Overlay Navigation

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_idle_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_idle_status_bar.snap
@@ -1,0 +1,5 @@
+---
+source: crates/genesis-tui/src/widgets/status_bar.rs
+expression: spans_text
+---
+◆ [Act] gpt-4o · 42%  ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_status_bar_with_tokens.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_status_bar_with_tokens.snap
@@ -1,0 +1,5 @@
+---
+source: crates/genesis-tui/src/widgets/status_bar.rs
+expression: spans_text
+---
+◆ [Act] gpt-4o · 42%  ↑5.0k ↓1.2k · ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_streaming_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_streaming_status_bar.snap
@@ -1,0 +1,5 @@
+---
+source: crates/genesis-tui/src/widgets/status_bar.rs
+expression: spans_text
+---
+◆ [Act] gpt-4o · 42%   streaming 256 tok   ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_thinking_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_thinking_status_bar.snap
@@ -1,0 +1,5 @@
+---
+source: crates/genesis-tui/src/widgets/status_bar.rs
+expression: spans_text
+---
+◆ [Act] gpt-4o · 42%   (~'.')~ thinking   ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_tool_running_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_tool_running_status_bar.snap
@@ -1,0 +1,5 @@
+---
+source: crates/genesis-tui/src/widgets/status_bar.rs
+expression: spans_text
+---
+◆ [Act] gpt-4o · 42%   shell_exec   ⎇ main

--- a/crates/genesis-tui/src/widgets/status_bar.rs
+++ b/crates/genesis-tui/src/widgets/status_bar.rs
@@ -715,6 +715,57 @@ mod tests {
         }
     }
 
+    // ── Snapshot tests ────────────────────────────────────────────────
+
+    #[test]
+    fn snapshot_idle_status_bar() {
+        let widget = make_widget();
+        let line = widget.to_line();
+        let spans_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        insta::assert_snapshot!(spans_text);
+    }
+
+    #[test]
+    fn snapshot_thinking_status_bar() {
+        let mut widget = make_widget();
+        widget.set_state(StatusState::Thinking);
+        let line = widget.to_line();
+        let spans_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        insta::assert_snapshot!(spans_text);
+    }
+
+    #[test]
+    fn snapshot_tool_running_status_bar() {
+        let mut widget = make_widget();
+        widget.set_state(StatusState::ToolRunning {
+            tool_name: "shell_exec".to_string(),
+        });
+        let line = widget.to_line();
+        let spans_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        insta::assert_snapshot!(spans_text);
+    }
+
+    #[test]
+    fn snapshot_streaming_status_bar() {
+        let mut widget = make_widget();
+        widget.set_state(StatusState::Streaming { tokens: 256 });
+        let line = widget.to_line();
+        let spans_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        insta::assert_snapshot!(spans_text);
+    }
+
+    #[test]
+    fn snapshot_status_bar_with_tokens() {
+        let mut widget = make_widget();
+        widget.tokens_in = 5000;
+        widget.tokens_out = 1200;
+        let line = widget.to_line();
+        let spans_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        insta::assert_snapshot!(spans_text);
+    }
+
+    // ── Non-snapshot tests ────────────────────────────────────────────
+
     #[test]
     fn idle_renders_without_sprite() {
         let widget = make_widget();


### PR DESCRIPTION
## Summary

- 10 snapshot tests for TUI widgets using insta
- Renders into ratatui Buffers, snapshots as text
- Covers ToolCell (4 modes), HelpOverlay, StatusBar (5 states)
- buffer_to_string() helper

## Test Plan

- [x] 425 tests pass (10 new snapshots)
- [x] Snapshot files committed

Partially addresses #144