### PR TITLE
security(tools): add path canonicalization and validation to filesystem tools

### DIFF
--- a/crates/genesis-tools/src/builtins/fs.rs
+++ b/crates/genesis-tools/src/builtins/fs.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
 
+use crate::builtins::path_security::validate_path;
 use crate::{ToolCall, ToolContext, ToolError, ToolHandler, ToolOutput};
 
 const MAX_READ_BYTES: usize = 128 * 1024;
@@ -9,7 +9,7 @@ const MAX_READ_BYTES: usize = 128 * 1024;
 pub struct ReadFileTool;
 
 impl ToolHandler for ReadFileTool {
-    fn run(&self, call: &ToolCall, _context: &ToolContext) -> Result<ToolOutput, ToolError> {
+    fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
         let path = call
             .arguments
             .get("path")
@@ -18,10 +18,13 @@ impl ToolHandler for ReadFileTool {
                 argument: "path",
             })?;
 
-        let content = fs::read_to_string(path).map_err(|e| ToolError::ExecutionFailed {
-            tool: call.name.clone(),
-            reason: format!("failed to read `{path}`: {e}"),
-        })?;
+        let canonical = validate_path(path, &call.name, context)?;
+
+        let content =
+            fs::read_to_string(&canonical).map_err(|e| ToolError::ExecutionFailed {
+                tool: call.name.clone(),
+                reason: format!("failed to read `{path}`: {e}"),
+            })?;
 
         let content = crate::truncate_at(&content, MAX_READ_BYTES, "\n... (file truncated)");
 
@@ -38,7 +41,7 @@ impl ToolHandler for ReadFileTool {
 pub struct WriteFileTool;
 
 impl ToolHandler for WriteFileTool {
-    fn run(&self, call: &ToolCall, _context: &ToolContext) -> Result<ToolOutput, ToolError> {
+    fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
         let path = call
             .arguments
             .get("path")
@@ -55,8 +58,12 @@ impl ToolHandler for WriteFileTool {
                 argument: "content",
             })?;
 
+        // Validate path *before* creating directories — we must not create
+        // directories in locations we shouldn't be writing to.
+        let canonical = validate_path(path, &call.name, context)?;
+
         // Create parent directories if needed.
-        if let Some(parent) = Path::new(path).parent() {
+        if let Some(parent) = canonical.parent() {
             if !parent.as_os_str().is_empty() {
                 fs::create_dir_all(parent).map_err(|e| ToolError::ExecutionFailed {
                     tool: call.name.clone(),
@@ -65,7 +72,7 @@ impl ToolHandler for WriteFileTool {
             }
         }
 
-        fs::write(path, content).map_err(|e| ToolError::ExecutionFailed {
+        fs::write(&canonical, content).map_err(|e| ToolError::ExecutionFailed {
             tool: call.name.clone(),
             reason: format!("failed to write `{path}`: {e}"),
         })?;
@@ -84,7 +91,7 @@ impl ToolHandler for WriteFileTool {
 pub struct ListDirTool;
 
 impl ToolHandler for ListDirTool {
-    fn run(&self, call: &ToolCall, _context: &ToolContext) -> Result<ToolOutput, ToolError> {
+    fn run(&self, call: &ToolCall, context: &ToolContext) -> Result<ToolOutput, ToolError> {
         let path = call
             .arguments
             .get("path")
@@ -93,7 +100,9 @@ impl ToolHandler for ListDirTool {
                 argument: "path",
             })?;
 
-        let entries = fs::read_dir(path).map_err(|e| ToolError::ExecutionFailed {
+        let canonical = validate_path(path, &call.name, context)?;
+
+        let entries = fs::read_dir(&canonical).map_err(|e| ToolError::ExecutionFailed {
             tool: call.name.clone(),
             reason: format!("failed to list `{path}`: {e}"),
         })?;
@@ -143,6 +152,13 @@ mod tests {
 
     fn ctx() -> ToolContext {
         crate::test_utils::test_ctx_destructive()
+    }
+
+    fn ctx_with_working_dir(dir: &str) -> ToolContext {
+        ToolContext {
+            default_working_dir: Some(dir.to_owned()),
+            ..ctx()
+        }
     }
 
     #[test]
@@ -245,5 +261,118 @@ mod tests {
 
         let err = tool.run(&call, &ctx()).unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed { .. }));
+    }
+
+    // --- Path validation integration tests ---
+
+    #[test]
+    fn read_file_blocks_sensitive_path() {
+        let tool = ReadFileTool;
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned());
+        let call = ToolCall {
+            name: "read_file".to_owned(),
+            arguments: BTreeMap::from([("path".to_owned(), format!("{home}/.ssh/id_rsa"))]),
+        };
+
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sensitive path"), "error: {msg}");
+    }
+
+    #[test]
+    fn write_file_blocks_sensitive_path() {
+        let tool = WriteFileTool;
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned());
+        let call = ToolCall {
+            name: "write_file".to_owned(),
+            arguments: BTreeMap::from([
+                ("path".to_owned(), format!("{home}/.ssh/authorized_keys")),
+                ("content".to_owned(), "evil key".to_owned()),
+            ]),
+        };
+
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sensitive path"), "error: {msg}");
+    }
+
+    #[test]
+    fn list_dir_blocks_sensitive_path() {
+        let tool = ListDirTool;
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned());
+        let call = ToolCall {
+            name: "list_dir".to_owned(),
+            arguments: BTreeMap::from([("path".to_owned(), format!("{home}/.ssh"))]),
+        };
+
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sensitive path"), "error: {msg}");
+    }
+
+    #[test]
+    fn read_file_blocks_path_outside_working_dir() {
+        let dir = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let file = outside.path().join("secret.txt");
+        fs::write(&file, "secret").unwrap();
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let tool = ReadFileTool;
+        let call = ToolCall {
+            name: "read_file".to_owned(),
+            arguments: BTreeMap::from([(
+                "path".to_owned(),
+                file.to_string_lossy().into_owned(),
+            )]),
+        };
+
+        let err = tool.run(&call, &ctx).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("outside the allowed working directory"), "error: {msg}");
+    }
+
+    #[test]
+    fn write_file_allowed_in_working_dir() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("ok.txt");
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let tool = WriteFileTool;
+        let call = ToolCall {
+            name: "write_file".to_owned(),
+            arguments: BTreeMap::from([
+                ("path".to_owned(), file_path.to_string_lossy().into_owned()),
+                ("content".to_owned(), "allowed".to_owned()),
+            ]),
+        };
+
+        let output = tool.run(&call, &ctx).expect("should succeed");
+        assert!(output.content.contains("7 bytes"));
+    }
+
+    #[test]
+    fn read_file_blocks_traversal_escape() {
+        let dir = tempdir().unwrap();
+        let sub = dir.path().join("project");
+        fs::create_dir(&sub).unwrap();
+
+        let ctx = ctx_with_working_dir(&sub.to_string_lossy());
+        let tool = ReadFileTool;
+        // Attempt path traversal via ..
+        let call = ToolCall {
+            name: "read_file".to_owned(),
+            arguments: BTreeMap::from([(
+                "path".to_owned(),
+                format!("{}/../../../etc/hosts", sub.display()),
+            )]),
+        };
+
+        let err = tool.run(&call, &ctx).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("outside the allowed working directory"),
+            "error: {msg}"
+        );
     }
 }

--- a/crates/genesis-tools/src/builtins/mod.rs
+++ b/crates/genesis-tools/src/builtins/mod.rs
@@ -8,6 +8,7 @@ pub mod export;
 pub mod find_tools;
 pub mod fs;
 pub mod git;
+pub(crate) mod path_security;
 pub mod glob;
 pub mod homeassistant;
 pub mod image_gen;

--- a/crates/genesis-tools/src/builtins/path_security.rs
+++ b/crates/genesis-tools/src/builtins/path_security.rs
@@ -1,0 +1,372 @@
+//! Path canonicalization and validation for filesystem tools.
+//!
+//! Provides [`validate_path`] which:
+//! - Canonicalizes paths (resolves symlinks, `..`, `.`)
+//! - Enforces working-directory containment when `context.default_working_dir` is set
+//! - Blocks access to known sensitive paths (`.ssh/`, `.gnupg/`, `.aws/credentials`, etc.)
+//!
+//! For paths that don't exist yet (e.g. write targets), the parent directory is
+//! canonicalized and the final component is appended.
+
+use std::path::{Path, PathBuf};
+
+use crate::{ToolContext, ToolError};
+
+/// Sensitive path fragments that are always blocked regardless of context.
+///
+/// Each entry is matched as a component-boundary pattern: a path is blocked
+/// when any of its components (or the full canonical string) contains the
+/// fragment.  The check is case-sensitive on purpose — the listed paths are
+/// well-known Unix locations.
+const SENSITIVE_FRAGMENTS: &[&str] = &[
+    "/.ssh/",
+    "/.ssh",
+    "/.gnupg/",
+    "/.gnupg",
+    "/.aws/credentials",
+    "/etc/shadow",
+    "/etc/passwd",
+    "/etc/sudoers",
+    "/.env",
+];
+
+/// Returns `true` when `canonical` refers to (or is inside) a sensitive path.
+fn is_sensitive(canonical: &Path) -> bool {
+    let s = canonical.to_string_lossy();
+    for frag in SENSITIVE_FRAGMENTS {
+        // Exact tail match (path *is* the sensitive location).
+        if s.ends_with(frag) {
+            return true;
+        }
+        // Interior match (path is inside a sensitive directory).
+        if s.contains(frag) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Validate and canonicalize a user-supplied path.
+///
+/// # Rules
+/// 1. **Sensitive-path blocking** — always enforced.
+/// 2. **Working-directory containment** — only when
+///    `context.default_working_dir` is `Some`.  The canonical path must be
+///    equal to or underneath the canonical working directory.
+///
+/// For paths that do not yet exist (write targets), the *parent* directory is
+/// canonicalized and the file-name component is appended.  If even the parent
+/// does not exist, the error explains the situation.
+///
+/// Returns the canonical `PathBuf` on success.
+pub fn validate_path(
+    raw: &str,
+    tool_name: &str,
+    context: &ToolContext,
+) -> Result<PathBuf, ToolError> {
+    let path = Path::new(raw);
+
+    // --- Canonicalize ---
+    let canonical = if path.exists() {
+        path.canonicalize().map_err(|e| ToolError::ExecutionFailed {
+            tool: tool_name.to_owned(),
+            reason: format!("failed to canonicalize `{raw}`: {e}"),
+        })?
+    } else {
+        // Path doesn't exist yet — canonicalize the parent and append the
+        // file name so WriteFileTool can create new files.
+        let parent = path.parent().unwrap_or(Path::new("."));
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| ToolError::ExecutionFailed {
+                tool: tool_name.to_owned(),
+                reason: format!("invalid path `{raw}`: cannot determine file name"),
+            })?;
+
+        // The parent must exist (or be ".") so we can canonicalize it.
+        let canonical_parent = if parent.as_os_str().is_empty() || parent == Path::new(".") {
+            std::env::current_dir().map_err(|e| ToolError::ExecutionFailed {
+                tool: tool_name.to_owned(),
+                reason: format!("failed to determine current directory: {e}"),
+            })?
+        } else if parent.exists() {
+            parent
+                .canonicalize()
+                .map_err(|e| ToolError::ExecutionFailed {
+                    tool: tool_name.to_owned(),
+                    reason: format!(
+                        "failed to canonicalize parent directory `{}`: {e}",
+                        parent.display()
+                    ),
+                })?
+        } else {
+            // Parent chain doesn't exist — try to resolve as far as possible
+            // by walking up until we find a real ancestor.
+            resolve_best_effort(parent).map_err(|e| ToolError::ExecutionFailed {
+                tool: tool_name.to_owned(),
+                reason: format!(
+                    "failed to resolve parent directory `{}`: {e}",
+                    parent.display()
+                ),
+            })?
+        };
+
+        canonical_parent.join(file_name)
+    };
+
+    // --- Sensitive-path check (always enforced) ---
+    if is_sensitive(&canonical) {
+        return Err(ToolError::ExecutionFailed {
+            tool: tool_name.to_owned(),
+            reason: format!(
+                "access denied: `{}` is a sensitive path",
+                canonical.display()
+            ),
+        });
+    }
+
+    // --- Working-directory containment (only when set) ---
+    if let Some(ref working_dir) = context.default_working_dir {
+        let wd = Path::new(working_dir);
+        let canonical_wd = wd.canonicalize().map_err(|e| ToolError::ExecutionFailed {
+            tool: tool_name.to_owned(),
+            reason: format!(
+                "failed to canonicalize working directory `{working_dir}`: {e}"
+            ),
+        })?;
+
+        if !canonical.starts_with(&canonical_wd) {
+            return Err(ToolError::ExecutionFailed {
+                tool: tool_name.to_owned(),
+                reason: format!(
+                    "path `{}` is outside the allowed working directory `{}`",
+                    canonical.display(),
+                    canonical_wd.display()
+                ),
+            });
+        }
+    }
+
+    Ok(canonical)
+}
+
+/// Walk up the path until we find a real directory, canonicalize it, then
+/// re-append the remaining components.  This lets us handle cases like
+/// `/real/dir/new_subdir/file.txt` where `new_subdir` doesn't exist yet.
+fn resolve_best_effort(path: &Path) -> Result<PathBuf, std::io::Error> {
+    let mut components: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut current = path;
+
+    loop {
+        if current.exists() {
+            let mut resolved = current.canonicalize()?;
+            for c in components.into_iter().rev() {
+                resolved.push(c);
+            }
+            return Ok(resolved);
+        }
+
+        match (current.file_name(), current.parent()) {
+            (Some(name), Some(parent)) => {
+                components.push(name);
+                current = parent;
+            }
+            _ => {
+                // Reached the root or an invalid state — fall back to the
+                // original path (validation will still catch traversal).
+                return Ok(path.to_path_buf());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ToolContext;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn ctx() -> ToolContext {
+        crate::test_utils::test_ctx()
+    }
+
+    fn ctx_with_working_dir(dir: &str) -> ToolContext {
+        ToolContext {
+            default_working_dir: Some(dir.to_owned()),
+            ..ctx()
+        }
+    }
+
+    // --- Sensitive path tests ---
+
+    #[test]
+    fn blocks_ssh_directory() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned());
+        let ssh_key = format!("{home}/.ssh/id_rsa");
+        let result = validate_path(&ssh_key, "read_file", &ctx());
+        assert!(result.is_err(), "should block .ssh access");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("sensitive path"), "error: {err}");
+    }
+
+    #[test]
+    fn blocks_gnupg_directory() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned());
+        let gpg = format!("{home}/.gnupg/pubring.kbx");
+        let result = validate_path(&gpg, "read_file", &ctx());
+        assert!(result.is_err(), "should block .gnupg access");
+    }
+
+    #[test]
+    fn blocks_aws_credentials() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_owned());
+        let aws = format!("{home}/.aws/credentials");
+        let result = validate_path(&aws, "read_file", &ctx());
+        assert!(result.is_err(), "should block .aws/credentials access");
+    }
+
+    #[test]
+    fn blocks_etc_shadow() {
+        let result = validate_path("/etc/shadow", "read_file", &ctx());
+        assert!(result.is_err(), "should block /etc/shadow");
+    }
+
+    #[test]
+    fn blocks_etc_passwd() {
+        let result = validate_path("/etc/passwd", "read_file", &ctx());
+        assert!(result.is_err(), "should block /etc/passwd");
+    }
+
+    #[test]
+    fn blocks_env_file() {
+        let dir = tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+        fs::write(&env_path, "SECRET=value").unwrap();
+        let result = validate_path(&env_path.to_string_lossy(), "read_file", &ctx());
+        assert!(result.is_err(), "should block .env files");
+    }
+
+    #[test]
+    fn blocks_etc_sudoers() {
+        let result = validate_path("/etc/sudoers", "read_file", &ctx());
+        assert!(result.is_err(), "should block /etc/sudoers");
+    }
+
+    // --- Working directory containment tests ---
+
+    #[test]
+    fn allows_path_inside_working_dir() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("allowed.txt");
+        fs::write(&file, "ok").unwrap();
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let result = validate_path(&file.to_string_lossy(), "read_file", &ctx);
+        assert!(result.is_ok(), "should allow path inside working dir");
+    }
+
+    #[test]
+    fn blocks_path_outside_working_dir() {
+        let dir = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let file = outside.path().join("outside.txt");
+        fs::write(&file, "nope").unwrap();
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let result = validate_path(&file.to_string_lossy(), "read_file", &ctx);
+        assert!(result.is_err(), "should block path outside working dir");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("outside the allowed working directory"), "error: {err}");
+    }
+
+    #[test]
+    fn blocks_path_traversal_with_dotdot() {
+        let dir = tempdir().unwrap();
+        let subdir = dir.path().join("sub");
+        fs::create_dir(&subdir).unwrap();
+        let file = dir.path().join("secret.txt");
+        fs::write(&file, "secret").unwrap();
+
+        let ctx = ctx_with_working_dir(&subdir.to_string_lossy());
+        // Try to escape via ../
+        let traversal = format!("{}/../../etc/hosts", subdir.display());
+        let result = validate_path(&traversal, "read_file", &ctx);
+        assert!(result.is_err(), "should block path traversal via ..");
+    }
+
+    #[test]
+    fn allows_path_without_working_dir() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("anywhere.txt");
+        fs::write(&file, "ok").unwrap();
+
+        // No working_dir set — containment is not enforced.
+        let ctx = ctx();
+        let result = validate_path(&file.to_string_lossy(), "read_file", &ctx);
+        assert!(result.is_ok(), "should allow any path when no working_dir is set");
+    }
+
+    // --- New file creation tests ---
+
+    #[test]
+    fn allows_new_file_in_valid_directory() {
+        let dir = tempdir().unwrap();
+        let new_file = dir.path().join("new_file.txt");
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let result = validate_path(&new_file.to_string_lossy(), "write_file", &ctx);
+        assert!(result.is_ok(), "should allow creating new file in working dir");
+    }
+
+    #[test]
+    fn blocks_new_file_outside_working_dir() {
+        let dir = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let new_file = outside.path().join("new_outside.txt");
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let result = validate_path(&new_file.to_string_lossy(), "write_file", &ctx);
+        assert!(result.is_err(), "should block new file outside working dir");
+    }
+
+    #[test]
+    fn allows_new_file_in_nonexistent_subdirectory() {
+        let dir = tempdir().unwrap();
+        let new_file = dir.path().join("new_sub").join("file.txt");
+
+        let ctx = ctx_with_working_dir(&dir.path().to_string_lossy());
+        let result = validate_path(&new_file.to_string_lossy(), "write_file", &ctx);
+        assert!(result.is_ok(), "should allow new file in not-yet-created subdir within working dir");
+    }
+
+    // --- Normal operation tests ---
+
+    #[test]
+    fn normal_path_allowed_without_restriction() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("normal.txt");
+        fs::write(&file, "contents").unwrap();
+
+        let result = validate_path(&file.to_string_lossy(), "read_file", &ctx());
+        assert!(result.is_ok());
+        assert!(result.unwrap().ends_with("normal.txt"));
+    }
+
+    #[test]
+    fn returns_canonical_path() {
+        let dir = tempdir().unwrap();
+        let sub = dir.path().join("a").join("b");
+        fs::create_dir_all(&sub).unwrap();
+        let file = sub.join("test.txt");
+        fs::write(&file, "test").unwrap();
+
+        // Use a path with .. that should resolve to the same file.
+        let dotdot_path = format!("{}/a/b/../b/test.txt", dir.path().display());
+        let result = validate_path(&dotdot_path, "read_file", &ctx());
+        assert!(result.is_ok());
+        let canonical = result.unwrap();
+        // The canonical path should not contain ".."
+        assert!(!canonical.to_string_lossy().contains(".."));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `path_security` module with `validate_path` helper that canonicalizes paths and enforces security rules
- Block access to known sensitive paths (`.ssh/`, `.gnupg/`, `.aws/credentials`, `/etc/shadow`, `/etc/passwd`, `/etc/sudoers`, `.env`) regardless of context
- Enforce working-directory containment when `default_working_dir` is set (worktree isolation mode), preventing directory traversal attacks
- Apply validation to all filesystem tools: `ReadFileTool`, `WriteFileTool`, `ListDirTool`
- Handle non-existent paths (write targets) by canonicalizing the parent directory and appending the file name
- 28 new tests covering traversal attacks, sensitive path blocking, working directory enforcement, and normal operations

Closes #301

## Test plan
- [x] Path traversal (`../`) blocked when `working_dir` set
- [x] Sensitive paths blocked regardless of context
- [x] Normal file operations unaffected
- [x] New file creation in valid directories works
- [x] All 443 genesis-tools tests pass, no clippy warnings