### PR TITLE
fix(gateway): replace format! errors with structured PlatformError

### DIFF
--- a/crates/genesis-gateway/src/platforms/discord.rs
+++ b/crates/genesis-gateway/src/platforms/discord.rs
@@ -351,7 +351,9 @@ async fn edit_followup(
     application_id: &str,
     interaction_token: &str,
     content: &str,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     // Discord has a 2000 character limit for messages
     let truncated = if content.len() > 2000 {
         format!("{}...", &content[..1997])
@@ -369,12 +371,19 @@ async fn edit_followup(
         })
         .send()
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(|source| super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::Discord,
+            source,
+        })?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("Discord API error {status}: {body}"));
+        return Err(super::PlatformError::ApiError {
+            platform: DeliveryPlatform::Discord,
+            status,
+            body,
+        });
     }
 
     Ok(())

--- a/crates/genesis-gateway/src/platforms/mod.rs
+++ b/crates/genesis-gateway/src/platforms/mod.rs
@@ -7,8 +7,63 @@ pub mod whatsapp;
 
 use genesis_core::execution::{SessionExecutionError, SessionTurnOutcome};
 use genesis_storage::PairingStore;
+use genesis_types::DeliveryPlatform;
 use std::collections::HashSet;
 use std::path::Path;
+
+/// Structured error type for platform webhook handler operations.
+///
+/// Replaces generic `format!`-based string errors throughout platform handlers,
+/// preserving the source error type for pattern matching, retry decisions, and
+/// structured logging.
+#[derive(Debug, thiserror::Error)]
+pub enum PlatformError {
+    /// An outbound HTTP request to a platform API failed at the transport level.
+    #[error("{platform} HTTP request failed: {source}")]
+    HttpRequest {
+        platform: DeliveryPlatform,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// The platform API returned a non-success HTTP status code.
+    #[error("{platform} API returned {status}: {body}")]
+    ApiError {
+        platform: DeliveryPlatform,
+        status: reqwest::StatusCode,
+        body: String,
+    },
+
+    /// Failed to deserialize a response from the platform API.
+    #[error("{platform} response parse failed: {source}")]
+    ResponseParse {
+        platform: DeliveryPlatform,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// The platform API returned a logical error (e.g. `ok: false`).
+    #[error("{platform} API error: {detail}")]
+    ApiLogicError {
+        platform: DeliveryPlatform,
+        detail: String,
+    },
+
+    /// A required configuration value (env var, token) is missing.
+    #[error("{platform} configuration missing: {detail}")]
+    ConfigMissing {
+        platform: DeliveryPlatform,
+        detail: String,
+    },
+
+    /// A platform-specific operation failed (file download, transcription, etc.).
+    #[error("{platform} {operation} failed: {detail}")]
+    OperationFailed {
+        platform: DeliveryPlatform,
+        operation: &'static str,
+        detail: String,
+    },
+}
 
 /// Extract the reply text from a `run_turn` result, logging success or failure.
 ///
@@ -275,5 +330,79 @@ mod tests {
         let reply = pairing_reply("ABCD1234");
         assert!(reply.contains("ABCD1234"));
         assert!(reply.contains("genesis pairing approve"));
+    }
+
+    #[test]
+    fn platform_error_http_request_display_includes_platform() {
+        // We can't easily construct a reqwest::Error, so test the other variants.
+        let err = PlatformError::ApiError {
+            platform: DeliveryPlatform::Telegram,
+            status: reqwest::StatusCode::FORBIDDEN,
+            body: "bot was blocked".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("telegram"), "should contain platform name: {msg}");
+        assert!(msg.contains("403"), "should contain status code: {msg}");
+        assert!(msg.contains("bot was blocked"), "should contain body: {msg}");
+    }
+
+    #[test]
+    fn platform_error_api_logic_error_display() {
+        let err = PlatformError::ApiLogicError {
+            platform: DeliveryPlatform::Slack,
+            detail: "channel_not_found".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("slack"));
+        assert!(msg.contains("channel_not_found"));
+    }
+
+    #[test]
+    fn platform_error_config_missing_display() {
+        let err = PlatformError::ConfigMissing {
+            platform: DeliveryPlatform::WhatsApp,
+            detail: "WHATSAPP_TOKEN not set".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("whatsapp"));
+        assert!(msg.contains("WHATSAPP_TOKEN not set"));
+    }
+
+    #[test]
+    fn platform_error_operation_failed_display() {
+        let err = PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "file download",
+            detail: "downloaded file is empty".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("telegram"));
+        assert!(msg.contains("file download"));
+        assert!(msg.contains("downloaded file is empty"));
+    }
+
+    #[test]
+    fn platform_error_response_parse_display_includes_platform() {
+        // ResponseParse requires a reqwest::Error source which is hard to construct.
+        // Verify the ApiError variant works for Signal to confirm platform Display.
+        let err = PlatformError::ApiError {
+            platform: DeliveryPlatform::Signal,
+            status: reqwest::StatusCode::BAD_GATEWAY,
+            body: "upstream timeout".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("signal"));
+        assert!(msg.contains("502"));
+    }
+
+    #[test]
+    fn platform_error_is_debug() {
+        let err = PlatformError::ApiLogicError {
+            platform: DeliveryPlatform::Discord,
+            detail: "unknown interaction".to_owned(),
+        };
+        let debug = format!("{err:?}");
+        assert!(debug.contains("ApiLogicError"));
+        assert!(debug.contains("Discord"));
     }
 }

--- a/crates/genesis-gateway/src/platforms/signal.rs
+++ b/crates/genesis-gateway/src/platforms/signal.rs
@@ -577,7 +577,7 @@ async fn send_message(
     recipient: &str,
     text: &str,
     quote_timestamp: Option<u64>,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
     let chunks = split_message(text, MAX_SIGNAL_MESSAGE_LEN);
 
     for (i, chunk) in chunks.iter().enumerate() {
@@ -615,7 +615,7 @@ async fn send_group_message(
     account: &str,
     group_id: &str,
     text: &str,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
     let chunks = split_message(text, MAX_SIGNAL_MESSAGE_LEN);
 
     for chunk in &chunks {
@@ -645,7 +645,7 @@ async fn send_typing_indicator(
     account: &str,
     recipient: &str,
     is_group: bool,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
     let mut params = serde_json::json!({
         "account": account,
     });
@@ -673,7 +673,7 @@ async fn send_typing_stop(
     account: &str,
     recipient: &str,
     is_group: bool,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
     let mut params = serde_json::json!({
         "account": account,
     });
@@ -699,7 +699,9 @@ async fn send_rpc(
     client: &reqwest::Client,
     base_url: &str,
     request: &JsonRpcRequest,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     let url = format!("{}/api/v1/rpc", base_url.trim_end_matches('/'));
 
     let resp = client
@@ -707,24 +709,33 @@ async fn send_rpc(
         .json(request)
         .send()
         .await
-        .map_err(|e| format!("signal-cli RPC request failed: {e}"))?;
+        .map_err(|source| super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::Signal,
+            source,
+        })?;
 
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("signal-cli RPC returned {status}: {body}"));
+        return Err(super::PlatformError::ApiError {
+            platform: DeliveryPlatform::Signal,
+            status,
+            body,
+        });
     }
 
-    let rpc_resp: JsonRpcResponse = resp
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse signal-cli RPC response: {e}"))?;
+    let rpc_resp: JsonRpcResponse = resp.json().await.map_err(|source| {
+        super::PlatformError::ResponseParse {
+            platform: DeliveryPlatform::Signal,
+            source,
+        }
+    })?;
 
     if let Some(err) = rpc_resp.error {
-        return Err(format!(
-            "signal-cli RPC error {}: {}",
-            err.code, err.message
-        ));
+        return Err(super::PlatformError::ApiLogicError {
+            platform: DeliveryPlatform::Signal,
+            detail: format!("RPC error {}: {}", err.code, err.message),
+        });
     }
 
     Ok(())

--- a/crates/genesis-gateway/src/platforms/slack.rs
+++ b/crates/genesis-gateway/src/platforms/slack.rs
@@ -275,7 +275,9 @@ async fn post_message(
     channel: &str,
     text: &str,
     thread_ts: Option<&str>,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     let resp = client
         .post("https://slack.com/api/chat.postMessage")
         .bearer_auth(token)
@@ -286,18 +288,26 @@ async fn post_message(
         })
         .send()
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(|source| super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::Slack,
+            source,
+        })?;
 
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse response: {e}"))?;
+    let body: serde_json::Value = resp.json().await.map_err(|source| {
+        super::PlatformError::ResponseParse {
+            platform: DeliveryPlatform::Slack,
+            source,
+        }
+    })?;
 
     if body["ok"].as_bool() != Some(true) {
-        return Err(format!(
-            "Slack API error: {}",
-            body["error"].as_str().unwrap_or("unknown")
-        ));
+        return Err(super::PlatformError::ApiLogicError {
+            platform: DeliveryPlatform::Slack,
+            detail: body["error"]
+                .as_str()
+                .unwrap_or("unknown")
+                .to_owned(),
+        });
     }
 
     Ok(())

--- a/crates/genesis-gateway/src/platforms/telegram.rs
+++ b/crates/genesis-gateway/src/platforms/telegram.rs
@@ -150,41 +150,64 @@ async fn telegram_fetch_file(
     client: &reqwest::Client,
     token: &str,
     file_id: &str,
-) -> Result<(Vec<u8>, String), String> {
+) -> Result<(Vec<u8>, String), super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     let get_file_url = format!("https://api.telegram.org/bot{token}/getFile");
     let resp = client
         .post(&get_file_url)
         .json(&serde_json::json!({ "file_id": file_id }))
         .send()
         .await
-        .map_err(|e| format!("getFile request failed: {e}"))?;
+        .map_err(|source| super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::Telegram,
+            source,
+        })?;
 
-    let file_resp: GetFileResponse = resp
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse getFile response: {e}"))?;
+    let file_resp: GetFileResponse = resp.json().await.map_err(|source| {
+        super::PlatformError::ResponseParse {
+            platform: DeliveryPlatform::Telegram,
+            source,
+        }
+    })?;
 
     if !file_resp.ok {
-        return Err("Telegram getFile returned not ok".to_owned());
+        return Err(super::PlatformError::ApiLogicError {
+            platform: DeliveryPlatform::Telegram,
+            detail: "getFile returned not ok".to_owned(),
+        });
     }
 
     let file_path = file_resp
         .result
         .and_then(|r| r.file_path)
-        .ok_or_else(|| "no file_path in getFile response".to_owned())?;
+        .ok_or_else(|| super::PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "getFile",
+            detail: "no file_path in response".to_owned(),
+        })?;
 
     let download_url = format!("https://api.telegram.org/file/bot{token}/{file_path}");
-    let file_bytes = client
-        .get(&download_url)
-        .send()
-        .await
-        .map_err(|e| format!("file download failed: {e}"))?
-        .bytes()
-        .await
-        .map_err(|e| format!("failed to read file bytes: {e}"))?;
+    let download_resp = client.get(&download_url).send().await.map_err(|source| {
+        super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::Telegram,
+            source,
+        }
+    })?;
+
+    let file_bytes = download_resp.bytes().await.map_err(|source| {
+        super::PlatformError::ResponseParse {
+            platform: DeliveryPlatform::Telegram,
+            source,
+        }
+    })?;
 
     if file_bytes.is_empty() {
-        return Err("downloaded file is empty".to_owned());
+        return Err(super::PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "file download",
+            detail: "downloaded file is empty".to_owned(),
+        });
     }
 
     Ok((file_bytes.to_vec(), file_path))
@@ -198,12 +221,17 @@ async fn transcribe_telegram_audio(
     client: &reqwest::Client,
     token: &str,
     file_id: &str,
-) -> Result<String, String> {
+) -> Result<String, super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     let (audio_bytes, file_path) = telegram_fetch_file(client, token, file_id).await?;
 
     // Transcribe via Whisper API.
-    let api_key = std::env::var("OPENAI_API_KEY")
-        .map_err(|_| "OPENAI_API_KEY not set, cannot transcribe".to_owned())?;
+    let api_key =
+        std::env::var("OPENAI_API_KEY").map_err(|_| super::PlatformError::ConfigMissing {
+            platform: DeliveryPlatform::Telegram,
+            detail: "OPENAI_API_KEY not set, cannot transcribe".to_owned(),
+        })?;
 
     let api_base =
         std::env::var("OPENAI_API_BASE").unwrap_or_else(|_| "https://api.openai.com/v1".to_owned());
@@ -223,7 +251,11 @@ async fn transcribe_telegram_audio(
     let file_part = reqwest::multipart::Part::bytes(audio_bytes.to_vec())
         .file_name(format!("voice.{ext}"))
         .mime_str(mime)
-        .map_err(|e| format!("failed to build multipart: {e}"))?;
+        .map_err(|e| super::PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "multipart build",
+            detail: e.to_string(),
+        })?;
 
     let form = reqwest::multipart::Form::new()
         .part("file", file_part)
@@ -238,18 +270,27 @@ async fn transcribe_telegram_audio(
         .multipart(form)
         .send()
         .await
-        .map_err(|e| format!("Whisper API request failed: {e}"))?;
+        .map_err(|source| super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::Telegram,
+            source,
+        })?;
 
     let status = whisper_resp.status();
     if !status.is_success() {
         let body = whisper_resp.text().await.unwrap_or_default();
-        return Err(format!("Whisper API returned {status}: {body}"));
+        return Err(super::PlatformError::ApiError {
+            platform: DeliveryPlatform::Telegram,
+            status,
+            body,
+        });
     }
 
-    let result: WhisperResponse = whisper_resp
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse Whisper response: {e}"))?;
+    let result: WhisperResponse = whisper_resp.json().await.map_err(|source| {
+        super::PlatformError::ResponseParse {
+            platform: DeliveryPlatform::Telegram,
+            source,
+        }
+    })?;
 
     Ok(result.text)
 }
@@ -329,7 +370,9 @@ async fn analyze_sticker_image(
     token: &str,
     file_id: &str,
     config: &genesis_config::GenesisConfig,
-) -> Result<String, String> {
+) -> Result<String, super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     let (image_bytes, file_path) = telegram_fetch_file(client, token, file_id).await?;
 
     // Determine MIME type from file extension.
@@ -355,8 +398,13 @@ async fn analyze_sticker_image(
         &env,
     );
 
-    let vision_client = genesis_provider::ChatClient::new(&provider)
-        .map_err(|e| format!("failed to create vision client: {e}"))?;
+    let vision_client = genesis_provider::ChatClient::new(&provider).map_err(|e| {
+        super::PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "vision client creation",
+            detail: e.to_string(),
+        }
+    })?;
 
     let request = genesis_provider::ChatCompletionRequest {
         model: String::new(), // ChatClient fills this from its config
@@ -379,10 +427,13 @@ async fn analyze_sticker_image(
         extra_body: config.provider.extra_body.clone(),
     };
 
-    let response = vision_client
-        .complete(request)
-        .await
-        .map_err(|e| format!("vision LLM call failed: {e}"))?;
+    let response = vision_client.complete(request).await.map_err(|e| {
+        super::PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "vision LLM call",
+            detail: e.to_string(),
+        }
+    })?;
 
     let description = response
         .choices
@@ -390,7 +441,11 @@ async fn analyze_sticker_image(
         .and_then(|c| c.message.content.as_ref())
         .and_then(|c| c.text())
         .map(|t| t.trim().to_owned())
-        .ok_or_else(|| "vision LLM returned empty response".to_owned())?;
+        .ok_or_else(|| super::PlatformError::OperationFailed {
+            platform: DeliveryPlatform::Telegram,
+            operation: "vision LLM call",
+            detail: "empty response".to_owned(),
+        })?;
 
     Ok(description)
 }
@@ -673,7 +728,9 @@ async fn send_reply(
     chat_id: i64,
     text: &str,
     reply_to: Option<i64>,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     // Telegram messages have a 4096 character limit.
     // Split long responses into chunks.
     let chunks = split_message(text, 4096);
@@ -693,18 +750,24 @@ async fn send_reply(
             })
             .send()
             .await
-            .map_err(|e| format!("HTTP request failed: {e}"))?;
+            .map_err(|source| super::PlatformError::HttpRequest {
+                platform: DeliveryPlatform::Telegram,
+                source,
+            })?;
 
-        let api_resp: TelegramApiResponse = resp
-            .json()
-            .await
-            .map_err(|e| format!("failed to parse response: {e}"))?;
+        let api_resp: TelegramApiResponse =
+            resp.json().await.map_err(|source| {
+                super::PlatformError::ResponseParse {
+                    platform: DeliveryPlatform::Telegram,
+                    source,
+                }
+            })?;
 
         if !api_resp.ok {
-            return Err(format!(
-                "Telegram API error: {}",
-                api_resp.description.unwrap_or_default()
-            ));
+            return Err(super::PlatformError::ApiLogicError {
+                platform: DeliveryPlatform::Telegram,
+                detail: api_resp.description.unwrap_or_default(),
+            });
         }
     }
 

--- a/crates/genesis-gateway/src/platforms/whatsapp.rs
+++ b/crates/genesis-gateway/src/platforms/whatsapp.rs
@@ -366,7 +366,9 @@ async fn send_reply(
     phone_number_id: &str,
     to: &str,
     text: &str,
-) -> Result<(), String> {
+) -> Result<(), super::PlatformError> {
+    use genesis_types::DeliveryPlatform;
+
     let url = format!("https://graph.facebook.com/v21.0/{phone_number_id}/messages");
 
     // Truncate if needed (WhatsApp limit is ~4096 chars for text)
@@ -387,12 +389,19 @@ async fn send_reply(
         })
         .send()
         .await
-        .map_err(|e| format!("HTTP request failed: {e}"))?;
+        .map_err(|source| super::PlatformError::HttpRequest {
+            platform: DeliveryPlatform::WhatsApp,
+            source,
+        })?;
 
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("WhatsApp API error {status}: {body}"));
+        return Err(super::PlatformError::ApiError {
+            platform: DeliveryPlatform::WhatsApp,
+            status,
+            body,
+        });
     }
 
     Ok(())

--- a/crates/genesis-types/src/lib.rs
+++ b/crates/genesis-types/src/lib.rs
@@ -45,6 +45,21 @@ pub enum DeliveryPlatform {
     Signal,
 }
 
+impl std::fmt::Display for DeliveryPlatform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cli => write!(f, "cli"),
+            Self::Api => write!(f, "api"),
+            Self::Telegram => write!(f, "telegram"),
+            Self::Discord => write!(f, "discord"),
+            Self::Slack => write!(f, "slack"),
+            Self::HomeAssistant => write!(f, "homeassistant"),
+            Self::WhatsApp => write!(f, "whatsapp"),
+            Self::Signal => write!(f, "signal"),
+        }
+    }
+}
+
 /// Identifies the LLM provider backend used for inference.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -228,5 +243,17 @@ mod tests {
 
         assert_eq!(decoded_request, request);
         assert_eq!(decoded_response, response);
+    }
+
+    #[test]
+    fn delivery_platform_display_matches_snake_case() {
+        assert_eq!(DeliveryPlatform::Cli.to_string(), "cli");
+        assert_eq!(DeliveryPlatform::Api.to_string(), "api");
+        assert_eq!(DeliveryPlatform::Telegram.to_string(), "telegram");
+        assert_eq!(DeliveryPlatform::Discord.to_string(), "discord");
+        assert_eq!(DeliveryPlatform::Slack.to_string(), "slack");
+        assert_eq!(DeliveryPlatform::HomeAssistant.to_string(), "homeassistant");
+        assert_eq!(DeliveryPlatform::WhatsApp.to_string(), "whatsapp");
+        assert_eq!(DeliveryPlatform::Signal.to_string(), "signal");
     }
 }


### PR DESCRIPTION
## Summary
- Introduces a `PlatformError` enum in `platforms/mod.rs` with six structured variants (`HttpRequest`, `ApiError`, `ResponseParse`, `ApiLogicError`, `ConfigMissing`, `OperationFailed`) that replace 30+ generic `format!`-based string errors across all platform webhook handlers
- Adds a `Display` impl for `DeliveryPlatform` so every error message includes the platform name for log filtering
- Updates all outbound API functions in Telegram, Discord, Slack, WhatsApp, and Signal handlers to return `Result<_, PlatformError>` instead of `Result<_, String>`
- Adds tests for error display formatting and Debug output

## Why
String errors cannot be pattern-matched for specific failure modes, making it impossible to distinguish retryable errors (network timeouts) from permanent ones (auth failures) or to set up monitoring alerts for specific error categories. Structured errors enable all of these.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo test -p genesis-gateway` passes (200 tests including 6 new PlatformError tests)
- [x] `cargo test -p genesis-types` passes (3 tests including new Display test)
- [x] Verified zero remaining `format!` error patterns in platform handlers

Closes #295