### PR TITLE
fix(web): align AuditEntry type with backend event_type field

### DIFF
--- a/web/src/components/dashboard/activity-feed.tsx
+++ b/web/src/components/dashboard/activity-feed.tsx
@@ -26,8 +26,8 @@ function getActionColor(action: string): string {
 }
 
 function ActivityItem({ entry }: { entry: AuditEntry }) {
-  const Icon = getActionIcon(entry.action)
-  const color = getActionColor(entry.action)
+  const Icon = getActionIcon(entry.event_type)
+  const color = getActionColor(entry.event_type)
 
   return (
     <div className="group flex items-start gap-2.5 py-1.5">
@@ -36,7 +36,7 @@ function ActivityItem({ entry }: { entry: AuditEntry }) {
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate font-mono text-[11px] text-foreground/80">
-          {entry.action}
+          {entry.event_type}
         </span>
         {entry.details && (
           <span className="truncate font-mono text-[10px] text-muted-foreground/50">

--- a/web/src/components/layout/system-bar.tsx
+++ b/web/src/components/layout/system-bar.tsx
@@ -83,8 +83,8 @@ export function SystemBar() {
       {/* Right: Latest event + status + clock */}
       <div className="flex items-center gap-3">
         {latestEvent && (
-          <span className="max-w-[180px] truncate font-mono text-[8px] text-muted-foreground/20" title={`${latestEvent.action} — ${formatRelativeTime(latestEvent.created_at)}`}>
-            {latestEvent.action}
+          <span className="max-w-[180px] truncate font-mono text-[8px] text-muted-foreground/20" title={`${latestEvent.event_type} — ${formatRelativeTime(latestEvent.created_at)}`}>
+            {latestEvent.event_type}
           </span>
         )}
         <span className={`font-mono text-[9px] font-medium tracking-wider ${

--- a/web/src/lib/api/types.ts
+++ b/web/src/lib/api/types.ts
@@ -139,7 +139,7 @@ export interface UsageStats {
 
 export interface AuditEntry {
   id: string
-  action: string
+  event_type: string
   session_id: string | null
   details: string | null
   created_at: string

--- a/web/src/routes/audit.lazy.tsx
+++ b/web/src/routes/audit.lazy.tsx
@@ -51,11 +51,11 @@ function getActionColor(action: string): string {
 }
 
 function AuditRow({ entry, isLast }: { entry: AuditEntry; isLast: boolean }) {
-  const category = categorize(entry.action)
+  const category = categorize(entry.event_type)
   const meta = CATEGORY_META[category]
   const Icon = meta.icon
   const [iconColor, bgColor] = meta.color.split(' ')
-  const actionColor = getActionColor(entry.action)
+  const actionColor = getActionColor(entry.event_type)
 
   return (
     <div className="group flex items-stretch gap-3">
@@ -71,7 +71,7 @@ function AuditRow({ entry, isLast }: { entry: AuditEntry; isLast: boolean }) {
       <div className="min-w-0 flex-1 pb-3">
         <div className="flex items-center gap-2">
           <span className={`font-mono text-[11px] font-medium ${actionColor}`}>
-            {entry.action}
+            {entry.event_type}
           </span>
           {entry.session_id && (
             <Link
@@ -107,7 +107,7 @@ function AuditPage() {
   const categoryCounts = React.useMemo(() => {
     const counts = new Map<ActionCategory, number>()
     for (const entry of entries ?? []) {
-      const cat = categorize(entry.action)
+      const cat = categorize(entry.event_type)
       counts.set(cat, (counts.get(cat) ?? 0) + 1)
     }
     return counts
@@ -117,10 +117,10 @@ function AuditPage() {
     return (entries ?? []).filter((entry) => {
       const matchesSearch =
         !search ||
-        entry.action.toLowerCase().includes(search.toLowerCase()) ||
+        entry.event_type.toLowerCase().includes(search.toLowerCase()) ||
         (entry.session_id?.toLowerCase().includes(search.toLowerCase()) ?? false) ||
         (entry.details?.toLowerCase().includes(search.toLowerCase()) ?? false)
-      const matchesCategory = !categoryFilter || categorize(entry.action) === categoryFilter
+      const matchesCategory = !categoryFilter || categorize(entry.event_type) === categoryFilter
       return matchesSearch && matchesCategory
     })
   }, [entries, search, categoryFilter])


### PR DESCRIPTION
## Summary
- The backend audit API returns `event_type` but the frontend `AuditEntry` interface defined it as `action`
- This caused a `TypeError: Cannot read properties of undefined (reading 'includes')` crash in the activity feed, audit page, and system bar
- Renamed `action` → `event_type` in the type definition and all 4 consuming components

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [ ] Load dashboard — activity feed renders without crash
- [ ] Visit `/audit` page — event timeline renders correctly
- [ ] System bar shows latest event type in bottom ticker