### PR TITLE
feat(cli): genesis model browse — search and filter OpenRouter models

### DIFF
--- a/crates/genesis-cli/src/commands/misc.rs
+++ b/crates/genesis-cli/src/commands/misc.rs
@@ -1168,7 +1168,7 @@ pub(crate) fn run_context(command: ContextCommand) -> Result<String, CliError> {
     }
 }
 
-pub(crate) fn run_model(
+pub(crate) async fn run_model(
     config_path: Option<PathBuf>,
     command: ModelCommand,
     json: bool,
@@ -1276,6 +1276,119 @@ pub(crate) fn run_model(
                     config_file.display()
                 ))
             }
+        }
+        ModelCommand::Browse {
+            query,
+            tools,
+            vision,
+            reasoning,
+            sort,
+            limit,
+            json: json_output,
+        } => {
+            let loaded = load(config_path.as_deref())?;
+            let cache_dir = loaded.paths.data_dir.join("cache");
+            let _ = std::fs::create_dir_all(&cache_dir);
+
+            // Resolve API key for OpenRouter.
+            let api_key = std::env::var("OPENROUTER_API_KEY").ok();
+
+            // Fetch models.
+            let mut models = genesis_provider::openrouter_models::fetch_models(
+                api_key.as_deref(),
+                &cache_dir,
+            )
+            .await
+            .map_err(|e| CliError::Other(format!("Failed to fetch models: {e}")))?;
+
+            // Filter by query.
+            if let Some(ref q) = query {
+                let q_lower = q.to_lowercase();
+                models.retain(|m| {
+                    m.id.to_lowercase().contains(&q_lower)
+                        || m.name.to_lowercase().contains(&q_lower)
+                });
+            }
+
+            // Filter by capabilities.
+            if tools {
+                models.retain(|m| m.supports_tools());
+            }
+            if vision {
+                models.retain(|m| m.supports_vision());
+            }
+            if reasoning {
+                models.retain(|m| m.supports_reasoning());
+            }
+
+            // Sort.
+            match sort.as_str() {
+                "cheapest" | "price" => {
+                    models.sort_by(|a, b| {
+                        let pa = a.pricing.prompt.parse::<f64>().unwrap_or(f64::MAX);
+                        let pb = b.pricing.prompt.parse::<f64>().unwrap_or(f64::MAX);
+                        pa.partial_cmp(&pb).unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                }
+                "context" | "largest" => {
+                    models.sort_by(|a, b| b.context_length.cmp(&a.context_length));
+                }
+                _ => {
+                    // Default: newest first.
+                    models.sort_by(|a, b| b.created.cmp(&a.created));
+                }
+            }
+
+            // Limit.
+            models.truncate(limit);
+
+            if json_output {
+                let output = serde_json::to_string_pretty(&models)?;
+                return Ok(output);
+            }
+
+            // Human-readable output.
+            if models.is_empty() {
+                return Ok("No models found matching your criteria.".to_owned());
+            }
+
+            let mut lines = Vec::new();
+            lines.push(format!("Found {} models:\n", models.len()));
+
+            for m in &models {
+                let mut badges = String::new();
+                if m.supports_tools() {
+                    badges.push_str(" [T]");
+                }
+                if m.supports_vision() {
+                    badges.push_str(" [V]");
+                }
+                if m.supports_reasoning() {
+                    badges.push_str(" [R]");
+                }
+
+                lines.push(format!(
+                    "  {:<45} {:>12}  {:>6}{}",
+                    if m.id.len() > 45 {
+                        let truncated: String = m.id.chars().take(44).collect();
+                        format!("{truncated}…")
+                    } else {
+                        m.id.clone()
+                    },
+                    m.price_display(),
+                    m.context_display(),
+                    badges,
+                ));
+            }
+
+            lines.push(String::new());
+            lines.push("Badges: [T] tools  [V] vision  [R] reasoning".to_owned());
+            lines.push(format!(
+                "Sort: {}  |  Use: genesis model set <id>",
+                sort
+            ));
+
+            Ok(lines.join("\n"))
         }
     }
 }

--- a/crates/genesis-cli/src/lib.rs
+++ b/crates/genesis-cli/src/lib.rs
@@ -692,6 +692,30 @@ pub enum ModelCommand {
         #[arg(long, help = "Environment variable holding the API key")]
         api_key_env: Option<String>,
     },
+    /// Browse available models from OpenRouter with search and filters.
+    Browse {
+        /// Filter by search query (matches ID and name).
+        #[arg(short, long)]
+        query: Option<String>,
+        /// Filter to models supporting tools.
+        #[arg(long)]
+        tools: bool,
+        /// Filter to models supporting vision.
+        #[arg(long)]
+        vision: bool,
+        /// Filter to models supporting reasoning.
+        #[arg(long)]
+        reasoning: bool,
+        /// Sort by: newest, cheapest, context (default: newest).
+        #[arg(short, long, default_value = "newest")]
+        sort: String,
+        /// Maximum number of models to display.
+        #[arg(short = 'n', long, default_value = "20")]
+        limit: usize,
+        /// Output as JSON.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1681,7 +1705,7 @@ pub async fn run(cli: Cli) -> Result<String, CliError> {
             }
         }
         Command::Model(model_command) => {
-            commands::misc::run_model(cli.config, model_command, cli.json)
+            commands::misc::run_model(cli.config, model_command, cli.json).await
         }
         Command::Serve { host, port } => {
             commands::serve::run_serve(cli.config, &host, port, runtime_overrides).await
@@ -6926,6 +6950,78 @@ trusted = true
                 assert!(!remove_data);
                 assert!(remove_config);
                 assert!(!force);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn model_browse_parses() {
+        let cli = Cli::try_parse_from([
+            "genesis",
+            "model",
+            "browse",
+            "--tools",
+            "--sort",
+            "cheapest",
+            "-n",
+            "5",
+        ])
+        .expect("model browse should parse");
+
+        match cli.command {
+            Command::Model(ModelCommand::Browse {
+                query,
+                tools,
+                vision,
+                reasoning,
+                sort,
+                limit,
+                json,
+            }) => {
+                assert!(query.is_none());
+                assert!(tools);
+                assert!(!vision);
+                assert!(!reasoning);
+                assert_eq!(sort, "cheapest");
+                assert_eq!(limit, 5);
+                assert!(!json);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn model_browse_parses_with_query() {
+        let cli = Cli::try_parse_from([
+            "genesis",
+            "model",
+            "browse",
+            "--query",
+            "gpt",
+            "--vision",
+            "--reasoning",
+            "--json",
+        ])
+        .expect("model browse with query should parse");
+
+        match cli.command {
+            Command::Model(ModelCommand::Browse {
+                query,
+                tools,
+                vision,
+                reasoning,
+                sort,
+                limit,
+                json,
+            }) => {
+                assert_eq!(query.as_deref(), Some("gpt"));
+                assert!(!tools);
+                assert!(vision);
+                assert!(reasoning);
+                assert_eq!(sort, "newest");
+                assert_eq!(limit, 20);
+                assert!(json);
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/genesis-provider/src/openrouter_models.rs
+++ b/crates/genesis-provider/src/openrouter_models.rs
@@ -4,7 +4,7 @@
 //! pricing, context length, capabilities, and creation timestamps. Results
 //! are cached locally with a configurable TTL.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::time::{Duration, SystemTime};
 
 /// Default cache TTL: 1 hour.
@@ -14,7 +14,7 @@ const CACHE_TTL: Duration = Duration::from_secs(3600);
 const API_BASE: &str = "https://openrouter.ai/api/v1";
 
 /// A model from the OpenRouter catalog.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OpenRouterModel {
     /// Model ID (e.g. "openai/gpt-4.1").
     pub id: String,
@@ -80,7 +80,7 @@ impl OpenRouterModel {
 }
 
 /// Token pricing.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ModelPricing {
     /// Price per input token as a string (e.g. "0.0000002").
     #[serde(default)]
@@ -103,7 +103,7 @@ impl ModelPricing {
 }
 
 /// Model architecture metadata.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ModelArchitecture {
     /// Input modalities (e.g. ["text", "image"]).
     #[serde(default)]


### PR DESCRIPTION
## Summary

- `genesis model browse` fetches and displays models from OpenRouter
- Filter by --query, --tools, --vision, --reasoning
- Sort by newest/cheapest/context
- JSON output with --json
- 2 new tests

### Example Output

```
Found 20 models:

  anthropic/claude-sonnet-4-6                  $3.00/$15.00    200k [T] [V] [R]
  openai/gpt-4.1                               $2.00/$8.00    1M [T] [V]
  google/gemini-2.5-pro                        $1.25/$10.00    1M [T] [V] [R]

Badges: [T] tools  [V] vision  [R] reasoning
```

Partially addresses #170