### PR TITLE
refactor(gateway): extract platform handler abstractions

### DIFF
--- a/crates/genesis-gateway/src/platforms/discord.rs
+++ b/crates/genesis-gateway/src/platforms/discord.rs
@@ -15,11 +15,11 @@ use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
-use genesis_core::execution::SessionTurnInput;
 use genesis_types::DeliveryPlatform;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, info_span, warn, Instrument};
 
+use super::{PlatformMessage, ProcessOutcome};
 use crate::verify::verify_discord_signature;
 use crate::AppState;
 
@@ -181,6 +181,7 @@ pub async fn interactions_handler(
         let user_name = extract_username(&interaction);
         let channel_id = interaction.channel_id.clone().unwrap_or_default();
         let session_id = format!("discord-{channel_id}");
+        let discord_user_id = extract_user_id(&interaction).unwrap_or_default();
 
         let span = info_span!(
             "discord.interaction",
@@ -191,107 +192,45 @@ pub async fn interactions_handler(
 
         info!(parent: &span, "received discord interaction");
 
-        // DM pairing check
-        let discord_user_id = extract_user_id(&interaction).unwrap_or_default();
-        match super::check_pairing(
-            &state.loaded.config.storage.database_path,
-            "discord",
-            &discord_user_id,
-            &user_name,
-        ) {
-            Ok(super::PairingCheck::Approved) => {}
-            Ok(super::PairingCheck::NeedsPairing(code)) => {
-                let reply = super::pairing_reply(&code);
-                return Ok(Json(
-                    serde_json::to_value(InteractionResponse {
-                        response_type: RESPONSE_CHANNEL_MESSAGE,
-                        data: Some(InteractionResponseData { content: reply }),
-                    })
-                    .map_err(|e| {
-                        error!(error = %e, "failed to serialize interaction response");
-                        StatusCode::INTERNAL_SERVER_ERROR
-                    })?,
-                ));
-            }
-            Ok(super::PairingCheck::AtCapacity) => {
-                return Ok(Json(
-                    serde_json::to_value(InteractionResponse {
-                        response_type: RESPONSE_CHANNEL_MESSAGE,
-                        data: Some(InteractionResponseData {
-                            content: super::pairing_capacity_reply().to_owned(),
-                        }),
-                    })
-                    .map_err(|e| {
-                        error!(error = %e, "failed to serialize interaction response");
-                        StatusCode::INTERNAL_SERVER_ERROR
-                    })?,
-                ));
-            }
-            Err(_) => return Err(StatusCode::SERVICE_UNAVAILABLE),
-        }
-
-        // Handle gateway slash commands.
-        let store = genesis_storage::SessionStore::new(&state.loaded.config.storage.database_path);
-        if let crate::commands::CommandResult::Reply(reply) =
-            crate::commands::handle_command(&message, &session_id, &store, &state.loaded.config)
-        {
-            return Ok(Json(
-                serde_json::to_value(InteractionResponse {
-                    response_type: RESPONSE_CHANNEL_MESSAGE,
-                    data: Some(InteractionResponseData { content: reply }),
-                })
-                .map_err(|e| {
-                    error!(error = %e, "failed to serialize interaction response");
-                    StatusCode::INTERNAL_SERVER_ERROR
-                })?,
-            ));
-        }
-
-        // Auto-reset expired sessions before processing.
-        crate::commands::check_session_expiry(
-            &session_id,
-            &store,
-            state.loaded.config.gateway.as_ref(),
-        );
-
         // Spawn background task to process and follow up
         tokio::spawn(
             async move {
-                let service = state.session_service();
+                let msg = PlatformMessage {
+                    user_id: &discord_user_id,
+                    user_name: &user_name,
+                    text: &message,
+                    session_id: &session_id,
+                    chat_id: &channel_id,
+                    platform_name: "discord",
+                    delivery_platform: DeliveryPlatform::Discord,
+                };
 
-                let result = service
-                    .run_turn(SessionTurnInput {
-                        session_id: &session_id,
-                        session_platform: "discord",
-                        delivery_platform: DeliveryPlatform::Discord,
-                        prompt: &message,
-                        title: Some(&format!("Discord: {user_name}")),
-                        images: Vec::new(),
-                    })
-                    .await;
-
-                let reply_text = super::extract_reply(result, "discord");
+                let reply = match super::process_platform_message(&state, &msg).await {
+                    ProcessOutcome::AgentReply(r)
+                    | ProcessOutcome::NeedsPairing(r)
+                    | ProcessOutcome::CommandReply(r) => r,
+                    ProcessOutcome::AtCapacity => super::pairing_capacity_reply().to_owned(),
+                    ProcessOutcome::PairingError => {
+                        error!("discord pairing check failed");
+                        return;
+                    }
+                    ProcessOutcome::ExecutionError(e) => {
+                        error!(error = %e, "discord execution error");
+                        return;
+                    }
+                };
 
                 // Edit the deferred response with the actual reply
                 if let Err(e) = edit_followup(
                     &state.http_client,
                     &application_id,
                     &interaction_token,
-                    &reply_text,
+                    &reply,
                 )
                 .await
                 {
                     error!(error = %e, "failed to send discord followup");
                 }
-
-                // Append delivery mirror for cross-platform visibility.
-                crate::mirror::append_delivery_mirror(
-                    &state.loaded.config.storage.database_path,
-                    "discord",
-                    &channel_id,
-                    &reply_text,
-                    "discord",
-                );
             }
             .instrument(span),
         );

--- a/crates/genesis-gateway/src/platforms/homeassistant.rs
+++ b/crates/genesis-gateway/src/platforms/homeassistant.rs
@@ -81,6 +81,7 @@ fn extract_provided_token(headers: &HeaderMap) -> Option<&str> {
 ///
 /// Unlike platform bots, we return the response synchronously since
 /// Home Assistant automations expect the result in the HTTP response.
+/// Home Assistant is exempt from DM pairing (trusted local network).
 pub async fn webhook_handler(
     headers: HeaderMap,
     State(state): State<Arc<AppState>>,

--- a/crates/genesis-gateway/src/platforms/mod.rs
+++ b/crates/genesis-gateway/src/platforms/mod.rs
@@ -5,11 +5,196 @@ pub mod slack;
 pub mod telegram;
 pub mod whatsapp;
 
-use genesis_core::execution::{SessionExecutionError, SessionTurnOutcome};
-use genesis_storage::PairingStore;
-use genesis_types::DeliveryPlatform;
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
+
+use genesis_core::execution::{SessionExecutionError, SessionTurnInput, SessionTurnOutcome};
+use genesis_storage::{PairingStore, SessionStore};
+use genesis_types::DeliveryPlatform;
+
+use crate::AppState;
+
+// ---------------------------------------------------------------------------
+// Shared platform message abstraction
+// ---------------------------------------------------------------------------
+
+/// Normalized incoming message from any platform.
+///
+/// Platform handlers extract their platform-specific payload into this struct,
+/// which is then processed by [`process_platform_message`].
+pub struct PlatformMessage<'a> {
+    /// The platform's identifier for the user (e.g. Telegram user ID, phone number).
+    pub user_id: &'a str,
+    /// Display name for the user.
+    pub user_name: &'a str,
+    /// The text content of the message (may include transcription markers, etc.).
+    pub text: &'a str,
+    /// Session ID for this conversation (e.g. `tg-12345`, `slack-C67890`).
+    pub session_id: &'a str,
+    /// Chat/channel identifier for delivery mirror logging.
+    pub chat_id: &'a str,
+    /// Platform name for logging and pairing (e.g. `"telegram"`, `"slack"`).
+    pub platform_name: &'a str,
+    /// Delivery platform enum variant.
+    pub delivery_platform: DeliveryPlatform,
+}
+
+/// Result of processing a platform message through the shared pipeline.
+pub enum ProcessOutcome {
+    /// Pairing is needed; the handler should send this reply to the user.
+    NeedsPairing(String),
+    /// Too many pending pairing requests; send this reply.
+    AtCapacity,
+    /// Pairing check failed; handler should return SERVICE_UNAVAILABLE.
+    PairingError,
+    /// A gateway command was handled; send this reply to the user.
+    CommandReply(String),
+    /// The agent processed the message; send this reply to the user.
+    AgentReply(String),
+    /// The agent processing failed at the execution level.
+    ExecutionError(String),
+}
+
+/// Shared processing pipeline for platform messages.
+///
+/// This encapsulates the common flow that every platform handler repeats:
+/// 1. Pairing check
+/// 2. Gateway slash command handling
+/// 3. Session expiry auto-reset
+/// 4. Agent turn execution
+/// 5. Reply extraction
+/// 6. Delivery mirror logging
+///
+/// Platform handlers call this after extracting the message from their
+/// platform-specific payload and verifying the webhook signature.
+pub async fn process_platform_message(
+    state: &Arc<AppState>,
+    msg: &PlatformMessage<'_>,
+) -> ProcessOutcome {
+    // 1. DM pairing check
+    match check_pairing(
+        &state.loaded.config.storage.database_path,
+        msg.platform_name,
+        msg.user_id,
+        msg.user_name,
+    ) {
+        Ok(PairingCheck::Approved) => {}
+        Ok(PairingCheck::NeedsPairing(code)) => {
+            return ProcessOutcome::NeedsPairing(pairing_reply(&code));
+        }
+        Ok(PairingCheck::AtCapacity) => {
+            return ProcessOutcome::AtCapacity;
+        }
+        Err(_) => {
+            return ProcessOutcome::PairingError;
+        }
+    }
+
+    // 2. Handle gateway slash commands
+    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    if let crate::commands::CommandResult::Reply(reply) =
+        crate::commands::handle_command(msg.text, msg.session_id, &store, &state.loaded.config)
+    {
+        return ProcessOutcome::CommandReply(reply);
+    }
+
+    // 3. Auto-reset expired sessions
+    crate::commands::check_session_expiry(
+        msg.session_id,
+        &store,
+        state.loaded.config.gateway.as_ref(),
+    );
+
+    // 4. Run the agent turn
+    let service = state.session_service();
+    let title = format!("{}: {}", capitalize_platform(msg.platform_name), msg.user_name);
+    let result = service
+        .run_turn(SessionTurnInput {
+            session_id: msg.session_id,
+            session_platform: msg.platform_name,
+            delivery_platform: msg.delivery_platform.clone(),
+            prompt: msg.text,
+            title: Some(&title),
+            images: Vec::new(),
+        })
+        .await;
+
+    // 5. Extract the reply
+    let reply_text = extract_reply(result, msg.platform_name);
+
+    // 6. Delivery mirror
+    crate::mirror::append_delivery_mirror(
+        &state.loaded.config.storage.database_path,
+        msg.platform_name,
+        msg.chat_id,
+        &reply_text,
+        msg.platform_name,
+    );
+
+    ProcessOutcome::AgentReply(reply_text)
+}
+
+/// Capitalize the first letter of a platform name for session titles.
+fn capitalize_platform(name: &str) -> String {
+    let mut chars = name.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().chain(chars).collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared message splitting
+// ---------------------------------------------------------------------------
+
+/// Split a message into chunks respecting a max byte length.
+///
+/// Tries to split on newlines first, then word boundaries. Uses
+/// char-boundary-safe indexing to avoid panics on multi-byte UTF-8.
+///
+/// This is used by Telegram (4096 char limit) and Signal (6000 byte limit).
+pub fn split_message(text: &str, max_len: usize) -> Vec<String> {
+    if text.len() <= max_len {
+        return vec![text.to_owned()];
+    }
+
+    let mut chunks = Vec::new();
+    let mut remaining = text;
+
+    while !remaining.is_empty() {
+        if remaining.len() <= max_len {
+            chunks.push(remaining.to_owned());
+            break;
+        }
+
+        // Walk back to a char boundary so we never slice inside a multi-byte
+        // character. `floor_char_boundary` returns the largest byte index
+        // <= max_len that sits on a UTF-8 char boundary.
+        let safe_end = remaining.floor_char_boundary(max_len);
+
+        // Try to find a newline within the limit, then a space
+        let mut split_at = remaining[..safe_end]
+            .rfind('\n')
+            .or_else(|| remaining[..safe_end].rfind(' '))
+            .unwrap_or(safe_end);
+
+        // Guard: if remaining starts with a delimiter, rfind returns 0 which
+        // would push an empty chunk. Fall back to the full safe window.
+        if split_at == 0 {
+            split_at = safe_end;
+        }
+
+        chunks.push(remaining[..split_at].to_owned());
+        remaining = remaining[split_at..].trim_start();
+    }
+
+    chunks
+}
+
+// ---------------------------------------------------------------------------
+// Reply extraction
+// ---------------------------------------------------------------------------
 
 /// Structured error type for platform webhook handler operations.
 ///
@@ -242,6 +427,66 @@ pub fn pairing_capacity_reply() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn split_message_short_text_returns_single_chunk() {
+        let chunks = split_message("hello", 4096);
+        assert_eq!(chunks, vec!["hello"]);
+    }
+
+    #[test]
+    fn split_message_splits_on_newlines() {
+        let text = format!("{}\n{}", "a".repeat(100), "b".repeat(100));
+        let chunks = split_message(&text, 150);
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks[0].len() <= 150);
+    }
+
+    #[test]
+    fn split_message_splits_on_spaces() {
+        let text = format!("{} {}", "word".repeat(30), "more".repeat(30));
+        let chunks = split_message(&text, 100);
+        assert!(chunks.len() >= 2);
+        for chunk in &chunks {
+            assert!(chunk.len() <= 100);
+        }
+    }
+
+    #[test]
+    fn split_message_multibyte_utf8_does_not_panic() {
+        let emoji = "\u{1F600}"; // 4 bytes
+        let text = emoji.repeat(30); // 120 bytes total
+        let chunks = split_message(&text, 50);
+        assert!(chunks.len() >= 2);
+        for chunk in &chunks {
+            assert!(chunk.len() <= 50);
+            assert!(!chunk.is_empty());
+        }
+    }
+
+    #[test]
+    fn split_message_leading_delimiter_does_not_produce_empty_chunk() {
+        let text = format!("\n{}", "a".repeat(100));
+        let chunks = split_message(&text, 50);
+        for chunk in &chunks {
+            assert!(!chunk.is_empty(), "empty chunk produced");
+        }
+    }
+
+    #[test]
+    fn capitalize_platform_capitalizes_first_letter() {
+        assert_eq!(capitalize_platform("telegram"), "Telegram");
+        assert_eq!(capitalize_platform("discord"), "Discord");
+        assert_eq!(capitalize_platform("slack"), "Slack");
+        assert_eq!(capitalize_platform("whatsapp"), "Whatsapp");
+        assert_eq!(capitalize_platform("signal"), "Signal");
+        assert_eq!(capitalize_platform(""), "");
+    }
+
+    #[test]
+    fn pairing_capacity_reply_is_non_empty() {
+        assert!(!pairing_capacity_reply().is_empty());
+    }
 
     #[test]
     fn is_truthy_env_recognizes_true_values() {

--- a/crates/genesis-gateway/src/platforms/signal.rs
+++ b/crates/genesis-gateway/src/platforms/signal.rs
@@ -7,15 +7,15 @@
 //! 1. Run signal-cli in daemon/HTTP mode (`signal-cli daemon --http`)
 //! 2. Set `SIGNAL_ACCOUNT` to your registered phone number (e.g. `+15551234567`)
 //! 3. Optionally set `SIGNAL_HTTP_URL` (default: `http://127.0.0.1:8080`)
-//! 4. Optionally set `SIGNAL_WEBHOOK_SECRET` — when set, incoming webhook
+//! 4. Optionally set `SIGNAL_WEBHOOK_SECRET` -- when set, incoming webhook
 //!    requests must include an `X-Signal-Secret` header matching this value
 //! 5. Optionally set `SIGNAL_GROUP_ALLOWED_USERS` to a comma-separated list of
 //!    phone numbers allowed to interact in group chats
 //!
 //! ## Endpoints
-//! - `POST /signal/webhook` — receives incoming messages (called by signal-cli
+//! - `POST /signal/webhook` -- receives incoming messages (called by signal-cli
 //!   or a polling proxy)
-//! - `POST /signal/poll` — one-shot poll: fetches pending messages from
+//! - `POST /signal/poll` -- one-shot poll: fetches pending messages from
 //!   signal-cli's `/v1/receive/{account}` endpoint and processes them
 
 use std::sync::Arc;
@@ -23,12 +23,11 @@ use std::sync::Arc;
 use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
-use genesis_core::execution::SessionTurnInput;
-use genesis_storage::SessionStore;
 use genesis_types::DeliveryPlatform;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, info_span, warn, Instrument};
 
+use super::{PlatformMessage, ProcessOutcome};
 use crate::verify::verify_secret_token;
 use crate::AppState;
 
@@ -209,11 +208,8 @@ pub async fn webhook_handler(
         }
     };
 
-    match process_envelope(&state, &account, envelope).await {
-        ProcessResult::Ok => StatusCode::OK,
-        ProcessResult::Ignored => StatusCode::OK,
-        ProcessResult::Error => StatusCode::INTERNAL_SERVER_ERROR,
-    }
+    process_envelope(&state, &account, envelope).await;
+    StatusCode::OK
 }
 
 /// Poll handler: fetches pending messages from signal-cli's REST endpoint.
@@ -280,7 +276,6 @@ pub async fn poll_handler(State(state): State<Arc<AppState>>) -> StatusCode {
 enum ProcessResult {
     Ok,
     Ignored,
-    Error,
 }
 
 /// Process a single signal envelope.
@@ -312,10 +307,6 @@ async fn process_envelope(
     let is_group = group_id.is_some();
 
     // Group authorization check.
-    // When `SIGNAL_GROUP_ALLOWED_USERS` is unset (or empty), all senders are
-    // allowed to interact in group chats — the group is effectively open.
-    // Set the env var to a comma-separated list of phone numbers to restrict
-    // access.
     if is_group {
         let allowed = group_allowed_users();
         if !allowed.is_empty() && !allowed.iter().any(|a| a == &source) {
@@ -359,101 +350,12 @@ async fn process_envelope(
 
     info!(parent: &span, "received signal message");
 
-    // DM pairing check (skip for group messages — use group allowlist instead).
-    if !is_group {
-        match super::check_pairing(
-            &state.loaded.config.storage.database_path,
-            "signal",
-            &source,
-            &user_name,
-        ) {
-            Ok(super::PairingCheck::Approved) => {} // proceed
-            Ok(super::PairingCheck::NeedsPairing(code)) => {
-                let reply = super::pairing_reply(&code);
-                let base_url = signal_http_url();
-                let client = state.http_client.clone();
-                let account_clone = account.to_owned();
-                let source_clone = source.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = send_message(
-                        &client,
-                        &base_url,
-                        &account_clone,
-                        &source_clone,
-                        &reply,
-                        None,
-                    )
-                    .await
-                    {
-                        error!(error = %e, "failed to send signal pairing reply");
-                    }
-                });
-                return ProcessResult::Ok;
-            }
-            Ok(super::PairingCheck::AtCapacity) => {
-                let reply = super::pairing_capacity_reply().to_owned();
-                let base_url = signal_http_url();
-                let client = state.http_client.clone();
-                let account_clone = account.to_owned();
-                let source_clone = source.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = send_message(
-                        &client,
-                        &base_url,
-                        &account_clone,
-                        &source_clone,
-                        &reply,
-                        None,
-                    )
-                    .await
-                    {
-                        error!(error = %e, "failed to send signal capacity reply");
-                    }
-                });
-                return ProcessResult::Ok;
-            }
-            Err(_) => {
-                return ProcessResult::Error;
-            }
-        }
-    }
+    // For group messages, skip the DM pairing check (use group allowlist instead).
+    // For DMs, use the shared pipeline which includes pairing.
+    // Signal has extra complexity: typing indicators and group vs DM routing.
+    // We handle the pairing inline for DMs to match the shared pipeline,
+    // but keep the send logic separate due to group/DM routing and typing.
 
-    // Handle gateway slash commands.
-    {
-        let store = SessionStore::new(&state.loaded.config.storage.database_path);
-        if let crate::commands::CommandResult::Reply(reply) =
-            crate::commands::handle_command(&prompt, &session_id, &store, &state.loaded.config)
-        {
-            let base_url = signal_http_url();
-            let client = state.http_client.clone();
-            let account_clone = account.to_owned();
-            let recipient = group_id.clone().unwrap_or_else(|| source.clone());
-            let is_group_clone = is_group;
-            tokio::spawn(async move {
-                let result = if is_group_clone {
-                    send_group_message(&client, &base_url, &account_clone, &recipient, &reply).await
-                } else {
-                    send_message(&client, &base_url, &account_clone, &recipient, &reply, None).await
-                };
-                if let Err(e) = result {
-                    error!(error = %e, "failed to send signal command reply");
-                }
-            });
-            return ProcessResult::Ok;
-        }
-    }
-
-    // Auto-reset expired sessions.
-    {
-        let store = SessionStore::new(&state.loaded.config.storage.database_path);
-        crate::commands::check_session_expiry(
-            &session_id,
-            &store,
-            state.loaded.config.gateway.as_ref(),
-        );
-    }
-
-    // Spawn agent execution in background.
     let state = Arc::clone(state);
     let account_owned = account.to_owned();
     let timestamp = data_message.timestamp;
@@ -471,20 +373,92 @@ async fn process_envelope(
             )
             .await;
 
-            let service = state.session_service();
+            let msg = PlatformMessage {
+                user_id: &source,
+                user_name: &user_name,
+                text: &prompt,
+                session_id: &session_id,
+                chat_id: &chat_id,
+                platform_name: "signal",
+                delivery_platform: DeliveryPlatform::Signal,
+            };
 
-            let result = service
-                .run_turn(SessionTurnInput {
-                    session_id: &session_id,
-                    session_platform: "signal",
-                    delivery_platform: DeliveryPlatform::Signal,
-                    prompt: &prompt,
-                    title: Some(&format!("Signal: {user_name}")),
-                    images: Vec::new(),
-                })
-                .await;
-
-            let reply_text = super::extract_reply(result, "signal");
+            // For group messages, skip pairing (handled by group allowlist above).
+            // For DMs, use the shared pipeline.
+            let reply = if is_group {
+                // Groups bypass pairing -- run commands/agent directly.
+                let store = genesis_storage::SessionStore::new(
+                    &state.loaded.config.storage.database_path,
+                );
+                if let crate::commands::CommandResult::Reply(r) =
+                    crate::commands::handle_command(
+                        &prompt,
+                        &session_id,
+                        &store,
+                        &state.loaded.config,
+                    )
+                {
+                    r
+                } else {
+                    crate::commands::check_session_expiry(
+                        &session_id,
+                        &store,
+                        state.loaded.config.gateway.as_ref(),
+                    );
+                    let service = state.session_service();
+                    let title = format!("Signal: {user_name}");
+                    let result = service
+                        .run_turn(genesis_core::execution::SessionTurnInput {
+                            session_id: &session_id,
+                            session_platform: "signal",
+                            delivery_platform: DeliveryPlatform::Signal,
+                            prompt: &prompt,
+                            title: Some(&title),
+                            images: Vec::new(),
+                        })
+                        .await;
+                    let reply_text = super::extract_reply(result, "signal");
+                    crate::mirror::append_delivery_mirror(
+                        &state.loaded.config.storage.database_path,
+                        "signal",
+                        &chat_id,
+                        &reply_text,
+                        "signal",
+                    );
+                    reply_text
+                }
+            } else {
+                match super::process_platform_message(&state, &msg).await {
+                    ProcessOutcome::AgentReply(r)
+                    | ProcessOutcome::NeedsPairing(r)
+                    | ProcessOutcome::CommandReply(r) => r,
+                    ProcessOutcome::AtCapacity => super::pairing_capacity_reply().to_owned(),
+                    ProcessOutcome::PairingError => {
+                        error!("signal pairing check failed");
+                        let _ = send_typing_stop(
+                            &state.http_client,
+                            &base_url,
+                            &account_owned,
+                            &recipient,
+                            is_group,
+                        )
+                        .await;
+                        return;
+                    }
+                    ProcessOutcome::ExecutionError(e) => {
+                        error!(error = %e, "signal execution error");
+                        let _ = send_typing_stop(
+                            &state.http_client,
+                            &base_url,
+                            &account_owned,
+                            &recipient,
+                            is_group,
+                        )
+                        .await;
+                        return;
+                    }
+                }
+            };
 
             // Stop typing indicator.
             let _ = send_typing_stop(
@@ -502,7 +476,7 @@ async fn process_envelope(
                     &base_url,
                     &account_owned,
                     &recipient,
-                    &reply_text,
+                    &reply,
                 )
                 .await
             } else {
@@ -511,7 +485,7 @@ async fn process_envelope(
                     &base_url,
                     &account_owned,
                     &recipient,
-                    &reply_text,
+                    &reply,
                     timestamp,
                 )
                 .await
@@ -520,15 +494,6 @@ async fn process_envelope(
             if let Err(e) = send_result {
                 error!(error = %e, "failed to send signal reply");
             }
-
-            // Cross-platform delivery mirror.
-            crate::mirror::append_delivery_mirror(
-                &state.loaded.config.storage.database_path,
-                "signal",
-                &chat_id,
-                &reply_text,
-                "signal",
-            );
         }
         .instrument(span),
     );
@@ -578,7 +543,7 @@ async fn send_message(
     text: &str,
     quote_timestamp: Option<u64>,
 ) -> Result<(), super::PlatformError> {
-    let chunks = split_message(text, MAX_SIGNAL_MESSAGE_LEN);
+    let chunks = super::split_message(text, MAX_SIGNAL_MESSAGE_LEN);
 
     for (i, chunk) in chunks.iter().enumerate() {
         // Only quote on the first chunk.
@@ -616,7 +581,7 @@ async fn send_group_message(
     group_id: &str,
     text: &str,
 ) -> Result<(), super::PlatformError> {
-    let chunks = split_message(text, MAX_SIGNAL_MESSAGE_LEN);
+    let chunks = super::split_message(text, MAX_SIGNAL_MESSAGE_LEN);
 
     for chunk in &chunks {
         let params = serde_json::json!({
@@ -745,40 +710,6 @@ async fn send_rpc(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Split a message into chunks respecting a max byte length.
-/// Tries to split on newlines first, then word boundaries.
-/// Uses char-boundary-safe indexing to avoid panics on multi-byte UTF-8.
-fn split_message(text: &str, max_len: usize) -> Vec<String> {
-    if text.len() <= max_len {
-        return vec![text.to_owned()];
-    }
-
-    let mut chunks = Vec::new();
-    let mut remaining = text;
-
-    while !remaining.is_empty() {
-        if remaining.len() <= max_len {
-            chunks.push(remaining.to_owned());
-            break;
-        }
-
-        // Walk back to a char boundary so we never slice inside a multi-byte
-        // character. `floor_char_boundary` returns the largest byte index
-        // <= max_len that is on a char boundary.
-        let safe_end = remaining.floor_char_boundary(max_len);
-
-        let split_at = remaining[..safe_end]
-            .rfind('\n')
-            .or_else(|| remaining[..safe_end].rfind(' '))
-            .unwrap_or(safe_end);
-
-        chunks.push(remaining[..split_at].to_owned());
-        remaining = remaining[split_at..].trim_start();
-    }
-
-    chunks
-}
-
 /// Generate a unique request ID for JSON-RPC correlation.
 fn request_id() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -904,14 +835,14 @@ mod tests {
 
     #[test]
     fn split_message_short_text() {
-        let chunks = split_message("hello", 6000);
+        let chunks = super::super::split_message("hello", 6000);
         assert_eq!(chunks, vec!["hello"]);
     }
 
     #[test]
     fn split_message_long_text_on_newlines() {
         let text = format!("{}\n{}", "a".repeat(100), "b".repeat(100));
-        let chunks = split_message(&text, 150);
+        let chunks = super::super::split_message(&text, 150);
         assert_eq!(chunks.len(), 2);
         assert!(chunks[0].len() <= 150);
     }
@@ -919,7 +850,7 @@ mod tests {
     #[test]
     fn split_message_long_text_on_spaces() {
         let text = format!("{} {}", "word".repeat(30), "more".repeat(30));
-        let chunks = split_message(&text, 100);
+        let chunks = super::super::split_message(&text, 100);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
             assert!(chunk.len() <= 100);
@@ -928,17 +859,12 @@ mod tests {
 
     #[test]
     fn split_message_multibyte_utf8_does_not_panic() {
-        // Each emoji is 4 bytes. Build a string that forces a split in the
-        // middle of a multi-byte character when using naive byte indexing.
         let emoji = "\u{1F600}"; // 4 bytes
         let text = emoji.repeat(30); // 120 bytes total
-                                     // max_len=50 would land inside an emoji at byte 50 if not handled.
-        let chunks = split_message(&text, 50);
+        let chunks = super::super::split_message(&text, 50);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
             assert!(chunk.len() <= 50);
-            // Verify the chunk is valid UTF-8 (String guarantees this, but
-            // confirm no panic occurred during construction).
             assert!(!chunk.is_empty());
         }
     }
@@ -1062,7 +988,6 @@ mod tests {
     fn request_id_generates_unique_ids() {
         let id1 = request_id();
         let id2 = request_id();
-        // They should be non-empty and probably different (time-based).
         assert!(!id1.is_empty());
         assert!(!id2.is_empty());
     }
@@ -1076,7 +1001,6 @@ mod tests {
 
     #[test]
     fn group_allowed_users_parsing() {
-        // Simulates parsing logic without setting env vars
         let raw = "+15551111111, +15552222222 , +15553333333";
         let parsed: Vec<String> = raw
             .split(',')

--- a/crates/genesis-gateway/src/platforms/slack.rs
+++ b/crates/genesis-gateway/src/platforms/slack.rs
@@ -15,11 +15,11 @@ use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::Json;
-use genesis_core::execution::SessionTurnInput;
 use genesis_types::DeliveryPlatform;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, info_span, warn, Instrument};
 
+use super::{PlatformMessage, ProcessOutcome};
 use crate::verify::verify_slack_signature;
 use crate::AppState;
 
@@ -153,114 +153,45 @@ pub async fn events_handler(
 
     info!(parent: &span, event_type = event.event_type.as_str(), "received slack event");
 
-    // DM pairing check
-    match super::check_pairing(
-        &state.loaded.config.storage.database_path,
-        "slack",
-        &user,
-        &user, // Slack user IDs are opaque; username isn't available without API call
-    ) {
-        Ok(super::PairingCheck::Approved) => {}
-        Ok(super::PairingCheck::NeedsPairing(code)) => {
-            let reply = super::pairing_reply(&code);
-            let client2 = state.http_client.clone();
-            let token2 = token.clone();
-            let channel2 = channel.clone();
-            let ts = thread_ts.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    post_message(&client2, &token2, &channel2, &reply, ts.as_deref()).await
-                {
-                    error!(error = %e, "failed to send pairing reply");
-                }
-            });
-            return Ok(Json(serde_json::json!({ "ok": true })));
-        }
-        Ok(super::PairingCheck::AtCapacity) => {
-            let reply = super::pairing_capacity_reply().to_owned();
-            let client2 = state.http_client.clone();
-            let token2 = token.clone();
-            let channel2 = channel.clone();
-            let ts = thread_ts.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    post_message(&client2, &token2, &channel2, &reply, ts.as_deref()).await
-                {
-                    error!(error = %e, "failed to send capacity reply");
-                }
-            });
-            return Ok(Json(serde_json::json!({ "ok": true })));
-        }
-        Err(_) => {
-            return Err(StatusCode::SERVICE_UNAVAILABLE);
-        }
-    }
-
-    // Handle gateway slash commands before reaching the agent.
-    let store = genesis_storage::SessionStore::new(&state.loaded.config.storage.database_path);
-    match crate::commands::handle_command(&text, &session_id, &store, &state.loaded.config) {
-        crate::commands::CommandResult::Reply(reply) => {
-            let client2 = state.http_client.clone();
-            let token2 = token.clone();
-            let channel2 = channel.clone();
-            let ts = thread_ts.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    post_message(&client2, &token2, &channel2, &reply, ts.as_deref()).await
-                {
-                    error!(error = %e, "failed to send command reply");
-                }
-            });
-            return Ok(Json(serde_json::json!({ "ok": true })));
-        }
-        crate::commands::CommandResult::PassThrough => {}
-    }
-
-    // Auto-reset expired sessions before processing.
-    crate::commands::check_session_expiry(
-        &session_id,
-        &store,
-        state.loaded.config.gateway.as_ref(),
-    );
-
-    // Process in background
+    // Process in background using the shared pipeline
     tokio::spawn(
         async move {
-            let service = state.session_service();
+            let msg = PlatformMessage {
+                user_id: &user,
+                user_name: &user, // Slack user IDs are opaque; username isn't available without API call
+                text: &text,
+                session_id: &session_id,
+                chat_id: &channel,
+                platform_name: "slack",
+                delivery_platform: DeliveryPlatform::Slack,
+            };
 
-            let result = service
-                .run_turn(SessionTurnInput {
-                    session_id: &session_id,
-                    session_platform: "slack",
-                    delivery_platform: DeliveryPlatform::Slack,
-                    prompt: &text,
-                    title: Some(&format!("Slack: {user}")),
-                    images: Vec::new(),
-                })
-                .await;
-
-            let reply_text = super::extract_reply(result, "slack");
+            let reply = match super::process_platform_message(&state, &msg).await {
+                ProcessOutcome::AgentReply(r)
+                | ProcessOutcome::NeedsPairing(r)
+                | ProcessOutcome::CommandReply(r) => r,
+                ProcessOutcome::AtCapacity => super::pairing_capacity_reply().to_owned(),
+                ProcessOutcome::PairingError => {
+                    error!("slack pairing check failed");
+                    return;
+                }
+                ProcessOutcome::ExecutionError(e) => {
+                    error!(error = %e, "slack execution error");
+                    return;
+                }
+            };
 
             if let Err(e) = post_message(
                 &state.http_client,
                 &token,
                 &channel,
-                &reply_text,
+                &reply,
                 thread_ts.as_deref(),
             )
             .await
             {
                 error!(error = %e, "failed to post slack message");
             }
-
-            // Append delivery mirror for cross-platform visibility.
-            crate::mirror::append_delivery_mirror(
-                &state.loaded.config.storage.database_path,
-                "slack",
-                &channel,
-                &reply_text,
-                "slack",
-            );
         }
         .instrument(span),
     );

--- a/crates/genesis-gateway/src/platforms/telegram.rs
+++ b/crates/genesis-gateway/src/platforms/telegram.rs
@@ -17,12 +17,12 @@ use axum::body::Bytes;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use base64::Engine;
-use genesis_core::execution::SessionTurnInput;
-use genesis_storage::{SessionStore, StickerCacheStore};
+use genesis_storage::StickerCacheStore;
 use genesis_types::DeliveryPlatform;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, info_span, warn, Instrument};
 
+use super::{PlatformMessage, ProcessOutcome};
 use crate::verify::verify_secret_token;
 use crate::AppState;
 
@@ -553,6 +553,11 @@ pub async fn webhook_handler(
 
     // Session ID: stable per chat so conversation persists
     let session_id = format!("tg-{chat_id}");
+    let user_id_str = message
+        .from
+        .as_ref()
+        .map(|u| u.id.to_string())
+        .unwrap_or_else(|| chat_id.to_string());
 
     let span = info_span!(
         "telegram.webhook",
@@ -562,80 +567,6 @@ pub async fn webhook_handler(
     );
 
     info!(parent: &span, "received telegram message");
-
-    // DM pairing check — gate unknown users
-    let user_id_str = message
-        .from
-        .as_ref()
-        .map(|u| u.id.to_string())
-        .unwrap_or_else(|| chat_id.to_string());
-
-    match super::check_pairing(
-        &state.loaded.config.storage.database_path,
-        "telegram",
-        &user_id_str,
-        &user_name,
-    ) {
-        Ok(super::PairingCheck::Approved) => {} // proceed
-        Ok(super::PairingCheck::NeedsPairing(code)) => {
-            let reply = super::pairing_reply(&code);
-            let client2 = state.http_client.clone();
-            let token2 = token.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    send_reply(&client2, &token2, chat_id, &reply, Some(message_id)).await
-                {
-                    error!(error = %e, "failed to send pairing reply");
-                }
-            });
-            return StatusCode::OK;
-        }
-        Ok(super::PairingCheck::AtCapacity) => {
-            let reply = super::pairing_capacity_reply().to_owned();
-            let client2 = state.http_client.clone();
-            let token2 = token.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    send_reply(&client2, &token2, chat_id, &reply, Some(message_id)).await
-                {
-                    error!(error = %e, "failed to send capacity reply");
-                }
-            });
-            return StatusCode::OK;
-        }
-        Err(_) => {
-            return StatusCode::SERVICE_UNAVAILABLE;
-        }
-    }
-
-    // Handle gateway slash commands (only for text messages).
-    if let MessageInput::Text(ref text) = input {
-        let store = SessionStore::new(&state.loaded.config.storage.database_path);
-        if let crate::commands::CommandResult::Reply(reply) =
-            crate::commands::handle_command(text, &session_id, &store, &state.loaded.config)
-        {
-            let client2 = state.http_client.clone();
-            let token2 = token.clone();
-            tokio::spawn(async move {
-                if let Err(e) =
-                    send_reply(&client2, &token2, chat_id, &reply, Some(message_id)).await
-                {
-                    error!(error = %e, "failed to send command reply");
-                }
-            });
-            return StatusCode::OK;
-        }
-    }
-
-    // Auto-reset expired sessions before processing.
-    {
-        let store = SessionStore::new(&state.loaded.config.storage.database_path);
-        crate::commands::check_session_expiry(
-            &session_id,
-            &store,
-            state.loaded.config.gateway.as_ref(),
-        );
-    }
 
     // Spawn background task so we return 200 immediately
     let state = Arc::clone(&state);
@@ -687,33 +618,35 @@ pub async fn webhook_handler(
                 }
             };
 
-            let service = state.session_service();
+            let chat_id_str = chat_id.to_string();
+            let msg = PlatformMessage {
+                user_id: &user_id_str,
+                user_name: &user_name,
+                text: &prompt,
+                session_id: &session_id,
+                chat_id: &chat_id_str,
+                platform_name: "telegram",
+                delivery_platform: DeliveryPlatform::Telegram,
+            };
 
-            let result = service
-                .run_turn(SessionTurnInput {
-                    session_id: &session_id,
-                    session_platform: "telegram",
-                    delivery_platform: DeliveryPlatform::Telegram,
-                    prompt: &prompt,
-                    title: Some(&format!("Telegram: {user_name}")),
-                    images: Vec::new(),
-                })
-                .await;
+            let reply = match super::process_platform_message(&state, &msg).await {
+                ProcessOutcome::AgentReply(r)
+                | ProcessOutcome::NeedsPairing(r)
+                | ProcessOutcome::CommandReply(r) => r,
+                ProcessOutcome::AtCapacity => super::pairing_capacity_reply().to_owned(),
+                ProcessOutcome::PairingError => {
+                    error!("telegram pairing check failed");
+                    return;
+                }
+                ProcessOutcome::ExecutionError(e) => {
+                    error!(error = %e, "telegram execution error");
+                    return;
+                }
+            };
 
-            let reply_text = super::extract_reply(result, "telegram");
-
-            if let Err(e) = send_reply(&state.http_client, &token, chat_id, &reply_text, Some(message_id)).await {
+            if let Err(e) = send_reply(&state.http_client, &token, chat_id, &reply, Some(message_id)).await {
                 error!(error = %e, "failed to send telegram reply");
             }
-
-            // Append delivery mirror for cross-platform visibility.
-            crate::mirror::append_delivery_mirror(
-                &state.loaded.config.storage.database_path,
-                "telegram",
-                &chat_id.to_string(),
-                &reply_text,
-                "telegram",
-            );
         }
         .instrument(span),
     );
@@ -733,7 +666,7 @@ async fn send_reply(
 
     // Telegram messages have a 4096 character limit.
     // Split long responses into chunks.
-    let chunks = split_message(text, 4096);
+    let chunks = super::split_message(text, 4096);
 
     let url = format!("https://api.telegram.org/bot{token}/sendMessage");
 
@@ -774,46 +707,6 @@ async fn send_reply(
     Ok(())
 }
 
-/// Split a message into chunks respecting a max length.
-/// Tries to split on newlines first, then word boundaries.
-fn split_message(text: &str, max_len: usize) -> Vec<String> {
-    if text.len() <= max_len {
-        return vec![text.to_owned()];
-    }
-
-    let mut chunks = Vec::new();
-    let mut remaining = text;
-
-    while !remaining.is_empty() {
-        if remaining.len() <= max_len {
-            chunks.push(remaining.to_owned());
-            break;
-        }
-
-        // Walk back to a char boundary so we never slice inside a multi-byte
-        // character (e.g. emoji). `floor_char_boundary` returns the largest
-        // byte index <= max_len that sits on a UTF-8 char boundary.
-        let safe_end = remaining.floor_char_boundary(max_len);
-
-        // Try to find a newline within the limit, then a space
-        let mut split_at = remaining[..safe_end]
-            .rfind('\n')
-            .or_else(|| remaining[..safe_end].rfind(' '))
-            .unwrap_or(safe_end);
-
-        // Guard: if remaining starts with a delimiter, rfind returns 0 which
-        // would push an empty chunk. Fall back to the full safe window.
-        if split_at == 0 {
-            split_at = safe_end;
-        }
-
-        chunks.push(remaining[..split_at].to_owned());
-        remaining = remaining[split_at..].trim_start();
-    }
-
-    chunks
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -846,14 +739,14 @@ mod tests {
 
     #[test]
     fn split_message_short_text() {
-        let chunks = split_message("hello", 4096);
+        let chunks = super::super::split_message("hello", 4096);
         assert_eq!(chunks, vec!["hello"]);
     }
 
     #[test]
     fn split_message_long_text_on_newlines() {
         let text = format!("{}\n{}", "a".repeat(100), "b".repeat(100));
-        let chunks = split_message(&text, 150);
+        let chunks = super::super::split_message(&text, 150);
         assert_eq!(chunks.len(), 2);
         assert!(chunks[0].len() <= 150);
     }
@@ -861,7 +754,7 @@ mod tests {
     #[test]
     fn split_message_long_text_on_spaces() {
         let text = format!("{} {}", "word".repeat(30), "more".repeat(30));
-        let chunks = split_message(&text, 100);
+        let chunks = super::super::split_message(&text, 100);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
             assert!(chunk.len() <= 100);
@@ -870,12 +763,9 @@ mod tests {
 
     #[test]
     fn split_message_multibyte_utf8_does_not_panic() {
-        // Each emoji is 4 bytes. Build a string that forces a split in the
-        // middle of a multi-byte character when using naive byte indexing.
         let emoji = "\u{1F600}"; // 4 bytes
         let text = emoji.repeat(30); // 120 bytes total
-                                     // max_len=50 would land inside an emoji at byte 50 if not handled.
-        let chunks = split_message(&text, 50);
+        let chunks = super::super::split_message(&text, 50);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
             assert!(chunk.len() <= 50);
@@ -885,10 +775,8 @@ mod tests {
 
     #[test]
     fn split_message_leading_delimiter_does_not_produce_empty_chunk() {
-        // When remaining starts with '\n' or ' ', rfind returns Some(0).
-        // The guard must prevent pushing an empty chunk.
         let text = format!("\n{}", "a".repeat(100));
-        let chunks = split_message(&text, 50);
+        let chunks = super::super::split_message(&text, 50);
         for chunk in &chunks {
             assert!(!chunk.is_empty(), "empty chunk produced");
         }
@@ -1023,7 +911,7 @@ mod tests {
 
     #[test]
     fn telegram_sticker_message_deserializes() {
-        let json = r#"{
+        let json = serde_json::json!({
             "update_id": 200,
             "message": {
                 "message_id": 10,
@@ -1034,25 +922,25 @@ mod tests {
                     "file_unique_id": "AgADuQAD1234",
                     "is_animated": false,
                     "is_video": false,
-                    "emoji": "😀",
+                    "emoji": "\u{1F600}",
                     "set_name": "TestPack"
                 }
             }
-        }"#;
-        let update: TelegramUpdate = serde_json::from_str(json).expect("should parse");
+        });
+        let update: TelegramUpdate = serde_json::from_value(json).expect("should parse");
         let msg = update.message.expect("should have message");
         let sticker = msg.sticker.expect("should have sticker");
         assert_eq!(sticker.file_id, "CAACAgIAAxkBAAIBe2abc");
         assert_eq!(sticker.file_unique_id, "AgADuQAD1234");
         assert!(!sticker.is_animated);
         assert!(!sticker.is_video);
-        assert_eq!(sticker.emoji.as_deref(), Some("😀"));
+        assert_eq!(sticker.emoji.as_deref(), Some("\u{1F600}"));
         assert_eq!(sticker.set_name.as_deref(), Some("TestPack"));
     }
 
     #[test]
     fn telegram_animated_sticker_deserializes() {
-        let json = r#"{
+        let json = serde_json::json!({
             "update_id": 201,
             "message": {
                 "message_id": 11,
@@ -1062,12 +950,12 @@ mod tests {
                     "file_unique_id": "AgADuQAD5678",
                     "is_animated": true,
                     "is_video": false,
-                    "emoji": "🎉",
+                    "emoji": "\u{1F389}",
                     "set_name": "AnimatedPack"
                 }
             }
-        }"#;
-        let update: TelegramUpdate = serde_json::from_str(json).expect("should parse");
+        });
+        let update: TelegramUpdate = serde_json::from_value(json).expect("should parse");
         let msg = update.message.expect("should have message");
         let sticker = msg.sticker.expect("should have sticker");
         assert!(sticker.is_animated);
@@ -1104,23 +992,23 @@ mod tests {
             file_unique_id: "AgADuQAD1234".to_owned(),
             is_animated: false,
             is_video: false,
-            emoji: Some("😺".to_owned()),
+            emoji: Some("\u{1F63A}".to_owned()),
             set_name: Some("CatPack".to_owned()),
         };
         assert_eq!(sticker.file_id, "CAACAgIAAxkBAAIBe2abc");
         assert_eq!(sticker.file_unique_id, "AgADuQAD1234");
         assert!(!sticker.is_animated);
         assert!(!sticker.is_video);
-        assert_eq!(sticker.emoji.as_deref(), Some("😺"));
+        assert_eq!(sticker.emoji.as_deref(), Some("\u{1F63A}"));
         assert_eq!(sticker.set_name.as_deref(), Some("CatPack"));
     }
 
     #[test]
     fn format_sticker_context_produces_expected_output() {
-        let result = format_sticker_context("😀", "MyPack", "A cat waving");
+        let result = format_sticker_context("\u{1F600}", "MyPack", "A cat waving");
         assert_eq!(
             result,
-            "[The user sent a sticker 😀 from \"MyPack\". It shows: \"A cat waving\"]"
+            "[The user sent a sticker \u{1F600} from \"MyPack\". It shows: \"A cat waving\"]"
         );
     }
 
@@ -1142,7 +1030,7 @@ mod tests {
 
         let cache = StickerCacheStore::new(&db_path);
         cache
-            .set("unique-123", "A happy frog jumping", "🐸", "FrogPack")
+            .set("unique-123", "A happy frog jumping", "\u{1F438}", "FrogPack")
             .expect("cache set");
 
         let cached = cache.get("unique-123").unwrap().unwrap();
@@ -1150,7 +1038,7 @@ mod tests {
             format_sticker_context(&cached.emoji, &cached.sticker_set, &cached.description);
         assert_eq!(
             context,
-            "[The user sent a sticker 🐸 from \"FrogPack\". It shows: \"A happy frog jumping\"]"
+            "[The user sent a sticker \u{1F438} from \"FrogPack\". It shows: \"A happy frog jumping\"]"
         );
     }
 }

--- a/crates/genesis-gateway/src/platforms/whatsapp.rs
+++ b/crates/genesis-gateway/src/platforms/whatsapp.rs
@@ -15,11 +15,11 @@ use std::sync::Arc;
 use axum::body::Bytes;
 use axum::extract::{Query, State};
 use axum::http::{HeaderMap, StatusCode};
-use genesis_core::execution::SessionTurnInput;
 use genesis_types::DeliveryPlatform;
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, info_span, warn, Instrument};
 
+use super::{PlatformMessage, ProcessOutcome};
 use crate::verify::verify_whatsapp_signature;
 use crate::AppState;
 
@@ -215,9 +215,6 @@ pub async fn webhook_handler(
                 .map(|c| c.profile.name.clone())
                 .unwrap_or_else(|| "Unknown".to_owned());
 
-            let store =
-                genesis_storage::SessionStore::new(&state.loaded.config.storage.database_path);
-
             for message in &change.value.messages {
                 if message.msg_type != "text" {
                     continue;
@@ -239,79 +236,6 @@ pub async fn webhook_handler(
 
                 info!(parent: &span, "received whatsapp message");
 
-                // DM pairing check
-                match super::check_pairing(
-                    &state.loaded.config.storage.database_path,
-                    "whatsapp",
-                    &from,
-                    &contact_name,
-                ) {
-                    Ok(super::PairingCheck::Approved) => {}
-                    Ok(super::PairingCheck::NeedsPairing(code)) => {
-                        let reply = super::pairing_reply(&code);
-                        let client2 = state.http_client.clone();
-                        let token2 = token.clone();
-                        let phone2 = phone_id.clone();
-                        let from2 = from.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) =
-                                send_reply(&client2, &token2, &phone2, &from2, &reply).await
-                            {
-                                error!(error = %e, "failed to send pairing reply");
-                            }
-                        });
-                        continue;
-                    }
-                    Ok(super::PairingCheck::AtCapacity) => {
-                        let reply = super::pairing_capacity_reply().to_owned();
-                        let client2 = state.http_client.clone();
-                        let token2 = token.clone();
-                        let phone2 = phone_id.clone();
-                        let from2 = from.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) =
-                                send_reply(&client2, &token2, &phone2, &from2, &reply).await
-                            {
-                                error!(error = %e, "failed to send capacity reply");
-                            }
-                        });
-                        continue;
-                    }
-                    Err(_) => {
-                        return StatusCode::SERVICE_UNAVAILABLE;
-                    }
-                }
-
-                match crate::commands::handle_command(
-                    &text,
-                    &session_id,
-                    &store,
-                    &state.loaded.config,
-                ) {
-                    crate::commands::CommandResult::Reply(reply) => {
-                        let client2 = state.http_client.clone();
-                        let token2 = token.clone();
-                        let phone2 = phone_id.clone();
-                        let from2 = from.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) =
-                                send_reply(&client2, &token2, &phone2, &from2, &reply).await
-                            {
-                                error!(error = %e, "failed to send command reply");
-                            }
-                        });
-                        continue;
-                    }
-                    crate::commands::CommandResult::PassThrough => {}
-                }
-
-                // Auto-reset expired sessions before processing.
-                crate::commands::check_session_expiry(
-                    &session_id,
-                    &store,
-                    state.loaded.config.gateway.as_ref(),
-                );
-
                 let state = Arc::clone(&state);
                 let token = token.clone();
                 let phone_id = phone_id.clone();
@@ -319,36 +243,38 @@ pub async fn webhook_handler(
 
                 tokio::spawn(
                     async move {
-                        let service = state.session_service();
+                        let msg = PlatformMessage {
+                            user_id: &from,
+                            user_name: &contact,
+                            text: &text,
+                            session_id: &session_id,
+                            chat_id: &from,
+                            platform_name: "whatsapp",
+                            delivery_platform: DeliveryPlatform::WhatsApp,
+                        };
 
-                        let result = service
-                            .run_turn(SessionTurnInput {
-                                session_id: &session_id,
-                                session_platform: "whatsapp",
-                                delivery_platform: DeliveryPlatform::WhatsApp,
-                                prompt: &text,
-                                title: Some(&format!("WhatsApp: {contact}")),
-                                images: Vec::new(),
-                            })
-                            .await;
-
-                        let reply_text = super::extract_reply(result, "whatsapp");
+                        let reply = match super::process_platform_message(&state, &msg).await {
+                            ProcessOutcome::AgentReply(r)
+                            | ProcessOutcome::NeedsPairing(r)
+                            | ProcessOutcome::CommandReply(r) => r,
+                            ProcessOutcome::AtCapacity => {
+                                super::pairing_capacity_reply().to_owned()
+                            }
+                            ProcessOutcome::PairingError => {
+                                error!("whatsapp pairing check failed");
+                                return;
+                            }
+                            ProcessOutcome::ExecutionError(e) => {
+                                error!(error = %e, "whatsapp execution error");
+                                return;
+                            }
+                        };
 
                         if let Err(e) =
-                            send_reply(&state.http_client, &token, &phone_id, &from, &reply_text)
-                                .await
+                            send_reply(&state.http_client, &token, &phone_id, &from, &reply).await
                         {
                             error!(error = %e, "failed to send whatsapp reply");
                         }
-
-                        // Append delivery mirror for cross-platform visibility.
-                        crate::mirror::append_delivery_mirror(
-                            &state.loaded.config.storage.database_path,
-                            "whatsapp",
-                            &from,
-                            &reply_text,
-                            "whatsapp",
-                        );
                     }
                     .instrument(span),
                 );


### PR DESCRIPTION
## Summary

- **Extracts shared `process_platform_message()` pipeline** in `platforms/mod.rs` that centralizes the duplicated webhook flow: pairing check, gateway slash commands, session expiry reset, agent turn execution, reply extraction, and delivery mirror logging
- **Introduces `PlatformMessage` struct and `ProcessOutcome` enum** as the common interface between platform-specific payload extraction and the shared processing pipeline
- **Consolidates `split_message()` utility** (UTF-8-safe message chunking) from duplicated implementations in telegram.rs and signal.rs into the shared module
- **Refactors 5 platform handlers** (Telegram, Discord, Slack, WhatsApp, Signal) to delegate to the shared pipeline after platform-specific signature verification and message extraction

Net result: **633 lines removed, 488 added** (-145 net). The 5 separate copies of the pairing/command/expiry/run_turn/mirror pipeline are replaced by a single shared function. Home Assistant handler kept its direct `run_turn` call to preserve structured response metrics (`turns_used`, `tool_calls_made`).

All 201 gateway tests pass. Zero clippy warnings.

Closes #288

## Test plan
- [x] `cargo clippy -p genesis-gateway -- -D warnings` passes with zero warnings
- [x] `cargo test -p genesis-gateway` passes all 201 tests
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] Verify Telegram webhook flow works end-to-end (voice/sticker/text)
- [ ] Verify Discord interactions flow (deferred response + followup)
- [ ] Verify Slack events flow (message + app_mention)
- [ ] Verify WhatsApp webhook flow (text messages)
- [ ] Verify Signal DM + group message flow (with typing indicators)
- [ ] Verify Home Assistant webhook returns structured response with metrics