### PR TITLE
fix: replace mutex .expect() calls with graceful poison recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -435,10 +435,10 @@ impl<'a> SessionExecutionService<'a> {
 
         let cache_key = self.lua_runtime_cache_key(session_id, &platform);
         let slot = {
-            let mut cache = self
-                .lua_runtime_cache
-                .lock()
-                .expect("lua runtime cache mutex should not be poisoned");
+            let mut cache = self.lua_runtime_cache.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("lua runtime cache mutex poisoned, recovering");
+                poisoned.into_inner()
+            });
             Arc::clone(
                 cache
                     .entry(cache_key.clone())

--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -213,9 +213,10 @@ where
         return Ok(Arc::clone(value));
     }
 
-    let _guard = init_lock
-        .lock()
-        .expect("embedding provider init lock poisoned");
+    let _guard = init_lock.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("embedding provider init lock poisoned, recovering");
+        poisoned.into_inner()
+    });
     if let Some(value) = cache.get() {
         return Ok(Arc::clone(value));
     }

--- a/crates/genesis-gateway/src/webhooks.rs
+++ b/crates/genesis-gateway/src/webhooks.rs
@@ -279,6 +279,7 @@ fn compute_hmac(secret: &str, body: &str) -> String {
 
     type HmacSha256 = Hmac<Sha256>;
 
+    // Safety: HMAC-SHA256 accepts keys of any length, so this cannot fail.
     let mut mac =
         HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
     mac.update(body.as_bytes());

--- a/crates/genesis-lua/Cargo.toml
+++ b/crates/genesis-lua/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/genesis-lua/src/api.rs
+++ b/crates/genesis-lua/src/api.rs
@@ -55,17 +55,17 @@ impl PluginContext {
     }
 
     pub(crate) fn close_tool_registration(&self) {
-        *self
-            .load_active
-            .lock()
-            .expect("plugin load state mutex should not be poisoned") = false;
+        *self.load_active.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("plugin load state mutex poisoned, recovering");
+            poisoned.into_inner()
+        }) = false;
     }
 
     fn load_active(&self) -> bool {
-        *self
-            .load_active
-            .lock()
-            .expect("plugin load state mutex should not be poisoned")
+        *self.load_active.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("plugin load state mutex poisoned, recovering");
+            poisoned.into_inner()
+        })
     }
 
     pub(crate) fn for_execution(name: String, permissions: PluginPermissions) -> Self {
@@ -202,7 +202,10 @@ impl UserData for GenesisApi {
                 }
                 hooks
                     .lock()
-                    .expect("hook registry mutex should not be poisoned")
+                    .unwrap_or_else(|poisoned| {
+                        tracing::warn!("hook registry mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    })
                     .register(event, callback, Some(plugin_context));
                 Ok(())
             })
@@ -221,7 +224,10 @@ impl UserData for GenesisApi {
                 }
                 tools
                     .lock()
-                    .expect("tool registry mutex should not be poisoned")
+                    .unwrap_or_else(|poisoned| {
+                        tracing::warn!("tool registry mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    })
                     .register(lua, &plugin_context.name, &plugin_context.permissions, spec)
                     .map_err(mlua::Error::external)?;
                 Ok(())
@@ -241,7 +247,10 @@ impl UserData for GenesisApi {
                 }
                 personalities
                     .lock()
-                    .expect("personality registry mutex should not be poisoned")
+                    .unwrap_or_else(|poisoned| {
+                        tracing::warn!("personality registry mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    })
                     .register(&plugin_context.name, &plugin_context.permissions, spec)
                     .map_err(mlua::Error::external)?;
                 Ok(())
@@ -320,7 +329,10 @@ fn make_memory_bridge(
             let kind = resolve_memory_kind(metadata)?;
             let session_id = session
                 .lock()
-                .expect("session state mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("session state mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .id
                 .clone();
             let store = MemoryStore::new(&database_path);
@@ -360,7 +372,10 @@ fn make_logger(
     prefix: Option<&'static str>,
 ) -> mlua::Result<mlua::Function> {
     lua.create_function(move |_, message: String| {
-        let mut stored = logs.lock().expect("log sink mutex should not be poisoned");
+        let mut stored = logs.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("log sink mutex poisoned, recovering");
+            poisoned.into_inner()
+        });
         stored.push(match prefix {
             Some(prefix) => format!("{prefix}{message}"),
             None => message,
@@ -382,7 +397,10 @@ fn make_tool_bridge(
         lua.create_function(move |lua, args: Option<Table>| {
             let plugin_context = active_plugin
                 .lock()
-                .expect("active plugin mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("active plugin mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .last()
                 .cloned()
                 .ok_or_else(|| {
@@ -405,7 +423,10 @@ fn make_tool_bridge(
 
             let executor = host_tools
                 .lock()
-                .expect("host tools mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("host tools mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .clone()
                 .ok_or_else(|| mlua::Error::external(LuaRuntimeError::HostToolBridgeUnavailable))?;
             let arguments = table_to_string_arguments(lua, args)?;

--- a/crates/genesis-lua/src/runtime.rs
+++ b/crates/genesis-lua/src/runtime.rs
@@ -305,7 +305,10 @@ impl LuaRuntime {
         lua.set_interrupt(move |_| {
             let active = interrupt_control
                 .lock()
-                .expect("plugin execution control mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("plugin execution control mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .active
                 .clone();
             let Some(active) = active else {
@@ -388,7 +391,10 @@ impl LuaRuntime {
             if configured_disabled.contains(&plugin.name) {
                 self.disabled_plugins
                     .lock()
-                    .expect("disabled plugins mutex should not be poisoned")
+                    .unwrap_or_else(|poisoned| {
+                        tracing::warn!("disabled plugins mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    })
                     .insert(plugin.name.clone());
                 continue;
             }
@@ -423,7 +429,10 @@ impl LuaRuntime {
     pub fn logs(&self) -> Vec<String> {
         self.logs
             .lock()
-            .expect("log sink mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("log sink mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .clone()
     }
 
@@ -435,7 +444,10 @@ impl LuaRuntime {
         let disabled = self.disabled_plugin_names();
         self.tool_registry
             .lock()
-            .expect("tool registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("tool registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .registered_tools()
             .into_iter()
             .filter(|tool| !disabled.contains(&tool.plugin_name))
@@ -446,7 +458,10 @@ impl LuaRuntime {
         let disabled = self.disabled_plugin_names();
         self.personality_registry
             .lock()
-            .expect("personality registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("personality registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .registered_personalities()
             .into_iter()
             .filter(|personality| !disabled.contains(&personality.plugin_name))
@@ -457,7 +472,10 @@ impl LuaRuntime {
         let entry = self
             .personality_registry
             .lock()
-            .expect("personality registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("personality registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .personality_entry(name)?;
         if self.plugin_disabled(&entry.metadata.plugin_name) {
             return None;
@@ -470,7 +488,10 @@ impl LuaRuntime {
         let entry = self
             .personality_registry
             .lock()
-            .expect("personality registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("personality registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .personality_entry(name)
             .ok_or_else(|| LuaRuntimeError::UnknownLuaPersonality {
                 name: name.to_owned(),
@@ -488,7 +509,10 @@ impl LuaRuntime {
         let selected = self
             .session_state
             .lock()
-            .expect("session state mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("session state mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .personality
             .clone();
         let Some(selected) = selected else {
@@ -497,7 +521,10 @@ impl LuaRuntime {
         let entry = self
             .personality_registry
             .lock()
-            .expect("personality registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("personality registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .personality_entry(&selected);
         let Some(entry) = entry else {
             return response.to_owned();
@@ -511,10 +538,10 @@ impl LuaRuntime {
         arguments: BTreeMap<String, String>,
     ) -> Result<LuaToolOutput, LuaRuntimeError> {
         let plugin_context = {
-            let registry = self
-                .tool_registry
-                .lock()
-                .expect("tool registry mutex should not be poisoned");
+            let registry = self.tool_registry.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("tool registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            });
             let tool = registry
                 .registered_tools()
                 .into_iter()
@@ -537,7 +564,10 @@ impl LuaRuntime {
         let result = self
             .tool_registry
             .lock()
-            .expect("tool registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("tool registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .invoke(&self.lua, name, arguments);
         if let Err(err) = &result {
             self.record_plugin_failure(&plugin_name, &err.to_string());
@@ -549,7 +579,10 @@ impl LuaRuntime {
         *self
             .host_tool_executor
             .lock()
-            .expect("host tool executor mutex should not be poisoned") = Some(executor);
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("host tool executor mutex poisoned, recovering");
+                poisoned.into_inner()
+            }) = Some(executor);
     }
 
     pub fn register_hook(
@@ -564,16 +597,19 @@ impl LuaRuntime {
         })?;
         self.hook_registry
             .lock()
-            .expect("hook registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("hook registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .register(event, callback, None);
         Ok(())
     }
 
     pub fn record_completed_turn(&self, tokens: u32) {
-        let mut state = self
-            .session_state
-            .lock()
-            .expect("session state mutex should not be poisoned");
+        let mut state = self.session_state.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("session state mutex poisoned, recovering");
+            poisoned.into_inner()
+        });
         state.turn_count = state.turn_count.saturating_add(1);
         state.total_tokens = state.total_tokens.saturating_add(tokens);
     }
@@ -628,7 +664,10 @@ impl LuaRuntime {
         let session_id = self
             .session_state
             .lock()
-            .expect("session state mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("session state mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .id
             .clone();
         let context = self.lua.create_table()?;
@@ -672,14 +711,20 @@ impl LuaRuntime {
             if configured_disabled.contains(bundled.name) {
                 self.disabled_plugins
                     .lock()
-                    .expect("disabled plugins mutex should not be poisoned")
+                    .unwrap_or_else(|poisoned| {
+                        tracing::warn!("disabled plugins mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    })
                     .insert(bundled.name.to_owned());
                 continue;
             }
             if self
                 .personality_registry
                 .lock()
-                .expect("personality registry mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("personality registry mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .personality_entry(bundled.name)
                 .is_some()
             {
@@ -723,11 +768,17 @@ impl LuaRuntime {
         if let Err(err) = load_result {
             self.tool_registry
                 .lock()
-                .expect("tool registry mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("tool registry mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .remove_tools_owned_by(&plugin.name);
             self.personality_registry
                 .lock()
-                .expect("personality registry mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("personality registry mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .remove_personalities_owned_by(&plugin.name);
             self.plugin_errors
                 .push(format!("plugin `{}` failed to load: {err}", plugin.name));
@@ -815,7 +866,10 @@ impl LuaRuntime {
         let callbacks = self
             .hook_registry
             .lock()
-            .expect("hook registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("hook registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .callbacks(event);
         for callback in callbacks {
             if callback
@@ -891,7 +945,10 @@ impl LuaRuntime {
         let callbacks = self
             .hook_registry
             .lock()
-            .expect("hook registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("hook registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .callbacks(event);
         for callback in callbacks {
             if callback
@@ -966,7 +1023,10 @@ impl LuaRuntime {
         let callbacks = self
             .hook_registry
             .lock()
-            .expect("hook registry mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("hook registry mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .callbacks(event);
         for callback in callbacks {
             if callback
@@ -1010,10 +1070,10 @@ impl LuaRuntime {
     }
 
     fn push_hook_error(&self, event: HookEvent, message: String) {
-        let mut logs = self
-            .logs
-            .lock()
-            .expect("log sink mutex should not be poisoned");
+        let mut logs = self.logs.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("log sink mutex poisoned, recovering");
+            poisoned.into_inner()
+        });
         logs.push(format!("[hook::{event:?}] {message}"));
     }
 
@@ -1021,10 +1081,10 @@ impl LuaRuntime {
         if !self.plugin_verbose {
             return;
         }
-        let mut logs = self
-            .logs
-            .lock()
-            .expect("log sink mutex should not be poisoned");
+        let mut logs = self.logs.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("log sink mutex poisoned, recovering");
+            poisoned.into_inner()
+        });
         logs.push(format!("[hook::{event:?}::{plugin_name}] {message}"));
     }
 
@@ -1037,7 +1097,10 @@ impl LuaRuntime {
         let session = self
             .session_state
             .lock()
-            .expect("session state mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("session state mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .clone();
         let context = match self.build_personality_context(&session) {
             Ok(context) => context,
@@ -1109,7 +1172,10 @@ impl LuaRuntime {
         let session = self
             .session_state
             .lock()
-            .expect("session state mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("session state mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .clone();
         let context = self.build_personality_context(&session).map_err(|error| {
             LuaRuntimeError::LuaPersonalityPromptFailed {
@@ -1226,10 +1292,10 @@ impl LuaRuntime {
     }
 
     fn push_personality_error(&self, plugin_name: &str, message: String) {
-        let mut logs = self
-            .logs
-            .lock()
-            .expect("log sink mutex should not be poisoned");
+        let mut logs = self.logs.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("log sink mutex poisoned, recovering");
+            poisoned.into_inner()
+        });
         logs.push(format!("[personality::{plugin_name}] {message}"));
     }
 
@@ -1252,7 +1318,10 @@ impl LuaRuntime {
         let previous = self
             .execution_control
             .lock()
-            .expect("plugin execution control mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("plugin execution control mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .active
             .replace(active);
         PluginExecutionGuard {
@@ -1268,14 +1337,20 @@ impl LuaRuntime {
     fn plugin_disabled(&self, plugin_name: &str) -> bool {
         self.disabled_plugins
             .lock()
-            .expect("disabled plugins mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("disabled plugins mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .contains(plugin_name)
     }
 
     fn disabled_plugin_names(&self) -> HashSet<String> {
         self.disabled_plugins
             .lock()
-            .expect("disabled plugins mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("disabled plugins mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .clone()
     }
 
@@ -1288,10 +1363,10 @@ impl LuaRuntime {
         }
 
         let failures = {
-            let mut failures = self
-                .plugin_failures
-                .lock()
-                .expect("plugin failures mutex should not be poisoned");
+            let mut failures = self.plugin_failures.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("plugin failures mutex poisoned, recovering");
+                poisoned.into_inner()
+            });
             let count = failures.entry(plugin_name.to_owned()).or_insert(0);
             *count += 1;
             *count
@@ -1304,13 +1379,16 @@ impl LuaRuntime {
         let newly_disabled = self
             .disabled_plugins
             .lock()
-            .expect("disabled plugins mutex should not be poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("disabled plugins mutex poisoned, recovering");
+                poisoned.into_inner()
+            })
             .insert(plugin_name.to_owned());
         if newly_disabled {
-            let mut logs = self
-                .logs
-                .lock()
-                .expect("log sink mutex should not be poisoned");
+            let mut logs = self.logs.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("log sink mutex poisoned, recovering");
+                poisoned.into_inner()
+            });
             logs.push(format!(
                 "[plugin::{plugin_name}] disabled for this session after {failures} failures"
             ));
@@ -1356,7 +1434,10 @@ impl ActivePluginGuard {
         let pushed = if let Some(plugin_context) = plugin_context {
             stack
                 .lock()
-                .expect("active plugin mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("active plugin mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .push(plugin_context);
             true
         } else {
@@ -1371,7 +1452,10 @@ impl Drop for ActivePluginGuard {
         if self.pushed {
             self.stack
                 .lock()
-                .expect("active plugin mutex should not be poisoned")
+                .unwrap_or_else(|poisoned| {
+                    tracing::warn!("active plugin mutex poisoned, recovering");
+                    poisoned.into_inner()
+                })
                 .pop();
         }
     }
@@ -1381,10 +1465,10 @@ impl Drop for PluginExecutionGuard {
     fn drop(&mut self) {
         let finished = Instant::now();
         let previous = {
-            let mut control = self
-                .control
-                .lock()
-                .expect("plugin execution control mutex should not be poisoned");
+            let mut control = self.control.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("plugin execution control mutex poisoned, recovering");
+                poisoned.into_inner()
+            });
             let current = control.active.take();
             control.active = self.previous.take();
             current
@@ -1397,7 +1481,10 @@ impl Drop for PluginExecutionGuard {
                     .as_millis();
                 self.logs
                     .lock()
-                    .expect("log sink mutex should not be poisoned")
+                    .unwrap_or_else(|poisoned| {
+                        tracing::warn!("log sink mutex poisoned, recovering");
+                        poisoned.into_inner()
+                    })
                     .push(format!(
                         "[plugin::{}] {} completed in {}ms",
                         self.plugin_name, self.operation, elapsed_ms

--- a/crates/genesis-provider/src/circuit_breaker.rs
+++ b/crates/genesis-provider/src/circuit_breaker.rs
@@ -86,10 +86,10 @@ impl CircuitBreaker {
     /// Returns `true` if the request can proceed, `false` if it should
     /// be rejected (circuit is Open and cooldown hasn't expired).
     pub fn allow_request(&self) -> bool {
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("circuit breaker state lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("circuit breaker state lock poisoned, recovering");
+            poisoned.into_inner()
+        });
         match inner.state {
             CircuitState::Closed => true,
             CircuitState::HalfOpen => {
@@ -122,10 +122,10 @@ impl CircuitBreaker {
 
     /// Record a successful request. Resets failure count and closes circuit.
     pub fn record_success(&self) {
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("circuit breaker state lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("circuit breaker state lock poisoned, recovering");
+            poisoned.into_inner()
+        });
         if inner.state == CircuitState::HalfOpen {
             tracing::info!("circuit breaker closing after successful probe");
         }
@@ -136,10 +136,10 @@ impl CircuitBreaker {
 
     /// Record a failed request. Increments failure count and may open circuit.
     pub fn record_failure(&self) {
-        let mut inner = self
-            .inner
-            .lock()
-            .expect("circuit breaker state lock poisoned");
+        let mut inner = self.inner.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("circuit breaker state lock poisoned, recovering");
+            poisoned.into_inner()
+        });
         inner.consecutive_failures += 1;
 
         match inner.state {
@@ -173,7 +173,10 @@ impl CircuitBreaker {
     pub fn state(&self) -> CircuitState {
         self.inner
             .lock()
-            .expect("circuit breaker state lock poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("circuit breaker state lock poisoned, recovering");
+                poisoned.into_inner()
+            })
             .state
     }
 
@@ -181,7 +184,10 @@ impl CircuitBreaker {
     pub fn consecutive_failures(&self) -> u32 {
         self.inner
             .lock()
-            .expect("circuit breaker state lock poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("circuit breaker state lock poisoned, recovering");
+                poisoned.into_inner()
+            })
             .consecutive_failures
     }
 
@@ -189,7 +195,10 @@ impl CircuitBreaker {
     pub fn open_count(&self) -> u64 {
         self.inner
             .lock()
-            .expect("circuit breaker state lock poisoned")
+            .unwrap_or_else(|poisoned| {
+                tracing::warn!("circuit breaker state lock poisoned, recovering");
+                poisoned.into_inner()
+            })
             .open_count
     }
 }

--- a/crates/genesis-tools/src/builtins/code_execution.rs
+++ b/crates/genesis-tools/src/builtins/code_execution.rs
@@ -351,8 +351,14 @@ pub fn execute_code_ptc(
     let _ = stdout_handle.join();
     let _ = stderr_handle.join();
 
-    let stdout_bytes = stdout_buf.lock().expect("stdout buffer lock poisoned");
-    let stderr_bytes = stderr_buf.lock().expect("stderr buffer lock poisoned");
+    let stdout_bytes = stdout_buf.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("stdout buffer lock poisoned, recovering");
+        poisoned.into_inner()
+    });
+    let stderr_bytes = stderr_buf.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("stderr buffer lock poisoned, recovering");
+        poisoned.into_inner()
+    });
     let mut stdout_text = String::from_utf8_lossy(&stdout_bytes).to_string();
     let stderr_text = String::from_utf8_lossy(&stderr_bytes).to_string();
 


### PR DESCRIPTION
## Summary
- Replace 50+ mutex `.expect()` calls in production code with `unwrap_or_else` poison recovery across 6 files in 5 crates
- Circuit breaker, Lua plugin system, gateway init, code execution, and runtime cache now recover gracefully from poisoned mutexes instead of panicking the process
- Add `tracing::warn` logging on every mutex poison recovery for observability
- Add `tracing` dependency to `genesis-lua` crate (was missing, needed for warn logging)
- HMAC `.expect()` in webhooks.rs retained with a safety comment (HMAC-SHA256 accepts any key length)
- Test-only `.expect()` calls intentionally left unchanged (panicking is desired in tests)

Closes #280

## Test plan
- [x] All mutex locks in production code use graceful recovery instead of `.expect()`
- [x] `tracing::warn` logged on every mutex poison recovery
- [x] HMAC `.expect()` retained with safety comment
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (2600+ tests)