### PR TITLE
fix: return proper HTTP 500 on audit/analytics DB errors, clean up dead code

### DIFF
--- a/crates/genesis-core/src/context_security.rs
+++ b/crates/genesis-core/src/context_security.rs
@@ -24,7 +24,10 @@ pub struct Threat {
 /// Result of scanning a context file.
 #[derive(Debug, Clone)]
 pub struct ScanResult {
-    /// Path of the scanned file (if from disk).
+    /// Path or label of the scanned source.
+    ///
+    /// Currently only read in tests; retained as part of the public scan API
+    /// for logging and diagnostics in future callers.
     #[allow(dead_code)]
     pub source: String,
     /// Detected threats.
@@ -38,7 +41,7 @@ impl ScanResult {
     }
 
     /// Returns true if any threats were found.
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn has_threats(&self) -> bool {
         !self.threats.is_empty()
     }
@@ -64,7 +67,7 @@ pub fn scan_context_file(path: &Path, content: &str) -> ScanResult {
 }
 
 /// Scan raw text (not from a file) for injection threats.
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn scan_text(label: &str, content: &str) -> ScanResult {
     let source = label.to_owned();
     let mut threats = Vec::new();
@@ -355,7 +358,7 @@ fn scan_tool_abuse(lower: &str, threats: &mut Vec<Threat>) {
 }
 
 /// Known context file names that should be scanned.
-#[allow(dead_code)]
+#[cfg(test)]
 pub const CONTEXT_FILE_NAMES: &[&str] = &[
     "AGENTS.md",
     ".cursorrules",
@@ -370,7 +373,7 @@ pub const CONTEXT_FILE_NAMES: &[&str] = &[
 ];
 
 /// Check if a filename is a known context file that should be scanned.
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn is_context_file(path: &Path) -> bool {
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 

--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -355,6 +355,7 @@ fn default_request_id() -> String {
 
 /// Map a storage error into an HTTP 500 response pair.
 fn storage_err(e: impl std::fmt::Display) -> (StatusCode, String) {
+    error!(error = %e, "storage operation failed");
     (
         StatusCode::INTERNAL_SERVER_ERROR,
         format!("storage error: {e}"),
@@ -2484,45 +2485,49 @@ struct AuditQueryParams {
 async fn audit_recent_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AuditQueryParams>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
     let limit = params.limit.unwrap_or(50);
     let entries = if let Some(ref event_type) = params.event_type {
-        store.by_event_type(event_type, limit).unwrap_or_default()
+        store
+            .by_event_type(event_type, limit)
+            .map_err(storage_err)?
     } else {
-        store.recent(limit).unwrap_or_default()
+        store.recent(limit).map_err(storage_err)?
     };
-    Json(serde_json::json!({
+    Ok(Json(serde_json::json!({
         "entries": entries,
         "count": entries.len(),
-    }))
+    })))
 }
 
-async fn audit_stats_handler(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
+async fn audit_stats_handler(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.stats().unwrap_or_default();
+    let stats = store.stats().map_err(storage_err)?;
     let total: i64 = stats.iter().map(|(_, c)| c).sum();
-    Json(serde_json::json!({
+    Ok(Json(serde_json::json!({
         "total_entries": total,
         "by_event_type": stats.into_iter().map(|(t, c)| {
             serde_json::json!({"event_type": t, "count": c})
         }).collect::<Vec<_>>(),
-    }))
+    })))
 }
 
 async fn audit_session_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
     Query(params): Query<AuditQueryParams>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
     let limit = params.limit.unwrap_or(100);
-    let entries = store.by_session(&id, limit).unwrap_or_default();
-    Json(serde_json::json!({
+    let entries = store.by_session(&id, limit).map_err(storage_err)?;
+    Ok(Json(serde_json::json!({
         "session_id": id,
         "entries": entries,
         "count": entries.len(),
-    }))
+    })))
 }
 
 #[derive(Deserialize)]
@@ -2533,18 +2538,14 @@ struct AuditPurgeRequest {
 async fn audit_purge_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<AuditPurgeRequest>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
     let days = request.older_than_days.unwrap_or(90);
-    match store.purge_older_than(days) {
-        Ok(deleted) => Json(serde_json::json!({
-            "purged": deleted,
-            "older_than_days": days,
-        })),
-        Err(e) => Json(serde_json::json!({
-            "error": e.to_string(),
-        })),
-    }
+    let deleted = store.purge_older_than(days).map_err(storage_err)?;
+    Ok(Json(serde_json::json!({
+        "purged": deleted,
+        "older_than_days": days,
+    })))
 }
 
 // ---------------------------------------------------------------------------
@@ -2559,27 +2560,27 @@ struct AnalyticsQuery {
 async fn tool_analytics_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AnalyticsQuery>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
     let days = params.days.unwrap_or(30);
-    let analytics = store.tool_analytics(days).unwrap_or_default();
-    Json(serde_json::json!({
+    let analytics = store.tool_analytics(days).map_err(storage_err)?;
+    Ok(Json(serde_json::json!({
         "period_days": days,
         "tools": analytics,
-    }))
+    })))
 }
 
 async fn llm_analytics_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AnalyticsQuery>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
     let days = params.days.unwrap_or(30);
-    let analytics = store.llm_analytics(days).unwrap_or_default();
-    Json(serde_json::json!({
+    let analytics = store.llm_analytics(days).map_err(storage_err)?;
+    Ok(Json(serde_json::json!({
         "period_days": days,
         "models": analytics,
-    }))
+    })))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fix 6 audit/analytics endpoints** that silently returned empty data on storage errors — now return proper HTTP 500 with error logging via the existing `storage_err` helper
- **Fix `audit_purge_handler`** that was returning errors as 200 OK with JSON error body — now returns proper HTTP 500
- **Add `error!()` tracing** to the `storage_err` helper for gateway-wide storage error observability
- **Replace `#[allow(dead_code)]` with `#[cfg(test)]`** on 4 test-only items in `context_security.rs` — strips unused code from production builds while keeping test utilities available

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes clean
- [x] `cargo test --workspace` — all tests pass, 0 failures
- [x] Audit endpoints now return 500 + log on DB errors instead of silent empty results
- [x] context_security test-only code excluded from release builds