### PR TITLE
perf(gateway): wrap SQLite operations in spawn_blocking

### DIFF
--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -362,6 +362,27 @@ fn storage_err(e: impl std::fmt::Display) -> (StatusCode, String) {
     )
 }
 
+/// Run a synchronous storage operation on a blocking thread.
+///
+/// SQLite operations (via `rusqlite`) are synchronous and can block the
+/// async runtime under concurrent load.  This helper offloads them to
+/// Tokio's blocking thread-pool so the main executor stays responsive.
+async fn blocking_storage<F, T>(f: F) -> Result<T, (StatusCode, String)>
+where
+    F: FnOnce() -> Result<T, (StatusCode, String)> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "blocking storage task failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("task join error: {e}"),
+            )
+        })?
+}
+
 /// Response body from the `/chat` endpoint.
 #[derive(Debug, Serialize)]
 pub(crate) struct ChatResponse {
@@ -873,15 +894,20 @@ async fn rate_limit_middleware(
 }
 
 /// Shared DB stats used by health, metrics, and prometheus handlers.
-fn fetch_db_stats(db_path: &std::path::Path) -> (usize, usize) {
-    let total_sessions = genesis_storage::SessionStore::new(db_path)
-        .session_count()
-        .unwrap_or(0) as usize;
-    let active_schedules = genesis_storage::ScheduleStore::new(db_path)
-        .list_enabled()
-        .map(|s| s.len())
-        .unwrap_or(0);
-    (total_sessions, active_schedules)
+async fn fetch_db_stats(db_path: &std::path::Path) -> (usize, usize) {
+    let db_path = db_path.to_path_buf();
+    blocking_storage(move || {
+        let total_sessions = genesis_storage::SessionStore::new(&db_path)
+            .session_count()
+            .unwrap_or(0) as usize;
+        let active_schedules = genesis_storage::ScheduleStore::new(&db_path)
+            .list_enabled()
+            .map(|s| s.len())
+            .unwrap_or(0);
+        Ok((total_sessions, active_schedules))
+    })
+    .await
+    .unwrap_or((0, 0))
 }
 
 async fn health_handler(State(state): State<Arc<AppState>>) -> Json<HealthResponse> {
@@ -890,7 +916,7 @@ async fn health_handler(State(state): State<Arc<AppState>>) -> Json<HealthRespon
         None => 0,
     };
     let (total_sessions, active_schedules) =
-        fetch_db_stats(&state.loaded.config.storage.database_path);
+        fetch_db_stats(&state.loaded.config.storage.database_path).await;
     let mcp_tools = match &state.mcp {
         Some(mcp) => mcp.tool_count().await,
         None => 0,
@@ -1019,7 +1045,7 @@ async fn prometheus_metrics_handler(State(state): State<Arc<AppState>>) -> Respo
     let stream_reqs = state.stream_requests_total.load(Ordering::Relaxed);
 
     let db_path = &state.loaded.config.storage.database_path;
-    let (total_sessions, active_schedules_usize) = fetch_db_stats(db_path);
+    let (total_sessions, active_schedules_usize) = fetch_db_stats(db_path).await;
     let total_sessions = total_sessions as u64;
     let active_schedules = active_schedules_usize as u64;
 
@@ -1028,8 +1054,13 @@ async fn prometheus_metrics_handler(State(state): State<Arc<AppState>>) -> Respo
         None => 0,
     };
 
-    let cache_store = genesis_storage::ResponseCacheStore::new(db_path);
-    let (cache_entries, cache_hits) = cache_store.stats().unwrap_or((0, 0));
+    let db_path_owned = db_path.to_path_buf();
+    let (cache_entries, cache_hits) = blocking_storage(move || {
+        let cache_store = genesis_storage::ResponseCacheStore::new(&db_path_owned);
+        Ok(cache_store.stats().unwrap_or((0, 0)))
+    })
+    .await
+    .unwrap_or((0, 0));
 
     let model = format!(
         "{}/{}",
@@ -1040,12 +1071,17 @@ async fn prometheus_metrics_handler(State(state): State<Arc<AppState>>) -> Respo
     let (wh_delivered, wh_retried, wh_failed) = state.webhooks.metrics();
 
     // Audit log total
-    let audit_total: i64 = genesis_storage::AuditLogStore::new(db_path)
-        .stats()
-        .unwrap_or_default()
-        .iter()
-        .map(|(_, c)| c)
-        .sum();
+    let db_path_for_audit = db_path.to_path_buf();
+    let audit_total: i64 = blocking_storage(move || {
+        Ok(genesis_storage::AuditLogStore::new(&db_path_for_audit)
+            .stats()
+            .unwrap_or_default()
+            .iter()
+            .map(|(_, c)| c)
+            .sum())
+    })
+    .await
+    .unwrap_or(0);
 
     // Request duration histogram
     let duration_histogram = if let Ok(hist) = state.request_duration_histogram.lock() {
@@ -1122,7 +1158,7 @@ async fn prometheus_metrics_handler(State(state): State<Arc<AppState>>) -> Respo
 /// JSON format that is easier for browser-based clients to consume.
 async fn metrics_json_handler(State(state): State<Arc<AppState>>) -> Json<MetricsJsonResponse> {
     let (total_sessions, active_schedules) =
-        fetch_db_stats(&state.loaded.config.storage.database_path);
+        fetch_db_stats(&state.loaded.config.storage.database_path).await;
 
     Json(MetricsJsonResponse {
         uptime_seconds: state.started_at.elapsed().as_secs(),
@@ -1152,13 +1188,17 @@ async fn list_sessions_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<ListSessionsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let sessions = if let Some(query) = &params.search {
-        store.search_sessions(query)
-    } else {
-        store.list_recent_sessions(params.limit)
-    }
-    .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let sessions = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        if let Some(query) = &params.search {
+            store.search_sessions(query)
+        } else {
+            store.list_recent_sessions(params.limit)
+        }
+        .map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "sessions": sessions,
@@ -1170,8 +1210,12 @@ async fn get_session_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let session = store.get_session(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let session = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.get_session(&id).map_err(storage_err)
+    })
+    .await?;
 
     match session {
         Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
@@ -1180,7 +1224,7 @@ async fn get_session_handler(
                 format!("serialization error: {e}"),
             )
         })?)),
-        None => Err((StatusCode::NOT_FOUND, format!("session '{id}' not found"))),
+        None => Err((StatusCode::NOT_FOUND, "session not found".to_owned())),
     }
 }
 
@@ -1188,8 +1232,13 @@ async fn delete_session_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete_session(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let deleted = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.delete_session(&id_clone).map_err(storage_err)
+    })
+    .await?;
 
     if deleted {
         Ok(Json(serde_json::json!({"deleted": true, "session_id": id})))
@@ -1241,8 +1290,13 @@ async fn session_messages_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let messages = store.load_messages(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let messages = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.load_messages(&id_clone).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "session_id": id,
@@ -1256,7 +1310,7 @@ async fn fork_session_handler(
     Path(id): Path<String>,
     Json(request): Json<ForkRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let new_id = request.new_session_id.unwrap_or_else(|| {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1265,7 +1319,13 @@ async fn fork_session_handler(
         format!("fork-{id}-{ts}")
     });
 
-    store.fork_session(&id, &new_id).map_err(storage_err)?;
+    let id_clone = id.clone();
+    let new_id_clone = new_id.clone();
+    blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.fork_session(&id_clone, &new_id_clone).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "source_session_id": id,
@@ -1278,8 +1338,14 @@ async fn update_session_title_handler(
     Path(id): Path<String>,
     Json(request): Json<UpdateTitleRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let updated = store.set_title(&id, &request.title).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let title_clone = request.title.clone();
+    let updated = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.set_title(&id_clone, &title_clone).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "session_id": id,
@@ -1298,11 +1364,15 @@ async fn export_session_handler(
     Path(id): Path<String>,
     axum::extract::Query(params): axum::extract::Query<ExportQuery>,
 ) -> Result<Response, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-
-    let session_title = store.get_session(&id).ok().flatten().and_then(|s| s.title);
-
-    let stored = store.load_messages(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let (session_title, stored) = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        let session_title = store.get_session(&id_clone).ok().flatten().and_then(|s| s.title);
+        let stored = store.load_messages(&id_clone).map_err(storage_err)?;
+        Ok((session_title, stored))
+    })
+    .await?;
 
     if stored.is_empty() {
         return Err((
@@ -1359,10 +1429,13 @@ async fn purge_sessions_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<PurgeQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let purged = store
-        .purge_older_than(params.older_than_days)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let days = params.older_than_days;
+    let purged = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.purge_older_than(days).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "purged": purged,
@@ -1374,8 +1447,13 @@ async fn get_session_tags_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let tags = store.get_tags(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let tags = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.get_tags(&id_clone).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(serde_json::json!({ "session_id": id, "tags": tags })))
 }
 
@@ -1389,9 +1467,15 @@ async fn set_session_tags_handler(
     Path(id): Path<String>,
     Json(request): Json<SetTagsRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
-    store.set_tags(&id, &tag_refs).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let tags = request.tags.clone();
+    blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        let tag_refs: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+        store.set_tags(&id_clone, &tag_refs).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(
         serde_json::json!({ "session_id": id, "tags": request.tags }),
     ))
@@ -1401,9 +1485,16 @@ async fn add_session_tag_handler(
     State(state): State<Arc<AppState>>,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let added = store.add_tag(&id, &tag).map_err(storage_err)?;
-    let tags = store.get_tags(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let tag_clone = tag.clone();
+    let (added, tags) = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        let added = store.add_tag(&id_clone, &tag_clone).map_err(storage_err)?;
+        let tags = store.get_tags(&id_clone).map_err(storage_err)?;
+        Ok((added, tags))
+    })
+    .await?;
     Ok(Json(
         serde_json::json!({ "session_id": id, "tag": tag, "added": added, "tags": tags }),
     ))
@@ -1413,9 +1504,16 @@ async fn remove_session_tag_handler(
     State(state): State<Arc<AppState>>,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let removed = store.remove_tag(&id, &tag).map_err(storage_err)?;
-    let tags = store.get_tags(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let tag_clone = tag.clone();
+    let (removed, tags) = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        let removed = store.remove_tag(&id_clone, &tag_clone).map_err(storage_err)?;
+        let tags = store.get_tags(&id_clone).map_err(storage_err)?;
+        Ok((removed, tags))
+    })
+    .await?;
     Ok(Json(
         serde_json::json!({ "session_id": id, "tag": tag, "removed": removed, "tags": tags }),
     ))
@@ -1425,8 +1523,13 @@ async fn sessions_by_tag_handler(
     State(state): State<Arc<AppState>>,
     Path(tag): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let sessions = store.sessions_by_tag(&tag).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let tag_clone = tag.clone();
+    let sessions = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.sessions_by_tag(&tag_clone).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(
         serde_json::json!({ "tag": tag, "sessions": sessions, "count": sessions.len() }),
     ))
@@ -1449,7 +1552,7 @@ async fn import_session_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ImportSessionRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
 
     let session_id = request.session_id.unwrap_or_else(|| {
         let ts = std::time::SystemTime::now()
@@ -1466,14 +1569,20 @@ async fn import_session_handler(
         .map(|m| (m.role, m.content))
         .collect();
 
-    store
-        .import_session(&session_id, request.title.as_deref(), messages)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("import error: {e}"),
-            )
-        })?;
+    let session_id_clone = session_id.clone();
+    let title = request.title;
+    blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store
+            .import_session(&session_id_clone, title.as_deref(), messages)
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("import error: {e}"),
+                )
+            })
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "session_id": session_id,
@@ -1500,49 +1609,60 @@ async fn bulk_export_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<BulkExportQuery>,
 ) -> Result<Response, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
 
     let limit = params.limit.unwrap_or(1000);
-    let sessions = store.list_recent_sessions(limit).map_err(storage_err)?;
+    let format = params.format.clone();
 
-    use genesis_tools::builtins::export::{export_json, export_jsonl};
+    // Validate format before spawning blocking work
+    if !matches!(format.as_str(), "jsonl" | "finetune" | "json") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "unsupported bulk format '{}'; use 'jsonl' or 'json'",
+                format
+            ),
+        ));
+    }
 
-    let mut output = String::new();
+    let output = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        let sessions = store.list_recent_sessions(limit).map_err(storage_err)?;
 
-    for session in &sessions {
-        let stored = match store.load_messages(&session.id) {
-            Ok(msgs) if !msgs.is_empty() => msgs,
-            _ => continue,
-        };
+        use genesis_tools::builtins::export::{export_json, export_jsonl};
 
-        let messages: Vec<(String, Option<String>, Option<String>, String)> = stored
-            .into_iter()
-            .map(|m| (m.role, m.content, m.tool_calls_json, m.created_at))
-            .collect();
+        let mut output = String::new();
 
-        match params.format.as_str() {
-            "jsonl" | "finetune" => {
-                let line = export_jsonl(&messages);
-                if !line.is_empty() {
-                    output.push_str(&line);
+        for session in &sessions {
+            let stored = match store.load_messages(&session.id) {
+                Ok(msgs) if !msgs.is_empty() => msgs,
+                _ => continue,
+            };
+
+            let messages: Vec<(String, Option<String>, Option<String>, String)> = stored
+                .into_iter()
+                .map(|m| (m.role, m.content, m.tool_calls_json, m.created_at))
+                .collect();
+
+            match format.as_str() {
+                "jsonl" | "finetune" => {
+                    let line = export_jsonl(&messages);
+                    if !line.is_empty() {
+                        output.push_str(&line);
+                    }
                 }
-            }
-            "json" => {
-                let json = export_json(&session.id, session.title.as_deref(), &messages);
-                output.push_str(&json);
-                output.push('\n');
-            }
-            _ => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!(
-                        "unsupported bulk format '{}'; use 'jsonl' or 'json'",
-                        params.format
-                    ),
-                ))
+                "json" => {
+                    let json = export_json(&session.id, session.title.as_deref(), &messages);
+                    output.push_str(&json);
+                    output.push('\n');
+                }
+                _ => unreachable!(),
             }
         }
-    }
+
+        Ok(output)
+    })
+    .await?;
 
     let content_type = match params.format.as_str() {
         "json" => "application/json; charset=utf-8",
@@ -1576,15 +1696,19 @@ async fn search_messages_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<SearchMessagesQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let results = store
-        .search_messages(&params.q, params.limit)
-        .map_err(|e| {
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let query = params.q.clone();
+    let limit = params.limit;
+    let results = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.search_messages(&query, limit).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 format!("search error: {e}"),
             )
-        })?;
+        })
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "query": params.q,
@@ -1597,8 +1721,12 @@ async fn insights_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<InsightsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let data = store.insights(params.days).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let data = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.insights(params.days).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::to_value(data).map_err(|e| {
         (
@@ -1611,8 +1739,12 @@ async fn insights_handler(
 async fn usage_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.usage_stats().map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let stats = blocking_storage(move || {
+        let store = SessionStore::new(&db_path);
+        store.usage_stats().map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::to_value(stats).map_err(|e| {
         (
@@ -1647,8 +1779,12 @@ struct SearchSkillsQuery {
 async fn list_skills_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let skills = store.list_all().map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let skills = blocking_storage(move || {
+        let store = SkillStore::new(&db_path);
+        store.list_all().map_err(storage_err)
+    })
+    .await?;
 
     let count = skills.len();
     Ok(Json(serde_json::json!({
@@ -1661,8 +1797,13 @@ async fn get_skill_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let skill = store.get(&name).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let name_clone = name.clone();
+    let skill = blocking_storage(move || {
+        let store = SkillStore::new(&db_path);
+        store.get(&name_clone).map_err(storage_err)
+    })
+    .await?;
 
     match skill {
         Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
@@ -1679,17 +1820,21 @@ async fn upsert_skill_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<UpsertSkillRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
-    let skill = store
-        .upsert(
-            &request.name,
-            &request.description,
-            &request.instructions,
-            request.trigger_hint.as_deref(),
-            &tag_refs,
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let skill = blocking_storage(move || {
+        let store = SkillStore::new(&db_path);
+        let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
+        store
+            .upsert(
+                &request.name,
+                &request.description,
+                &request.instructions,
+                request.trigger_hint.as_deref(),
+                &tag_refs,
+            )
+            .map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::to_value(skill).map_err(|e| {
         (
@@ -1703,8 +1848,13 @@ async fn delete_skill_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete(&name).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let name_clone = name.clone();
+    let deleted = blocking_storage(move || {
+        let store = SkillStore::new(&db_path);
+        store.delete(&name_clone).map_err(storage_err)
+    })
+    .await?;
 
     if deleted {
         Ok(Json(serde_json::json!({"deleted": true, "name": name})))
@@ -1717,8 +1867,12 @@ async fn search_skills_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<SearchSkillsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let skills = store.find_by_tag(&params.tag).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let skills = blocking_storage(move || {
+        let store = SkillStore::new(&db_path);
+        store.find_by_tag(&params.tag).map_err(storage_err)
+    })
+    .await?;
 
     let count = skills.len();
     Ok(Json(serde_json::json!({
@@ -1830,8 +1984,12 @@ async fn list_memories_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<ListMemoriesQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = MemoryStore::new(&state.loaded.config.storage.database_path);
-    let memories = store.list(params.limit).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let memories = blocking_storage(move || {
+        let store = MemoryStore::new(&db_path);
+        store.list(params.limit).map_err(storage_err)
+    })
+    .await?;
 
     let count = memories.len();
     Ok(Json(serde_json::json!({
@@ -1896,15 +2054,22 @@ async fn delete_memory_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let db_path = &state.loaded.config.storage.database_path;
-    let store = MemoryStore::new(db_path);
-    let deleted = store.delete(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let deleted = blocking_storage(move || {
+        let store = MemoryStore::new(&db_path);
+        let deleted = store.delete(&id_clone).map_err(storage_err)?;
+        if deleted {
+            // Also clean up any associated embedding
+            if let Err(e) = EmbeddingStore::new(&db_path).delete(&id_clone) {
+                warn!(memory_id = %id_clone, error = %e, "failed to delete embedding for memory");
+            }
+        }
+        Ok(deleted)
+    })
+    .await?;
 
     if deleted {
-        // Also clean up any associated embedding
-        if let Err(e) = EmbeddingStore::new(db_path).delete(&id) {
-            warn!(memory_id = %id, error = %e, "failed to delete embedding for memory");
-        }
         Ok(Json(serde_json::json!({"deleted": true, "id": id})))
     } else {
         Err((StatusCode::NOT_FOUND, format!("memory '{id}' not found")))
@@ -2086,13 +2251,17 @@ async fn list_schedules_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<ListSchedulesQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let schedules = if params.enabled_only {
-        store.list_enabled()
-    } else {
-        store.list_all()
-    }
-    .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let schedules = blocking_storage(move || {
+        let store = ScheduleStore::new(&db_path);
+        if params.enabled_only {
+            store.list_enabled()
+        } else {
+            store.list_all()
+        }
+        .map_err(storage_err)
+    })
+    .await?;
 
     let count = schedules.len();
     Ok(Json(serde_json::json!({
@@ -2105,8 +2274,13 @@ async fn get_schedule_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let schedule = store.get(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let schedule = blocking_storage(move || {
+        let store = ScheduleStore::new(&db_path);
+        store.get(&id_clone).map_err(storage_err)
+    })
+    .await?;
 
     match schedule {
         Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
@@ -2123,15 +2297,19 @@ async fn create_schedule_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<CreateScheduleRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, String)> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let schedule = store
-        .create(
-            &request.id,
-            &request.cron_expression,
-            &request.destination,
-            &request.prompt,
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let schedule = blocking_storage(move || {
+        let store = ScheduleStore::new(&db_path);
+        store
+            .create(
+                &request.id,
+                &request.cron_expression,
+                &request.destination,
+                &request.prompt,
+            )
+            .map_err(storage_err)
+    })
+    .await?;
 
     Ok((
         StatusCode::CREATED,
@@ -2148,8 +2326,13 @@ async fn delete_schedule_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let deleted = blocking_storage(move || {
+        let store = ScheduleStore::new(&db_path);
+        store.delete(&id_clone).map_err(storage_err)
+    })
+    .await?;
 
     if deleted {
         Ok(Json(serde_json::json!({"deleted": true, "id": id})))
@@ -2163,10 +2346,14 @@ async fn set_schedule_enabled_handler(
     Path(id): Path<String>,
     Json(request): Json<SetEnabledRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let updated = store
-        .set_enabled(&id, request.enabled)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let enabled = request.enabled;
+    let updated = blocking_storage(move || {
+        let store = ScheduleStore::new(&db_path);
+        store.set_enabled(&id_clone, enabled).map_err(storage_err)
+    })
+    .await?;
 
     if updated {
         Ok(Json(serde_json::json!({
@@ -2199,15 +2386,19 @@ async fn list_user_traits_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<ListTraitsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let traits = if let Some(category) = &params.category {
-        store.list_by_category(category)
-    } else if let Some(threshold) = params.min_confidence {
-        store.confident_traits(threshold)
-    } else {
-        store.list_all()
-    }
-    .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let traits = blocking_storage(move || {
+        let store = UserModelStore::new(&db_path);
+        if let Some(category) = &params.category {
+            store.list_by_category(category)
+        } else if let Some(threshold) = params.min_confidence {
+            store.confident_traits(threshold)
+        } else {
+            store.list_all()
+        }
+        .map_err(storage_err)
+    })
+    .await?;
 
     let count = traits.len();
     Ok(Json(serde_json::json!({
@@ -2220,8 +2411,13 @@ async fn get_user_trait_handler(
     State(state): State<Arc<AppState>>,
     Path(key): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let user_trait = store.get(&key).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let key_clone = key.clone();
+    let user_trait = blocking_storage(move || {
+        let store = UserModelStore::new(&db_path);
+        store.get(&key_clone).map_err(storage_err)
+    })
+    .await?;
 
     match user_trait {
         Some(t) => Ok(Json(serde_json::to_value(t).map_err(|e| {
@@ -2238,15 +2434,19 @@ async fn observe_user_trait_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ObserveTraitRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, String)> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let observed = store
-        .observe(
-            &request.trait_key,
-            &request.category,
-            &request.value,
-            request.source_session.as_deref(),
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let observed = blocking_storage(move || {
+        let store = UserModelStore::new(&db_path);
+        store
+            .observe(
+                &request.trait_key,
+                &request.category,
+                &request.value,
+                request.source_session.as_deref(),
+            )
+            .map_err(storage_err)
+    })
+    .await?;
 
     Ok((
         StatusCode::OK,
@@ -2263,8 +2463,13 @@ async fn delete_user_trait_handler(
     State(state): State<Arc<AppState>>,
     Path(key): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete(&key).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let key_clone = key.clone();
+    let deleted = blocking_storage(move || {
+        let store = UserModelStore::new(&db_path);
+        store.delete(&key_clone).map_err(storage_err)
+    })
+    .await?;
 
     if deleted {
         Ok(Json(serde_json::json!({"deleted": true, "trait_key": key})))
@@ -2279,8 +2484,13 @@ async fn get_subagent_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SubagentStore::new(&state.loaded.config.storage.database_path);
-    let subagent = store.get(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let subagent = blocking_storage(move || {
+        let store = SubagentStore::new(&db_path);
+        store.get(&id_clone).map_err(storage_err)
+    })
+    .await?;
 
     match subagent {
         Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
@@ -2297,8 +2507,13 @@ async fn list_session_subagents_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SubagentStore::new(&state.loaded.config.storage.database_path);
-    let subagents = store.list_by_parent(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let subagents = blocking_storage(move || {
+        let store = SubagentStore::new(&db_path);
+        store.list_by_parent(&id_clone).map_err(storage_err)
+    })
+    .await?;
 
     let count = subagents.len();
     Ok(Json(serde_json::json!({
@@ -2324,8 +2539,12 @@ async fn skill_usage_stats_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillUsageStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.stats(&name).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let stats = blocking_storage(move || {
+        let store = SkillUsageStore::new(&db_path);
+        store.stats(&name).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::to_value(stats).map_err(|e| {
         (
@@ -2340,10 +2559,13 @@ async fn skill_usage_recent_handler(
     Path(name): Path<String>,
     axum::extract::Query(params): axum::extract::Query<SkillUsageRecentQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = SkillUsageStore::new(&state.loaded.config.storage.database_path);
-    let usages = store
-        .recent_usages(&name, params.limit)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let name_clone = name.clone();
+    let usages = blocking_storage(move || {
+        let store = SkillUsageStore::new(&db_path);
+        store.recent_usages(&name_clone, params.limit).map_err(storage_err)
+    })
+    .await?;
 
     let count = usages.len();
     Ok(Json(serde_json::json!({
@@ -2442,9 +2664,13 @@ async fn config_handler(State(state): State<Arc<AppState>>) -> Json<serde_json::
 }
 
 async fn cache_stats_handler(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
-    let cache =
-        genesis_storage::ResponseCacheStore::new(&state.loaded.config.storage.database_path);
-    let (entries, hits) = cache.stats().unwrap_or((0, 0));
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let (entries, hits) = blocking_storage(move || {
+        let cache = genesis_storage::ResponseCacheStore::new(&db_path);
+        Ok(cache.stats().unwrap_or((0, 0)))
+    })
+    .await
+    .unwrap_or((0, 0));
     let enabled = state
         .loaded
         .config
@@ -2460,14 +2686,23 @@ async fn cache_stats_handler(State(state): State<Arc<AppState>>) -> Json<serde_j
 }
 
 async fn cache_clear_handler(State(state): State<Arc<AppState>>) -> Json<serde_json::Value> {
-    let cache =
-        genesis_storage::ResponseCacheStore::new(&state.loaded.config.storage.database_path);
-    match cache.clear() {
+    let db_path = state.loaded.config.storage.database_path.clone();
+    match blocking_storage(move || {
+        let cache = genesis_storage::ResponseCacheStore::new(&db_path);
+        cache.clear().map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                e.to_string(),
+            )
+        })
+    })
+    .await
+    {
         Ok(deleted) => Json(serde_json::json!({
             "cleared": deleted,
         })),
-        Err(e) => Json(serde_json::json!({
-            "error": e.to_string(),
+        Err((_, e)) => Json(serde_json::json!({
+            "error": e,
         })),
     }
 }
@@ -2486,15 +2721,17 @@ async fn audit_recent_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AuditQueryParams>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
-    let limit = params.limit.unwrap_or(50);
-    let entries = if let Some(ref event_type) = params.event_type {
-        store
-            .by_event_type(event_type, limit)
-            .map_err(storage_err)?
-    } else {
-        store.recent(limit).map_err(storage_err)?
-    };
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let entries = blocking_storage(move || {
+        let store = genesis_storage::AuditLogStore::new(&db_path);
+        let limit = params.limit.unwrap_or(50);
+        if let Some(ref event_type) = params.event_type {
+            store.by_event_type(event_type, limit).map_err(storage_err)
+        } else {
+            store.recent(limit).map_err(storage_err)
+        }
+    })
+    .await?;
     Ok(Json(serde_json::json!({
         "entries": entries,
         "count": entries.len(),
@@ -2504,8 +2741,12 @@ async fn audit_recent_handler(
 async fn audit_stats_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.stats().map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let stats = blocking_storage(move || {
+        let store = genesis_storage::AuditLogStore::new(&db_path);
+        store.stats().map_err(storage_err)
+    })
+    .await?;
     let total: i64 = stats.iter().map(|(_, c)| c).sum();
     Ok(Json(serde_json::json!({
         "total_entries": total,
@@ -2520,9 +2761,14 @@ async fn audit_session_handler(
     Path(id): Path<String>,
     Query(params): Query<AuditQueryParams>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
-    let limit = params.limit.unwrap_or(100);
-    let entries = store.by_session(&id, limit).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let id_clone = id.clone();
+    let entries = blocking_storage(move || {
+        let store = genesis_storage::AuditLogStore::new(&db_path);
+        let limit = params.limit.unwrap_or(100);
+        store.by_session(&id_clone, limit).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(serde_json::json!({
         "session_id": id,
         "entries": entries,
@@ -2539,9 +2785,13 @@ async fn audit_purge_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<AuditPurgeRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let days = request.older_than_days.unwrap_or(90);
-    let deleted = store.purge_older_than(days).map_err(storage_err)?;
+    let deleted = blocking_storage(move || {
+        let store = genesis_storage::AuditLogStore::new(&db_path);
+        store.purge_older_than(days).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(serde_json::json!({
         "purged": deleted,
         "older_than_days": days,
@@ -2561,9 +2811,13 @@ async fn tool_analytics_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AnalyticsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let days = params.days.unwrap_or(30);
-    let analytics = store.tool_analytics(days).map_err(storage_err)?;
+    let analytics = blocking_storage(move || {
+        let store = genesis_storage::AuditLogStore::new(&db_path);
+        store.tool_analytics(days).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(serde_json::json!({
         "period_days": days,
         "tools": analytics,
@@ -2574,9 +2828,13 @@ async fn llm_analytics_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AnalyticsQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let days = params.days.unwrap_or(30);
-    let analytics = store.llm_analytics(days).map_err(storage_err)?;
+    let analytics = blocking_storage(move || {
+        let store = genesis_storage::AuditLogStore::new(&db_path);
+        store.llm_analytics(days).map_err(storage_err)
+    })
+    .await?;
     Ok(Json(serde_json::json!({
         "period_days": days,
         "models": analytics,
@@ -3928,10 +4186,12 @@ async fn list_approved_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<PairingPlatformQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let users = store
-        .list_approved(params.platform.as_deref())
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let users = blocking_storage(move || {
+        let store = PairingStore::new(&db_path);
+        store.list_approved(params.platform.as_deref()).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "approved": users,
@@ -3943,10 +4203,12 @@ async fn list_pending_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<PairingPlatformQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let pending = store
-        .list_pending(params.platform.as_deref())
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let pending = blocking_storage(move || {
+        let store = PairingStore::new(&db_path);
+        store.list_pending(params.platform.as_deref()).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "pending": pending,
@@ -3958,10 +4220,12 @@ async fn approve_pairing_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ApprovePairingRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let approved = store
-        .approve_code(&request.platform, &request.code)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let approved = blocking_storage(move || {
+        let store = PairingStore::new(&db_path);
+        store.approve_code(&request.platform, &request.code).map_err(storage_err)
+    })
+    .await?;
 
     match approved {
         Some(user) => Ok(Json(serde_json::json!({
@@ -3979,23 +4243,27 @@ async fn revoke_pairing_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<RevokePairingRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let revoked = store
-        .revoke(&request.platform, &request.user_id)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let platform = request.platform.clone();
+    let user_id = request.user_id.clone();
+    let revoked = blocking_storage(move || {
+        let store = PairingStore::new(&db_path);
+        store.revoke(&request.platform, &request.user_id).map_err(storage_err)
+    })
+    .await?;
 
     if revoked {
         Ok(Json(serde_json::json!({
             "revoked": true,
-            "platform": request.platform,
-            "user_id": request.user_id,
+            "platform": platform,
+            "user_id": user_id,
         })))
     } else {
         Err((
             StatusCode::NOT_FOUND,
             format!(
                 "no approved user '{}' on platform '{}'",
-                request.user_id, request.platform
+                user_id, platform
             ),
         ))
     }
@@ -4005,14 +4273,17 @@ async fn clear_pending_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ClearPendingRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let cleared = store
-        .clear_pending(request.platform.as_deref())
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let platform = request.platform.clone();
+    let cleared = blocking_storage(move || {
+        let store = PairingStore::new(&db_path);
+        store.clear_pending(request.platform.as_deref()).map_err(storage_err)
+    })
+    .await?;
 
     Ok(Json(serde_json::json!({
         "cleared": cleared,
-        "platform": request.platform,
+        "platform": platform,
     })))
 }
 


### PR DESCRIPTION
## Summary
- Add `blocking_storage` helper function to offload synchronous SQLite operations to tokio's blocking thread-pool via `spawn_blocking`
- Wrap all 40+ synchronous storage calls across gateway route handlers (sessions, skills, memories, schedules, user traits, subagents, pairing, audit, analytics, cache, health/metrics)
- Prevents async runtime starvation under concurrent gateway load

Works cleanly because storage stores only hold a `PathBuf` and open a fresh `Connection` per method call, making them `Send + 'static` for the `spawn_blocking` closure boundary.

Closes #297

## Test plan
- [x] All gateway storage operations use spawn_blocking
- [x] No synchronous I/O on tokio runtime threads in gateway handlers
- [x] Error handling preserved through spawn_blocking boundary
- [x] All 178 gateway tests pass
- [x] Full workspace tests pass (2636 tests, 0 failures)
- [x] No clippy warnings (`--workspace --all-targets`)