### PR TITLE
refactor: move raw SQL queries from non-storage files into genesis-storage

### DIFF
--- a/crates/genesis-cli/src/slash.rs
+++ b/crates/genesis-cli/src/slash.rs
@@ -490,6 +490,7 @@ pub(crate) fn handle_chat_command(
         }
         "bus" => {
             let bus_store = genesis_core::agent_bus::AgentBusStore::new(store.database_path());
+            let _ = bus_store.ensure_table();
             let sub = _args.trim();
             if sub == "stats" {
                 match bus_store.channel_stats() {
@@ -521,7 +522,7 @@ pub(crate) fn handle_chat_command(
                                 let mut lines = vec![format!("Channel '{channel}' ({} messages):", messages.len())];
                                 for msg in &messages {
                                     lines.push(format!(
-                                        "  [{}] {} ({:?}): {}",
+                                        "  [{}] {} ({}): {}",
                                         msg.timestamp, msg.sender, msg.kind,
                                         if msg.payload.len() > 100 {
                                             format!("{}...", &msg.payload[..100])

--- a/crates/genesis-core/src/agent_bus.rs
+++ b/crates/genesis-core/src/agent_bus.rs
@@ -11,6 +11,7 @@
 //! - **Subscriptions**: Agents register interest in specific channels
 //! - **Persistence**: All messages stored in SQLite for durability and replay
 
+pub use genesis_storage::{AgentBusStore, StoredBusMessage};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::sync::broadcast;
@@ -53,6 +54,39 @@ pub enum MessageKind {
     Lifecycle,
 }
 
+impl AgentMessage {
+    /// Convert to storage representation.
+    fn to_stored(&self) -> StoredBusMessage {
+        let kind_str = serde_json::to_string(&self.kind)
+            .unwrap_or_else(|_| "\"text\"".to_owned())
+            .trim_matches('"')
+            .to_owned();
+        StoredBusMessage {
+            id: self.id.clone(),
+            channel: self.channel.clone(),
+            sender: self.sender.clone(),
+            kind: kind_str,
+            payload: self.payload.clone(),
+            metadata: self.metadata.clone(),
+            timestamp: self.timestamp.clone(),
+        }
+    }
+
+    /// Convert from storage representation.
+    fn from_stored(stored: StoredBusMessage) -> Self {
+        Self {
+            id: stored.id,
+            channel: stored.channel,
+            sender: stored.sender,
+            kind: serde_json::from_value(serde_json::Value::String(stored.kind))
+                .unwrap_or(MessageKind::Text),
+            payload: stored.payload,
+            metadata: stored.metadata,
+            timestamp: stored.timestamp,
+        }
+    }
+}
+
 /// In-memory agent message bus with broadcast channels.
 pub struct AgentBus {
     channels: tokio::sync::RwLock<HashMap<String, broadcast::Sender<AgentMessage>>>,
@@ -71,9 +105,14 @@ impl AgentBus {
 
     /// Create a bus with SQLite persistence.
     pub fn with_persistence(database_path: impl Into<std::path::PathBuf>) -> Self {
+        let db_path = database_path.into();
+        let store = AgentBusStore::new(&db_path);
+        if let Err(e) = store.ensure_table() {
+            tracing::warn!(error = %e, "failed to initialize agent_bus_messages table");
+        }
         Self {
             channels: tokio::sync::RwLock::new(HashMap::new()),
-            database_path: Some(database_path.into()),
+            database_path: Some(db_path),
         }
     }
 
@@ -85,7 +124,7 @@ impl AgentBus {
         // Persist to SQLite if configured
         if let Some(ref db_path) = self.database_path {
             let store = AgentBusStore::new(db_path);
-            if let Err(e) = store.store_message(&message) {
+            if let Err(e) = store.store_message(&message.to_stored()) {
                 tracing::warn!(error = %e, channel = %message.channel, "failed to persist bus message");
             }
         }
@@ -131,7 +170,12 @@ impl AgentBus {
     pub fn history(&self, channel: &str, limit: usize) -> Vec<AgentMessage> {
         if let Some(ref db_path) = self.database_path {
             let store = AgentBusStore::new(db_path);
-            store.channel_messages(channel, limit).unwrap_or_default()
+            store
+                .channel_messages(channel, limit)
+                .unwrap_or_default()
+                .into_iter()
+                .map(AgentMessage::from_stored)
+                .collect()
         } else {
             Vec::new()
         }
@@ -215,194 +259,6 @@ fn rand_bits() -> u64 {
 
 fn now_iso8601() -> String {
     chrono::Utc::now().to_rfc3339()
-}
-
-// ---------------------------------------------------------------------------
-// SQLite persistence for bus messages
-// ---------------------------------------------------------------------------
-
-/// Persistent storage for agent bus messages.
-pub struct AgentBusStore {
-    database_path: std::path::PathBuf,
-}
-
-impl AgentBusStore {
-    pub fn new(database_path: &std::path::Path) -> Self {
-        let store = Self {
-            database_path: database_path.to_path_buf(),
-        };
-        if let Err(e) = store.ensure_table() {
-            tracing::warn!(error = %e, "failed to initialize agent_bus_messages table");
-        }
-        store
-    }
-
-    /// Ensure the agent_bus_messages table exists.
-    fn ensure_table(&self) -> Result<(), String> {
-        let conn = rusqlite::Connection::open(&self.database_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
-        conn.execute_batch(
-            "CREATE TABLE IF NOT EXISTS agent_bus_messages (
-                id TEXT PRIMARY KEY,
-                channel TEXT NOT NULL,
-                sender TEXT NOT NULL,
-                kind TEXT NOT NULL,
-                payload TEXT NOT NULL,
-                metadata TEXT NOT NULL DEFAULT '{}',
-                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-            );
-            CREATE INDEX IF NOT EXISTS idx_bus_messages_channel
-                ON agent_bus_messages(channel);
-            CREATE INDEX IF NOT EXISTS idx_bus_messages_sender
-                ON agent_bus_messages(sender);
-            CREATE INDEX IF NOT EXISTS idx_bus_messages_created_at
-                ON agent_bus_messages(created_at);",
-        )
-        .map_err(|e| format!("Failed to create table: {e}"))?;
-        Ok(())
-    }
-
-    /// Store a message.
-    pub fn store_message(&self, message: &AgentMessage) -> Result<(), String> {
-        let conn = rusqlite::Connection::open(&self.database_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
-        let metadata_json =
-            serde_json::to_string(&message.metadata).unwrap_or_else(|_| "{}".to_owned());
-        let kind_str = serde_json::to_string(&message.kind)
-            .unwrap_or_else(|_| "\"text\"".to_owned())
-            .trim_matches('"')
-            .to_owned();
-        conn.execute(
-            "INSERT OR REPLACE INTO agent_bus_messages (id, channel, sender, kind, payload, metadata, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            rusqlite::params![
-                message.id,
-                message.channel,
-                message.sender,
-                kind_str,
-                message.payload,
-                metadata_json,
-                message.timestamp,
-            ],
-        )
-        .map_err(|e| format!("Failed to insert message: {e}"))?;
-        Ok(())
-    }
-
-    /// Retrieve recent messages from a channel.
-    pub fn channel_messages(
-        &self,
-        channel: &str,
-        limit: usize,
-    ) -> Result<Vec<AgentMessage>, String> {
-        let conn = rusqlite::Connection::open(&self.database_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT id, channel, sender, kind, payload, metadata, created_at
-                 FROM agent_bus_messages
-                 WHERE channel = ?1
-                 ORDER BY created_at DESC
-                 LIMIT ?2",
-            )
-            .map_err(|e| format!("Failed to prepare query: {e}"))?;
-
-        let messages = stmt
-            .query_map(rusqlite::params![channel, limit], |row| {
-                let kind_str: String = row.get(3)?;
-                let metadata_str: String = row.get(5)?;
-                Ok(AgentMessage {
-                    id: row.get(0)?,
-                    channel: row.get(1)?,
-                    sender: row.get(2)?,
-                    kind: serde_json::from_value(serde_json::Value::String(kind_str))
-                        .unwrap_or(MessageKind::Text),
-                    payload: row.get(4)?,
-                    metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
-                    timestamp: row.get(6)?,
-                })
-            })
-            .map_err(|e| format!("Failed to query messages: {e}"))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("Failed to read messages: {e}"))?;
-
-        Ok(messages)
-    }
-
-    /// Count messages per channel.
-    pub fn channel_stats(&self) -> Result<Vec<(String, i64)>, String> {
-        let conn = rusqlite::Connection::open(&self.database_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT channel, COUNT(*) as cnt
-                 FROM agent_bus_messages
-                 GROUP BY channel
-                 ORDER BY cnt DESC",
-            )
-            .map_err(|e| format!("Failed to prepare query: {e}"))?;
-
-        let stats = stmt
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
-            .map_err(|e| format!("Failed to query stats: {e}"))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("Failed to read stats: {e}"))?;
-
-        Ok(stats)
-    }
-}
-
-#[cfg(test)]
-impl AgentBusStore {
-    /// Get all messages from a sender.
-    pub fn sender_messages(&self, sender: &str, limit: usize) -> Result<Vec<AgentMessage>, String> {
-        let conn = rusqlite::Connection::open(&self.database_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
-        let mut stmt = conn
-            .prepare(
-                "SELECT id, channel, sender, kind, payload, metadata, created_at
-                 FROM agent_bus_messages
-                 WHERE sender = ?1
-                 ORDER BY created_at DESC
-                 LIMIT ?2",
-            )
-            .map_err(|e| format!("Failed to prepare query: {e}"))?;
-
-        let messages = stmt
-            .query_map(rusqlite::params![sender, limit], |row| {
-                let kind_str: String = row.get(3)?;
-                let metadata_str: String = row.get(5)?;
-                Ok(AgentMessage {
-                    id: row.get(0)?,
-                    channel: row.get(1)?,
-                    sender: row.get(2)?,
-                    kind: serde_json::from_value(serde_json::Value::String(kind_str))
-                        .unwrap_or(MessageKind::Text),
-                    payload: row.get(4)?,
-                    metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
-                    timestamp: row.get(6)?,
-                })
-            })
-            .map_err(|e| format!("Failed to query messages: {e}"))?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("Failed to read messages: {e}"))?;
-
-        Ok(messages)
-    }
-
-    /// Purge messages older than N days.
-    pub fn purge_older_than(&self, days: u32) -> Result<usize, String> {
-        let conn = rusqlite::Connection::open(&self.database_path)
-            .map_err(|e| format!("Failed to open database: {e}"))?;
-        let rows = conn
-            .execute(
-                "DELETE FROM agent_bus_messages
-                 WHERE created_at < datetime('now', ?1)",
-                rusqlite::params![format!("-{days} days")],
-            )
-            .map_err(|e| format!("Failed to purge messages: {e}"))?;
-        Ok(rows)
-    }
 }
 
 #[cfg(test)]
@@ -531,12 +387,24 @@ mod tests {
         assert_eq!(channels, vec!["alpha", "beta"]);
     }
 
+    /// Helper to create a test store with table initialized.
+    fn test_store(db_path: &std::path::Path) -> AgentBusStore {
+        let store = AgentBusStore::new(db_path);
+        store.ensure_table().expect("ensure_table");
+        store
+    }
+
+    /// Helper to create a `StoredBusMessage` from an `AgentMessage`.
+    fn to_stored(msg: &AgentMessage) -> StoredBusMessage {
+        msg.to_stored()
+    }
+
     #[test]
     fn bus_store_persistence() {
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("bus.db");
 
-        let store = AgentBusStore::new(&db_path);
+        let store = test_store(&db_path);
 
         let msg = AgentMessage {
             id: "persist-1".into(),
@@ -547,7 +415,7 @@ mod tests {
             metadata: HashMap::new(),
             timestamp: "2025-06-01T12:00:00Z".into(),
         };
-        store.store_message(&msg).unwrap();
+        store.store_message(&to_stored(&msg)).unwrap();
 
         let messages = store.channel_messages("logs", 10).unwrap();
         assert_eq!(messages.len(), 1);
@@ -560,33 +428,31 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("bus.db");
 
-        let store = AgentBusStore::new(&db_path);
+        let store = test_store(&db_path);
 
         for i in 0..5 {
-            store
-                .store_message(&AgentMessage {
-                    id: format!("a-{i}"),
-                    channel: "alpha".into(),
-                    sender: "s".into(),
-                    kind: MessageKind::Text,
-                    payload: "msg".into(),
-                    metadata: HashMap::new(),
-                    timestamp: now_iso8601(),
-                })
-                .unwrap();
+            let msg = AgentMessage {
+                id: format!("a-{i}"),
+                channel: "alpha".into(),
+                sender: "s".into(),
+                kind: MessageKind::Text,
+                payload: "msg".into(),
+                metadata: HashMap::new(),
+                timestamp: now_iso8601(),
+            };
+            store.store_message(&to_stored(&msg)).unwrap();
         }
         for i in 0..3 {
-            store
-                .store_message(&AgentMessage {
-                    id: format!("b-{i}"),
-                    channel: "beta".into(),
-                    sender: "s".into(),
-                    kind: MessageKind::Text,
-                    payload: "msg".into(),
-                    metadata: HashMap::new(),
-                    timestamp: now_iso8601(),
-                })
-                .unwrap();
+            let msg = AgentMessage {
+                id: format!("b-{i}"),
+                channel: "beta".into(),
+                sender: "s".into(),
+                kind: MessageKind::Text,
+                payload: "msg".into(),
+                metadata: HashMap::new(),
+                timestamp: now_iso8601(),
+            };
+            store.store_message(&to_stored(&msg)).unwrap();
         }
 
         let stats = store.channel_stats().unwrap();
@@ -600,30 +466,29 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("bus.db");
 
-        let store = AgentBusStore::new(&db_path);
+        let store = test_store(&db_path);
 
-        store
-            .store_message(&AgentMessage {
-                id: "s1".into(),
-                channel: "ch".into(),
-                sender: "agent-a".into(),
-                kind: MessageKind::Text,
-                payload: "from a".into(),
-                metadata: HashMap::new(),
-                timestamp: now_iso8601(),
-            })
-            .unwrap();
-        store
-            .store_message(&AgentMessage {
-                id: "s2".into(),
-                channel: "ch".into(),
-                sender: "agent-b".into(),
-                kind: MessageKind::TaskResult,
-                payload: "from b".into(),
-                metadata: HashMap::new(),
-                timestamp: now_iso8601(),
-            })
-            .unwrap();
+        let msg1 = AgentMessage {
+            id: "s1".into(),
+            channel: "ch".into(),
+            sender: "agent-a".into(),
+            kind: MessageKind::Text,
+            payload: "from a".into(),
+            metadata: HashMap::new(),
+            timestamp: now_iso8601(),
+        };
+        store.store_message(&to_stored(&msg1)).unwrap();
+
+        let msg2 = AgentMessage {
+            id: "s2".into(),
+            channel: "ch".into(),
+            sender: "agent-b".into(),
+            kind: MessageKind::TaskResult,
+            payload: "from b".into(),
+            metadata: HashMap::new(),
+            timestamp: now_iso8601(),
+        };
+        store.store_message(&to_stored(&msg2)).unwrap();
 
         let msgs = store.sender_messages("agent-a", 10).unwrap();
         assert_eq!(msgs.len(), 1);

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -40,7 +40,9 @@ use genesis_config::{load, GenesisConfig, LoadedConfig};
 use genesis_lua::{LuaHostToolExecutor, LuaRuntime, LuaToolOutput};
 use genesis_mcp::McpManager;
 use genesis_provider::resolve;
-use genesis_storage::{bootstrap, inspect, SessionStore, StorageHealth};
+use genesis_storage::{
+    bootstrap, inspect, integrity_check, ScheduleStore, SessionStore, SkillStore, StorageHealth,
+};
 use genesis_tools::{
     default_registry, ApprovalPolicy, ToolCall, ToolContext, ToolError, ToolHandler, ToolOutput,
     ToolRegistry,
@@ -439,20 +441,8 @@ fn check_tool_registry() -> DoctorCheck {
 /// Gather storage statistics: session, skill, and schedule counts.
 fn check_storage_stats(db_path: &Path) -> DoctorCheck {
     let sessions = SessionStore::new(db_path).session_count().unwrap_or(0);
-
-    // Use direct COUNT(*) queries to avoid loading full rows
-    let (skills, schedules) = match rusqlite::Connection::open(db_path) {
-        Ok(conn) => {
-            let skills: i64 = conn
-                .query_row("SELECT COUNT(*) FROM skills", [], |r| r.get(0))
-                .unwrap_or(0);
-            let schedules: i64 = conn
-                .query_row("SELECT COUNT(*) FROM schedules", [], |r| r.get(0))
-                .unwrap_or(0);
-            (skills as u64, schedules as u64)
-        }
-        Err(_) => (0, 0),
-    };
+    let skills = SkillStore::new(db_path).count().unwrap_or(0);
+    let schedules = ScheduleStore::new(db_path).count().unwrap_or(0);
 
     DoctorCheck {
         name: "storage_stats".to_owned(),
@@ -463,30 +453,21 @@ fn check_storage_stats(db_path: &Path) -> DoctorCheck {
 
 /// Run PRAGMA integrity_check on the database.
 fn check_database_integrity(db_path: &Path) -> DoctorCheck {
-    match rusqlite::Connection::open(db_path) {
-        Ok(conn) => {
-            match conn.query_row("PRAGMA integrity_check", [], |row| row.get::<_, String>(0)) {
-                Ok(result) if result == "ok" => DoctorCheck {
-                    name: "db_integrity".to_owned(),
-                    status: CheckStatus::Pass,
-                    detail: "integrity check passed".to_owned(),
-                },
-                Ok(result) => DoctorCheck {
-                    name: "db_integrity".to_owned(),
-                    status: CheckStatus::Fail,
-                    detail: format!("integrity issue: {result}"),
-                },
-                Err(e) => DoctorCheck {
-                    name: "db_integrity".to_owned(),
-                    status: CheckStatus::Fail,
-                    detail: format!("integrity check failed: {e}"),
-                },
-            }
-        }
+    match integrity_check(db_path) {
+        Ok(result) if result == "ok" => DoctorCheck {
+            name: "db_integrity".to_owned(),
+            status: CheckStatus::Pass,
+            detail: "integrity check passed".to_owned(),
+        },
+        Ok(result) => DoctorCheck {
+            name: "db_integrity".to_owned(),
+            status: CheckStatus::Fail,
+            detail: format!("integrity issue: {result}"),
+        },
         Err(e) => DoctorCheck {
             name: "db_integrity".to_owned(),
             status: CheckStatus::Fail,
-            detail: format!("cannot open database: {e}"),
+            detail: format!("integrity check failed: {e}"),
         },
     }
 }

--- a/crates/genesis-core/src/nudge.rs
+++ b/crates/genesis-core/src/nudge.rs
@@ -6,7 +6,8 @@
 
 use genesis_config::LoadedConfig;
 use genesis_storage::{
-    bootstrap, format_user_traits, SessionStore, SkillStore, SkillUsageStore, UserModelStore,
+    bootstrap, format_user_traits, MemoryStore, SessionStore, SkillStore, SkillUsageStore,
+    UserModelStore,
 };
 
 use crate::execution::{SessionExecutionError, SessionExecutionService, SessionTurnInput};
@@ -112,25 +113,8 @@ pub async fn run_nudge(
 }
 
 fn load_memories_section(db_path: &std::path::Path) -> Option<String> {
-    let connection = rusqlite::Connection::open(db_path).ok()?;
-    let mut stmt = connection
-        .prepare(
-            "SELECT kind, content, created_at FROM memories
-             ORDER BY created_at DESC LIMIT 50",
-        )
-        .ok()?;
-
-    let memories: Vec<(String, String, String)> = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-            ))
-        })
-        .ok()?
-        .filter_map(|r| r.ok())
-        .collect();
+    let store = MemoryStore::new(db_path);
+    let memories = store.list(50).ok()?;
 
     if memories.is_empty() {
         return None;
@@ -138,7 +122,7 @@ fn load_memories_section(db_path: &std::path::Path) -> Option<String> {
 
     let lines: Vec<String> = memories
         .iter()
-        .map(|(kind, content, created_at)| format!("- [{}] {} ({})", kind, content, created_at))
+        .map(|m| format!("- [{}] {} ({})", m.kind, m.content, m.created_at))
         .collect();
 
     Some(lines.join("\n"))

--- a/crates/genesis-storage/src/lib.rs
+++ b/crates/genesis-storage/src/lib.rs
@@ -1498,6 +1498,22 @@ pub fn inspect(database_path: &Path) -> Result<StorageHealth, StorageError> {
     })
 }
 
+/// Run `PRAGMA integrity_check` and return the result string.
+///
+/// Returns `Ok("ok")` when the database is healthy. Any other value
+/// indicates corruption.
+pub fn integrity_check(database_path: &Path) -> Result<String, StorageError> {
+    let connection = open(database_path)?;
+    connection
+        .query_row("PRAGMA integrity_check", [], |row| {
+            row.get::<_, String>(0)
+        })
+        .map_err(|source| StorageError::Sqlite {
+            path: database_path.to_path_buf(),
+            source,
+        })
+}
+
 pub fn discover_legacy_source(root: &Path) -> LegacyImportSource {
     let config_path = first_existing_file(
         [
@@ -3048,6 +3064,19 @@ impl ScheduleStore {
 
         collect_rows(rows, self.db.path())
     }
+
+    /// Count total number of schedules.
+    pub fn count(&self) -> Result<u64, StorageError> {
+        let connection = open(&self.database_path)?;
+        connection
+            .query_row("SELECT COUNT(*) FROM schedules", [], |row| {
+                Ok(row.get::<_, i64>(0)? as u64)
+            })
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })
+    }
 }
 
 /// A stored user trait — an observation about the user's preferences, personality, or goals.
@@ -3603,6 +3632,19 @@ impl SkillStore {
                 source,
             })?;
         Ok(rows_changed > 0)
+    }
+
+    /// Count total number of skills.
+    pub fn count(&self) -> Result<u64, StorageError> {
+        let connection = open(&self.database_path)?;
+        connection
+            .query_row("SELECT COUNT(*) FROM skills", [], |row| {
+                Ok(row.get::<_, i64>(0)? as u64)
+            })
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })
     }
 }
 
@@ -6557,6 +6599,218 @@ impl SandboxStore {
             )
             .map_err(|source| StorageError::Sqlite {
                 path: self.db.path().to_path_buf(),
+                source,
+            })?;
+        Ok(deleted)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Agent Bus Store
+// ---------------------------------------------------------------------------
+
+/// A message on the agent bus (storage representation).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredBusMessage {
+    /// Unique message ID.
+    pub id: String,
+    /// Channel this message was published to.
+    pub channel: String,
+    /// Sender agent/session ID.
+    pub sender: String,
+    /// Message type for routing and filtering.
+    pub kind: String,
+    /// The message payload.
+    pub payload: String,
+    /// Optional structured metadata (JSON).
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    /// ISO 8601 timestamp.
+    pub timestamp: String,
+}
+
+/// Persistent storage for agent bus messages.
+pub struct AgentBusStore {
+    database_path: PathBuf,
+}
+
+impl AgentBusStore {
+    pub fn new(database_path: &Path) -> Self {
+        Self {
+            database_path: database_path.to_path_buf(),
+        }
+    }
+
+    /// Ensure the agent_bus_messages table exists.
+    pub fn ensure_table(&self) -> Result<(), StorageError> {
+        let conn = open(&self.database_path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS agent_bus_messages (
+                id TEXT PRIMARY KEY,
+                channel TEXT NOT NULL,
+                sender TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                metadata TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_bus_messages_channel
+                ON agent_bus_messages(channel);
+            CREATE INDEX IF NOT EXISTS idx_bus_messages_sender
+                ON agent_bus_messages(sender);
+            CREATE INDEX IF NOT EXISTS idx_bus_messages_created_at
+                ON agent_bus_messages(created_at);",
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: self.database_path.clone(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    /// Store a message.
+    pub fn store_message(&self, message: &StoredBusMessage) -> Result<(), StorageError> {
+        let conn = open(&self.database_path)?;
+        let metadata_json =
+            serde_json::to_string(&message.metadata).unwrap_or_else(|_| "{}".to_owned());
+        conn.execute(
+            "INSERT OR REPLACE INTO agent_bus_messages (id, channel, sender, kind, payload, metadata, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                message.id,
+                message.channel,
+                message.sender,
+                message.kind,
+                message.payload,
+                metadata_json,
+                message.timestamp,
+            ],
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: self.database_path.clone(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    /// Retrieve recent messages from a channel.
+    pub fn channel_messages(
+        &self,
+        channel: &str,
+        limit: usize,
+    ) -> Result<Vec<StoredBusMessage>, StorageError> {
+        let conn = open(&self.database_path)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, channel, sender, kind, payload, metadata, created_at
+                 FROM agent_bus_messages
+                 WHERE channel = ?1
+                 ORDER BY created_at DESC
+                 LIMIT ?2",
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+
+        let rows = stmt
+            .query_map(params![channel, limit as i64], |row| {
+                let metadata_str: String = row.get(5)?;
+                Ok(StoredBusMessage {
+                    id: row.get(0)?,
+                    channel: row.get(1)?,
+                    sender: row.get(2)?,
+                    kind: row.get(3)?,
+                    payload: row.get(4)?,
+                    metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
+                    timestamp: row.get(6)?,
+                })
+            })
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+
+        collect_rows(rows, &self.database_path)
+    }
+
+    /// Count messages per channel.
+    pub fn channel_stats(&self) -> Result<Vec<(String, i64)>, StorageError> {
+        let conn = open(&self.database_path)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT channel, COUNT(*) as cnt
+                 FROM agent_bus_messages
+                 GROUP BY channel
+                 ORDER BY cnt DESC",
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+
+        collect_rows(rows, &self.database_path)
+    }
+
+    /// Get all messages from a sender.
+    pub fn sender_messages(
+        &self,
+        sender: &str,
+        limit: usize,
+    ) -> Result<Vec<StoredBusMessage>, StorageError> {
+        let conn = open(&self.database_path)?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, channel, sender, kind, payload, metadata, created_at
+                 FROM agent_bus_messages
+                 WHERE sender = ?1
+                 ORDER BY created_at DESC
+                 LIMIT ?2",
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+
+        let rows = stmt
+            .query_map(params![sender, limit as i64], |row| {
+                let metadata_str: String = row.get(5)?;
+                Ok(StoredBusMessage {
+                    id: row.get(0)?,
+                    channel: row.get(1)?,
+                    sender: row.get(2)?,
+                    kind: row.get(3)?,
+                    payload: row.get(4)?,
+                    metadata: serde_json::from_str(&metadata_str).unwrap_or_default(),
+                    timestamp: row.get(6)?,
+                })
+            })
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
+                source,
+            })?;
+
+        collect_rows(rows, &self.database_path)
+    }
+
+    /// Purge messages older than N days.
+    pub fn purge_older_than(&self, days: u32) -> Result<usize, StorageError> {
+        let conn = open(&self.database_path)?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM agent_bus_messages
+                 WHERE created_at < datetime('now', ?1)",
+                params![format!("-{days} days")],
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: self.database_path.clone(),
                 source,
             })?;
         Ok(deleted)


### PR DESCRIPTION
## Summary

- Moves all raw SQL queries from `genesis-core` and `genesis-cli` into `genesis-storage`, enforcing the storage abstraction boundary
- Adds `SkillStore::count()`, `ScheduleStore::count()`, and `integrity_check()` to genesis-storage
- Moves `AgentBusStore` (with `StoredBusMessage` type) from `genesis-core/src/agent_bus.rs` into `genesis-storage`
- Replaces raw `rusqlite` usage in `genesis-core/src/lib.rs` (doctor checks), `nudge.rs` (memory loading), and `agent_bus.rs` (bus persistence) with proper Store API calls

## Files changed

| File | Change |
|------|--------|
| `crates/genesis-storage/src/lib.rs` | +254 lines: new `SkillStore::count()`, `ScheduleStore::count()`, `integrity_check()`, `AgentBusStore`, `StoredBusMessage` |
| `crates/genesis-core/src/agent_bus.rs` | Removed local `AgentBusStore` impl with raw SQL, re-exports from genesis-storage, added conversion between `AgentMessage` and `StoredBusMessage` |
| `crates/genesis-core/src/lib.rs` | Replaced raw `rusqlite` queries in `check_storage_stats` and `check_database_integrity` with store methods |
| `crates/genesis-core/src/nudge.rs` | Replaced raw SQL in `load_memories_section` with `MemoryStore::list(50)` |
| `crates/genesis-cli/src/slash.rs` | Updated to use re-exported `AgentBusStore` from genesis-storage |

## Test plan

- [x] `cargo build --workspace` compiles cleanly
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo test --workspace` — all 2,643 tests pass (0 failures)
- [x] Specifically verified `genesis-storage` (163 tests), `genesis-core` (713 tests), and `genesis-gateway` (178 tests)

Fixes #277