### PR TITLE
refactor(config): centralize environment variable loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
 name = "genesis-lua"
 version = "0.1.0"
 dependencies = [
+ "genesis-config",
  "genesis-storage",
  "genesis-types",
  "mlua",
@@ -1834,6 +1835,7 @@ name = "genesis-ui"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "genesis-config",
  "image",
  "owo-colors",
  "syntect",

--- a/apps/genesis/src/main.rs
+++ b/apps/genesis/src/main.rs
@@ -66,9 +66,8 @@ fn init_tracing(
 ) -> Option<OtelGuard> {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
-    let use_json = std::env::var("GENESIS_LOG_FORMAT")
-        .map(|v| v.eq_ignore_ascii_case("json"))
-        .unwrap_or(false);
+    let use_json = genesis_config::env::get_opt(genesis_config::env::GENESIS_LOG_FORMAT)
+        .is_some_and(|v| v.eq_ignore_ascii_case("json"));
 
     if tui_active {
         // TUI mode: redirect all logging to ~/.genesis/logs/tui.log so it

--- a/crates/genesis-auth/src/codex.rs
+++ b/crates/genesis-auth/src/codex.rs
@@ -48,9 +48,7 @@ fn refresh_client() -> &'static reqwest::Client {
 
 /// Read the Codex base URL, allowing override via `GENESIS_CODEX_BASE_URL` env var.
 fn codex_base_url() -> String {
-    std::env::var("GENESIS_CODEX_BASE_URL")
-        .ok()
-        .filter(|s| !s.is_empty())
+    genesis_config::env::get_opt(genesis_config::env::GENESIS_CODEX_BASE_URL)
         .unwrap_or_else(|| CODEX_INFERENCE_URL.to_owned())
 }
 
@@ -74,13 +72,14 @@ pub struct DeviceCodeResponse {
 
 /// Check if running in an SSH/remote session where browser can't be opened.
 pub fn is_remote_session() -> bool {
-    std::env::var("SSH_CLIENT").is_ok() || std::env::var("SSH_TTY").is_ok()
+    genesis_config::env::is_present(genesis_config::env::SSH_CLIENT)
+        || genesis_config::env::is_present(genesis_config::env::SSH_TTY)
 }
 
 /// Try to import tokens from the Codex CLI auth store (~/.codex/auth.json).
 /// Uses `CODEX_HOME` env var or defaults to `~/.codex`.
 pub fn import_codex_cli_tokens() -> Option<CodexTokens> {
-    let codex_dir = std::env::var_os("CODEX_HOME")
+    let codex_dir = genesis_config::env::get_os(genesis_config::env::CODEX_HOME)
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)
         .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;

--- a/crates/genesis-cli/src/clipboard.rs
+++ b/crates/genesis-cli/src/clipboard.rs
@@ -46,7 +46,7 @@ pub fn detect_platform() -> Result<DisplayPlatform, ClipboardError> {
     if cfg!(target_os = "macos") {
         Ok(DisplayPlatform::MacOs)
     } else if cfg!(target_os = "linux") {
-        if std::env::var("WAYLAND_DISPLAY").is_ok() {
+        if genesis_config::env::is_present(genesis_config::env::WAYLAND_DISPLAY) {
             Ok(DisplayPlatform::LinuxWayland)
         } else {
             Ok(DisplayPlatform::LinuxX11)

--- a/crates/genesis-cli/src/commands/init.rs
+++ b/crates/genesis-cli/src/commands/init.rs
@@ -281,7 +281,7 @@ pub(crate) async fn run_init_wizard(config_path: Option<PathBuf>) -> Result<Stri
         eprintln!();
 
         // Check if the key is actually set
-        if std::env::var(&input).is_ok() {
+        if genesis_config::env::is_present(&input) {
             eprintln!("  [ok] ${} is set", input);
         } else {
             eprintln!("  [!!] ${} is NOT set — set it before chatting:", input);
@@ -426,7 +426,7 @@ pub(crate) fn run_init_non_interactive(
         .api_key_env
         .as_deref()
         .unwrap_or("OPENAI_API_KEY");
-    if std::env::var(api_key_var).is_ok() {
+    if genesis_config::env::is_present(api_key_var) {
         steps.push(format!("[ok] API key: ${api_key_var} is set"));
     } else {
         steps.push(format!(

--- a/crates/genesis-cli/src/commands/misc.rs
+++ b/crates/genesis-cli/src/commands/misc.rs
@@ -1147,7 +1147,7 @@ pub(crate) fn run_context(command: ContextCommand) -> Result<String, CliError> {
                 std::fs::write(&context_path, context_template())?;
             }
 
-            let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
+            let editor = genesis_config::env::get_or(genesis_config::env::EDITOR, "vi");
             let path_str = context_path.display().to_string();
             let status = std::process::Command::new(&editor)
                 .arg(&path_str)
@@ -1287,7 +1287,7 @@ pub(crate) async fn run_model(
             let _ = std::fs::create_dir_all(&cache_dir);
 
             // Resolve API key for OpenRouter.
-            let api_key = std::env::var("OPENROUTER_API_KEY").ok();
+            let api_key = genesis_config::env::get_opt(genesis_config::env::OPENROUTER_API_KEY);
 
             // Fetch models.
             let mut models =

--- a/crates/genesis-cli/src/commands/serve.rs
+++ b/crates/genesis-cli/src/commands/serve.rs
@@ -64,7 +64,7 @@ pub(crate) async fn run_serve(
     let service = build_session_service(&loaded, strict_startup, false, runtime_overrides).await?;
     let mcp = service.mcp_manager();
 
-    let api_key = std::env::var("GENESIS_API_KEY").ok();
+    let api_key = genesis_config::env::get_opt(genesis_config::env::GENESIS_API_KEY);
     let api_key_required = resolve_api_key_required(&loaded.config.profile)?;
 
     // Warn before binding if exposing the server without authentication
@@ -81,9 +81,7 @@ pub(crate) async fn run_serve(
 
     let trusted_proxies = parse_trusted_proxies()?;
     // Env var overrides config file setting
-    let rate_limit_rpm = std::env::var("GENESIS_RATE_LIMIT_RPM")
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok())
+    let rate_limit_rpm = genesis_config::env::get_u32(genesis_config::env::GENESIS_RATE_LIMIT_RPM)
         .or_else(|| {
             loaded
                 .config

--- a/crates/genesis-cli/src/lib.rs
+++ b/crates/genesis-cli/src/lib.rs
@@ -1135,7 +1135,7 @@ pub async fn run(cli: Cli) -> Result<String, CliError> {
         }
         Command::Config(ConfigCommand::Edit) => {
             let loaded = load(cli.config.as_deref())?;
-            let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_owned());
+            let editor = genesis_config::env::get_or(genesis_config::env::EDITOR, "vi");
             let config_path = loaded.paths.config_path.display().to_string();
             let status = std::process::Command::new(&editor)
                 .arg(&config_path)
@@ -1192,7 +1192,7 @@ pub async fn run(cli: Cli) -> Result<String, CliError> {
                         _ => "OPENAI_API_KEY",
                     },
                 );
-            if std::env::var(api_key_env).is_err() {
+            if genesis_config::env::get(api_key_env).is_err() {
                 warnings.push(format!("API key env var '{}' is not set.", api_key_env));
             }
 
@@ -2010,7 +2010,7 @@ fn is_production_profile(profile: &str) -> bool {
 }
 
 fn parse_bool_env(name: &str) -> Option<Result<bool, CliError>> {
-    std::env::var(name).ok().map(|value| {
+    genesis_config::env::get(name).ok().map(|value| {
         value.parse::<bool>().map_err(|_| {
             CliError::Other(format!(
                 "invalid value for {name}: {value} (expected true or false)"
@@ -2020,14 +2020,13 @@ fn parse_bool_env(name: &str) -> Option<Result<bool, CliError>> {
 }
 
 fn is_production_environment() -> bool {
-    std::env::var("GENESIS_ENV")
-        .ok()
+    genesis_config::env::get_opt(genesis_config::env::GENESIS_ENV)
         .map(|value| is_production_profile(&value))
         .unwrap_or(false)
 }
 
 fn mcp_startup_strict(loaded: &LoadedConfig) -> Result<bool, CliError> {
-    if let Some(result) = parse_bool_env("GENESIS_MCP_STRICT_STARTUP") {
+    if let Some(result) = parse_bool_env(genesis_config::env::GENESIS_MCP_STRICT_STARTUP) {
         return result;
     }
 
@@ -2035,7 +2034,7 @@ fn mcp_startup_strict(loaded: &LoadedConfig) -> Result<bool, CliError> {
 }
 
 fn resolve_api_key_required(_profile: &str) -> Result<bool, CliError> {
-    if let Some(result) = parse_bool_env("GENESIS_API_KEY_REQUIRED") {
+    if let Some(result) = parse_bool_env(genesis_config::env::GENESIS_API_KEY_REQUIRED) {
         return result;
     }
 
@@ -2043,7 +2042,7 @@ fn resolve_api_key_required(_profile: &str) -> Result<bool, CliError> {
 }
 
 fn parse_trusted_proxies() -> Result<Vec<std::net::IpAddr>, CliError> {
-    match std::env::var("GENESIS_TRUSTED_PROXIES") {
+    match genesis_config::env::get(genesis_config::env::GENESIS_TRUSTED_PROXIES) {
         Ok(value) => value
             .split(',')
             .map(|entry| entry.trim())

--- a/crates/genesis-config/src/env.rs
+++ b/crates/genesis-config/src/env.rs
@@ -1,0 +1,590 @@
+//! Centralized environment variable loading for the Genesis project.
+//!
+//! All environment variable names used by Genesis are defined here as constants,
+//! with accessor functions that provide consistent loading semantics. This
+//! eliminates scattered `std::env::var(...)` calls across the codebase and gives
+//! a single source of truth for every env var the system reads.
+//!
+//! # Categories
+//!
+//! | Prefix / Group        | Purpose                                       |
+//! |-----------------------|-----------------------------------------------|
+//! | `GENESIS_*`           | Core Genesis configuration                    |
+//! | Provider keys         | LLM provider API keys                         |
+//! | `TELEGRAM_*`          | Telegram platform integration                 |
+//! | `DISCORD_*`           | Discord platform integration                  |
+//! | `SLACK_*`             | Slack platform integration                    |
+//! | `WHATSAPP_*`          | WhatsApp platform integration                 |
+//! | `SIGNAL_*`            | Signal platform integration                   |
+//! | `HOMEASSISTANT_*`     | Home Assistant platform integration            |
+//! | `HASS_*`              | Home Assistant tool integration (hass style)   |
+//! | `BROWSERBASE_*`       | Browserbase cloud browser                     |
+//! | `BROWSER_*`           | Local browser settings                        |
+//! | `DAYTONA_*`           | Daytona sandbox                               |
+//! | `MODAL_*`             | Modal sandbox                                 |
+//! | `TERMINAL_*`          | Terminal/sandbox scratch directories           |
+//! | `GATEWAY_*`           | Gateway access control                        |
+//! | Shell / OS            | `HOME`, `PATH`, `EDITOR`, `NO_COLOR`, etc.    |
+
+// ---------------------------------------------------------------------------
+// Genesis core
+// ---------------------------------------------------------------------------
+
+/// Log format override (`json` for structured logging).
+pub const GENESIS_LOG_FORMAT: &str = "GENESIS_LOG_FORMAT";
+
+/// API key for the Genesis gateway HTTP server.
+pub const GENESIS_API_KEY: &str = "GENESIS_API_KEY";
+
+/// Whether the gateway API key is required (`true`/`false`).
+pub const GENESIS_API_KEY_REQUIRED: &str = "GENESIS_API_KEY_REQUIRED";
+
+/// Requests-per-minute rate limit override for the gateway.
+pub const GENESIS_RATE_LIMIT_RPM: &str = "GENESIS_RATE_LIMIT_RPM";
+
+/// Comma-separated list of trusted proxy IP addresses.
+pub const GENESIS_TRUSTED_PROXIES: &str = "GENESIS_TRUSTED_PROXIES";
+
+/// Current environment name (`prod`, `production`, etc.).
+pub const GENESIS_ENV: &str = "GENESIS_ENV";
+
+/// Whether MCP server connections must succeed at startup (`true`/`false`).
+pub const GENESIS_MCP_STRICT_STARTUP: &str = "GENESIS_MCP_STRICT_STARTUP";
+
+/// Override data directory path.
+pub const GENESIS_DATA_DIR: &str = "GENESIS_DATA_DIR";
+
+/// Override database file path.
+pub const GENESIS_DATABASE_PATH: &str = "GENESIS_DATABASE_PATH";
+
+/// Codex inference base URL override.
+pub const GENESIS_CODEX_BASE_URL: &str = "GENESIS_CODEX_BASE_URL";
+
+/// Debug mode flag.
+pub const GENESIS_DEBUG: &str = "GENESIS_DEBUG";
+
+// ---------------------------------------------------------------------------
+// LLM provider API keys
+// ---------------------------------------------------------------------------
+
+/// OpenAI API key.
+pub const OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+
+/// OpenAI-compatible API base URL override.
+pub const OPENAI_API_BASE: &str = "OPENAI_API_BASE";
+
+/// Anthropic API key.
+pub const ANTHROPIC_API_KEY: &str = "ANTHROPIC_API_KEY";
+
+/// OpenRouter API key.
+pub const OPENROUTER_API_KEY: &str = "OPENROUTER_API_KEY";
+
+/// Google / Gemini API key.
+pub const GOOGLE_API_KEY: &str = "GOOGLE_API_KEY";
+
+/// Brave Search API key.
+pub const BRAVE_API_KEY: &str = "BRAVE_API_KEY";
+
+/// GitHub personal access token (used for skills hub).
+pub const GITHUB_TOKEN: &str = "GITHUB_TOKEN";
+
+/// Auxiliary vision model override (default: `gpt-4o`).
+pub const AUXILIARY_VISION_MODEL: &str = "AUXILIARY_VISION_MODEL";
+
+// ---------------------------------------------------------------------------
+// Telegram
+// ---------------------------------------------------------------------------
+
+/// Telegram Bot API token.
+pub const TELEGRAM_BOT_TOKEN: &str = "TELEGRAM_BOT_TOKEN";
+
+/// Shared secret for Telegram webhook verification.
+pub const TELEGRAM_WEBHOOK_SECRET: &str = "TELEGRAM_WEBHOOK_SECRET";
+
+/// Allow all Telegram users without pairing.
+pub const TELEGRAM_ALLOW_ALL_USERS: &str = "TELEGRAM_ALLOW_ALL_USERS";
+
+/// Comma-separated list of allowed Telegram user IDs.
+pub const TELEGRAM_ALLOWED_USERS: &str = "TELEGRAM_ALLOWED_USERS";
+
+// ---------------------------------------------------------------------------
+// Discord
+// ---------------------------------------------------------------------------
+
+/// Discord application public key (for interaction signature verification).
+pub const DISCORD_PUBLIC_KEY: &str = "DISCORD_PUBLIC_KEY";
+
+/// Discord bot token.
+pub const DISCORD_BOT_TOKEN: &str = "DISCORD_BOT_TOKEN";
+
+/// Allow all Discord users without pairing.
+pub const DISCORD_ALLOW_ALL_USERS: &str = "DISCORD_ALLOW_ALL_USERS";
+
+/// Comma-separated list of allowed Discord user IDs.
+pub const DISCORD_ALLOWED_USERS: &str = "DISCORD_ALLOWED_USERS";
+
+// ---------------------------------------------------------------------------
+// Slack
+// ---------------------------------------------------------------------------
+
+/// Slack bot OAuth token.
+pub const SLACK_BOT_TOKEN: &str = "SLACK_BOT_TOKEN";
+
+/// Slack app signing secret.
+pub const SLACK_SIGNING_SECRET: &str = "SLACK_SIGNING_SECRET";
+
+/// Allow all Slack users without pairing.
+pub const SLACK_ALLOW_ALL_USERS: &str = "SLACK_ALLOW_ALL_USERS";
+
+/// Comma-separated list of allowed Slack user IDs.
+pub const SLACK_ALLOWED_USERS: &str = "SLACK_ALLOWED_USERS";
+
+// ---------------------------------------------------------------------------
+// WhatsApp
+// ---------------------------------------------------------------------------
+
+/// WhatsApp Cloud API permanent token.
+pub const WHATSAPP_TOKEN: &str = "WHATSAPP_TOKEN";
+
+/// WhatsApp Business phone number ID.
+pub const WHATSAPP_PHONE_NUMBER_ID: &str = "WHATSAPP_PHONE_NUMBER_ID";
+
+/// WhatsApp webhook verification token.
+pub const WHATSAPP_VERIFY_TOKEN: &str = "WHATSAPP_VERIFY_TOKEN";
+
+/// WhatsApp app secret (HMAC webhook signature verification).
+pub const WHATSAPP_APP_SECRET: &str = "WHATSAPP_APP_SECRET";
+
+/// Allow all WhatsApp users without pairing.
+pub const WHATSAPP_ALLOW_ALL_USERS: &str = "WHATSAPP_ALLOW_ALL_USERS";
+
+/// Comma-separated list of allowed WhatsApp user IDs.
+pub const WHATSAPP_ALLOWED_USERS: &str = "WHATSAPP_ALLOWED_USERS";
+
+// ---------------------------------------------------------------------------
+// Signal
+// ---------------------------------------------------------------------------
+
+/// Base URL of the signal-cli HTTP daemon.
+pub const SIGNAL_HTTP_URL: &str = "SIGNAL_HTTP_URL";
+
+/// Registered Signal account (phone number).
+pub const SIGNAL_ACCOUNT: &str = "SIGNAL_ACCOUNT";
+
+/// Shared secret for Signal webhook endpoint authentication.
+pub const SIGNAL_WEBHOOK_SECRET: &str = "SIGNAL_WEBHOOK_SECRET";
+
+/// Comma-separated phone numbers allowed to interact in Signal group chats.
+pub const SIGNAL_GROUP_ALLOWED_USERS: &str = "SIGNAL_GROUP_ALLOWED_USERS";
+
+/// Allow all Signal users without pairing.
+pub const SIGNAL_ALLOW_ALL_USERS: &str = "SIGNAL_ALLOW_ALL_USERS";
+
+/// Comma-separated list of allowed Signal user IDs.
+pub const SIGNAL_ALLOWED_USERS: &str = "SIGNAL_ALLOWED_USERS";
+
+// ---------------------------------------------------------------------------
+// Home Assistant
+// ---------------------------------------------------------------------------
+
+/// Home Assistant webhook authentication token.
+pub const HOMEASSISTANT_TOKEN: &str = "HOMEASSISTANT_TOKEN";
+
+/// Home Assistant base URL (for REST API callbacks).
+pub const HOMEASSISTANT_URL: &str = "HOMEASSISTANT_URL";
+
+/// Home Assistant long-lived access token (for service calls).
+pub const HOMEASSISTANT_LONG_LIVED_TOKEN: &str = "HOMEASSISTANT_LONG_LIVED_TOKEN";
+
+/// Home Assistant URL (hass-style, used by HA tools).
+pub const HASS_URL: &str = "HASS_URL";
+
+/// Home Assistant token (hass-style, used by HA tools).
+pub const HASS_TOKEN: &str = "HASS_TOKEN";
+
+// ---------------------------------------------------------------------------
+// Gateway access control
+// ---------------------------------------------------------------------------
+
+/// Comma-separated list of globally allowed user IDs (all platforms).
+pub const GATEWAY_ALLOWED_USERS: &str = "GATEWAY_ALLOWED_USERS";
+
+/// Allow all users on all platforms without pairing.
+pub const GATEWAY_ALLOW_ALL_USERS: &str = "GATEWAY_ALLOW_ALL_USERS";
+
+// ---------------------------------------------------------------------------
+// Browserbase (cloud browser)
+// ---------------------------------------------------------------------------
+
+/// Browserbase API key.
+pub const BROWSERBASE_API_KEY: &str = "BROWSERBASE_API_KEY";
+
+/// Browserbase project ID.
+pub const BROWSERBASE_PROJECT_ID: &str = "BROWSERBASE_PROJECT_ID";
+
+/// Enable/disable Browserbase proxy support.
+pub const BROWSERBASE_PROXIES: &str = "BROWSERBASE_PROXIES";
+
+/// Enable/disable Browserbase advanced stealth mode.
+pub const BROWSERBASE_ADVANCED_STEALTH: &str = "BROWSERBASE_ADVANCED_STEALTH";
+
+/// Enable/disable Browserbase keep-alive.
+pub const BROWSERBASE_KEEP_ALIVE: &str = "BROWSERBASE_KEEP_ALIVE";
+
+/// Browserbase session timeout in milliseconds.
+pub const BROWSERBASE_SESSION_TIMEOUT: &str = "BROWSERBASE_SESSION_TIMEOUT";
+
+// ---------------------------------------------------------------------------
+// Local browser
+// ---------------------------------------------------------------------------
+
+/// Browser inactivity timeout in seconds.
+pub const BROWSER_INACTIVITY_TIMEOUT: &str = "BROWSER_INACTIVITY_TIMEOUT";
+
+// ---------------------------------------------------------------------------
+// Sandbox backends
+// ---------------------------------------------------------------------------
+
+/// Daytona API key.
+pub const DAYTONA_API_KEY: &str = "DAYTONA_API_KEY";
+
+/// Daytona API URL override.
+pub const DAYTONA_API_URL: &str = "DAYTONA_API_URL";
+
+/// Modal token ID.
+pub const MODAL_TOKEN_ID: &str = "MODAL_TOKEN_ID";
+
+/// Modal token secret.
+pub const MODAL_TOKEN_SECRET: &str = "MODAL_TOKEN_SECRET";
+
+/// Singularity scratch directory override.
+pub const TERMINAL_SCRATCH_DIR: &str = "TERMINAL_SCRATCH_DIR";
+
+/// Singularity sandbox directory override.
+pub const TERMINAL_SANDBOX_DIR: &str = "TERMINAL_SANDBOX_DIR";
+
+// ---------------------------------------------------------------------------
+// SSH / Remote detection
+// ---------------------------------------------------------------------------
+
+/// Set by SSH when connecting (used for remote session detection).
+pub const SSH_CLIENT: &str = "SSH_CLIENT";
+
+/// Set by SSH for allocated TTY (used for remote session detection).
+pub const SSH_TTY: &str = "SSH_TTY";
+
+/// Codex CLI home directory override.
+pub const CODEX_HOME: &str = "CODEX_HOME";
+
+// ---------------------------------------------------------------------------
+// Shell / OS / Display
+// ---------------------------------------------------------------------------
+
+/// User's home directory.
+pub const HOME: &str = "HOME";
+
+/// Preferred text editor.
+pub const EDITOR: &str = "EDITOR";
+
+/// Current system PATH.
+pub const PATH: &str = "PATH";
+
+/// Current user name.
+pub const USER: &str = "USER";
+
+/// Disable color output (<https://no-color.org>).
+pub const NO_COLOR: &str = "NO_COLOR";
+
+/// Reduce motion / animations.
+pub const REDUCE_MOTION: &str = "REDUCE_MOTION";
+
+/// Wayland display (used for clipboard platform detection).
+pub const WAYLAND_DISPLAY: &str = "WAYLAND_DISPLAY";
+
+/// Tmux session detection.
+pub const TMUX: &str = "TMUX";
+
+/// Zellij session detection.
+pub const ZELLIJ_SESSION_NAME: &str = "ZELLIJ_SESSION_NAME";
+
+// ---------------------------------------------------------------------------
+// Accessor helpers
+// ---------------------------------------------------------------------------
+
+/// Read an optional string env var (returns `None` if unset or empty).
+#[inline]
+pub fn get_opt(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|s| !s.is_empty())
+}
+
+/// Read a required string env var (returns `Err` if unset).
+#[inline]
+pub fn get(name: &str) -> Result<String, std::env::VarError> {
+    std::env::var(name)
+}
+
+/// Check whether an env var is set (non-empty).
+#[inline]
+pub fn is_set(name: &str) -> bool {
+    std::env::var(name).ok().is_some_and(|v| !v.is_empty())
+}
+
+/// Check whether an env var is present (even if empty).
+#[inline]
+pub fn is_present(name: &str) -> bool {
+    std::env::var(name).is_ok()
+}
+
+/// Read an env var as an `OsString`, returning `None` if unset.
+#[inline]
+pub fn get_os(name: &str) -> Option<std::ffi::OsString> {
+    std::env::var_os(name)
+}
+
+/// Parse a boolean-ish env var (`1`, `true`, `yes`, `on` → true).
+/// Returns `default` when the var is unset.
+#[inline]
+pub fn get_bool(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(default)
+}
+
+/// Parse a `u64` env var, returning `None` when unset or unparseable.
+#[inline]
+pub fn get_u64(name: &str) -> Option<u64> {
+    std::env::var(name).ok().and_then(|v| v.parse().ok())
+}
+
+/// Parse a `u32` env var, returning `None` when unset or unparseable.
+#[inline]
+pub fn get_u32(name: &str) -> Option<u32> {
+    std::env::var(name).ok().and_then(|v| v.parse().ok())
+}
+
+/// Read an env var with a fallback default value.
+#[inline]
+pub fn get_or(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_owned())
+}
+
+/// Return the platform-specific allowlist env var name.
+pub fn platform_allowlist_var(platform: &str) -> &'static str {
+    match platform {
+        "telegram" => TELEGRAM_ALLOWED_USERS,
+        "discord" => DISCORD_ALLOWED_USERS,
+        "whatsapp" => WHATSAPP_ALLOWED_USERS,
+        "slack" => SLACK_ALLOWED_USERS,
+        "signal" => SIGNAL_ALLOWED_USERS,
+        _ => "",
+    }
+}
+
+/// Return the platform-specific allow-all env var name.
+pub fn platform_allow_all_var(platform: &str) -> &'static str {
+    match platform {
+        "telegram" => TELEGRAM_ALLOW_ALL_USERS,
+        "discord" => DISCORD_ALLOW_ALL_USERS,
+        "whatsapp" => WHATSAPP_ALLOW_ALL_USERS,
+        "slack" => SLACK_ALLOW_ALL_USERS,
+        "signal" => SIGNAL_ALLOW_ALL_USERS,
+        _ => "",
+    }
+}
+
+/// Collect all env vars into a `BTreeMap` (used for provider resolution, etc.).
+#[inline]
+pub fn all_vars() -> std::collections::BTreeMap<String, String> {
+    std::env::vars().collect()
+}
+
+// ---------------------------------------------------------------------------
+// Startup validation
+// ---------------------------------------------------------------------------
+
+/// A warning about a missing or misconfigured environment variable.
+#[derive(Debug, Clone)]
+pub struct EnvWarning {
+    pub var_name: &'static str,
+    pub message: String,
+}
+
+impl std::fmt::Display for EnvWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.var_name, self.message)
+    }
+}
+
+/// Validate that env vars required for enabled features are present.
+///
+/// Returns a list of warnings (not errors) so the caller can log them.
+/// This is meant to be called once at startup.
+pub fn validate_startup() -> Vec<EnvWarning> {
+    let mut warnings = Vec::new();
+
+    // Check platform tokens: warn if only partially configured.
+    if is_present(TELEGRAM_BOT_TOKEN) && !is_present(TELEGRAM_WEBHOOK_SECRET) {
+        warnings.push(EnvWarning {
+            var_name: TELEGRAM_WEBHOOK_SECRET,
+            message: "TELEGRAM_BOT_TOKEN is set but TELEGRAM_WEBHOOK_SECRET is not — \
+                      webhook requests will not be verified"
+                .to_owned(),
+        });
+    }
+
+    if is_present(SLACK_BOT_TOKEN) && !is_present(SLACK_SIGNING_SECRET) {
+        warnings.push(EnvWarning {
+            var_name: SLACK_SIGNING_SECRET,
+            message: "SLACK_BOT_TOKEN is set but SLACK_SIGNING_SECRET is not — \
+                      webhook requests will not be verified"
+                .to_owned(),
+        });
+    }
+
+    if is_present(WHATSAPP_TOKEN) {
+        if !is_present(WHATSAPP_PHONE_NUMBER_ID) {
+            warnings.push(EnvWarning {
+                var_name: WHATSAPP_PHONE_NUMBER_ID,
+                message: "WHATSAPP_TOKEN is set but WHATSAPP_PHONE_NUMBER_ID is not — \
+                          WhatsApp messages cannot be sent"
+                    .to_owned(),
+            });
+        }
+        if !is_present(WHATSAPP_APP_SECRET) {
+            warnings.push(EnvWarning {
+                var_name: WHATSAPP_APP_SECRET,
+                message: "WHATSAPP_TOKEN is set but WHATSAPP_APP_SECRET is not — \
+                          webhook requests will not be verified"
+                    .to_owned(),
+            });
+        }
+    }
+
+    if is_present(SIGNAL_ACCOUNT) && !is_present(SIGNAL_HTTP_URL) {
+        warnings.push(EnvWarning {
+            var_name: SIGNAL_HTTP_URL,
+            message: "SIGNAL_ACCOUNT is set but SIGNAL_HTTP_URL is not — \
+                      will default to http://127.0.0.1:8080"
+                .to_owned(),
+        });
+    }
+
+    warnings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_opt_returns_none_for_unset() {
+        // Use a var name that is extremely unlikely to be set.
+        assert!(get_opt("__GENESIS_TEST_UNSET_VAR_XYZ__").is_none());
+    }
+
+    #[test]
+    fn is_set_returns_false_for_unset() {
+        assert!(!is_set("__GENESIS_TEST_UNSET_VAR_XYZ__"));
+    }
+
+    #[test]
+    fn is_present_returns_false_for_unset() {
+        assert!(!is_present("__GENESIS_TEST_UNSET_VAR_XYZ__"));
+    }
+
+    #[test]
+    fn get_bool_returns_default_for_unset() {
+        assert!(!get_bool("__GENESIS_TEST_UNSET_VAR_XYZ__", false));
+        assert!(get_bool("__GENESIS_TEST_UNSET_VAR_XYZ__", true));
+    }
+
+    #[test]
+    fn get_bool_parses_truthy_values() {
+        std::env::set_var("__GENESIS_TEST_BOOL_1__", "1");
+        assert!(get_bool("__GENESIS_TEST_BOOL_1__", false));
+        std::env::remove_var("__GENESIS_TEST_BOOL_1__");
+
+        std::env::set_var("__GENESIS_TEST_BOOL_TRUE__", "True");
+        assert!(get_bool("__GENESIS_TEST_BOOL_TRUE__", false));
+        std::env::remove_var("__GENESIS_TEST_BOOL_TRUE__");
+
+        std::env::set_var("__GENESIS_TEST_BOOL_YES__", "YES");
+        assert!(get_bool("__GENESIS_TEST_BOOL_YES__", false));
+        std::env::remove_var("__GENESIS_TEST_BOOL_YES__");
+
+        std::env::set_var("__GENESIS_TEST_BOOL_ON__", "on");
+        assert!(get_bool("__GENESIS_TEST_BOOL_ON__", false));
+        std::env::remove_var("__GENESIS_TEST_BOOL_ON__");
+    }
+
+    #[test]
+    fn get_bool_returns_false_for_falsy_values() {
+        std::env::set_var("__GENESIS_TEST_BOOL_NO__", "no");
+        assert!(!get_bool("__GENESIS_TEST_BOOL_NO__", true));
+        std::env::remove_var("__GENESIS_TEST_BOOL_NO__");
+    }
+
+    #[test]
+    fn get_u64_returns_none_for_unset() {
+        assert!(get_u64("__GENESIS_TEST_UNSET_VAR_XYZ__").is_none());
+    }
+
+    #[test]
+    fn get_u64_parses_valid_numbers() {
+        std::env::set_var("__GENESIS_TEST_U64__", "42");
+        assert_eq!(get_u64("__GENESIS_TEST_U64__"), Some(42));
+        std::env::remove_var("__GENESIS_TEST_U64__");
+    }
+
+    #[test]
+    fn get_or_returns_default_for_unset() {
+        assert_eq!(
+            get_or("__GENESIS_TEST_UNSET_VAR_XYZ__", "fallback"),
+            "fallback"
+        );
+    }
+
+    #[test]
+    fn get_or_returns_value_when_set() {
+        std::env::set_var("__GENESIS_TEST_GET_OR__", "custom");
+        assert_eq!(get_or("__GENESIS_TEST_GET_OR__", "fallback"), "custom");
+        std::env::remove_var("__GENESIS_TEST_GET_OR__");
+    }
+
+    #[test]
+    fn platform_allowlist_var_returns_correct_names() {
+        assert_eq!(platform_allowlist_var("telegram"), TELEGRAM_ALLOWED_USERS);
+        assert_eq!(platform_allowlist_var("discord"), DISCORD_ALLOWED_USERS);
+        assert_eq!(platform_allowlist_var("whatsapp"), WHATSAPP_ALLOWED_USERS);
+        assert_eq!(platform_allowlist_var("slack"), SLACK_ALLOWED_USERS);
+        assert_eq!(platform_allowlist_var("signal"), SIGNAL_ALLOWED_USERS);
+        assert_eq!(platform_allowlist_var("unknown"), "");
+    }
+
+    #[test]
+    fn platform_allow_all_var_returns_correct_names() {
+        assert_eq!(platform_allow_all_var("telegram"), TELEGRAM_ALLOW_ALL_USERS);
+        assert_eq!(platform_allow_all_var("discord"), DISCORD_ALLOW_ALL_USERS);
+        assert_eq!(platform_allow_all_var("slack"), SLACK_ALLOW_ALL_USERS);
+        assert_eq!(platform_allow_all_var("signal"), SIGNAL_ALLOW_ALL_USERS);
+        assert_eq!(platform_allow_all_var("unknown"), "");
+    }
+
+    #[test]
+    fn validate_startup_returns_empty_when_nothing_configured() {
+        // When no platform tokens are set, there should be no warnings.
+        // (We can't guarantee the test env doesn't have these set, but
+        // in most CI / dev environments they won't be.)
+        let warnings = validate_startup();
+        // Just verify it doesn't panic and returns a Vec.
+        let _ = warnings;
+    }
+
+    #[test]
+    fn all_vars_returns_btreemap() {
+        let vars = all_vars();
+        // PATH is virtually always set.
+        assert!(vars.contains_key("PATH") || vars.is_empty());
+    }
+}

--- a/crates/genesis-config/src/lib.rs
+++ b/crates/genesis-config/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod defaults;
+pub mod env;
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -1015,7 +1016,7 @@ pub enum ConfigError {
 }
 
 pub fn load(config_path_override: Option<&Path>) -> Result<LoadedConfig, ConfigError> {
-    let env = std::env::vars().collect::<BTreeMap<_, _>>();
+    let env = env::all_vars();
     load_from_map(config_path_override, &env)
 }
 

--- a/crates/genesis-core/src/embedding.rs
+++ b/crates/genesis-core/src/embedding.rs
@@ -81,7 +81,7 @@ impl RemoteEmbeddingProvider {
     /// Resolves the API key from the environment using the same strategy
     /// as the main provider (explicit env var name, then standard fallbacks).
     fn from_config(config: &EmbeddingConfig) -> Result<Self, EmbeddingError> {
-        let env: std::collections::BTreeMap<String, String> = std::env::vars().collect();
+        let env: std::collections::BTreeMap<String, String> = genesis_config::env::all_vars();
         let resolved = genesis_provider::resolve(
             &config.backend,
             &config.model,

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -81,12 +81,7 @@ fn lua_runtime_build_count(key: &LuaRuntimeCacheKey) -> usize {
 }
 
 fn env_flag(name: &str) -> bool {
-    std::env::var(name).ok().is_some_and(|value| {
-        matches!(
-            value.to_ascii_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    genesis_config::env::get_bool(name, false)
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -361,7 +361,7 @@ fn mask_api_key(key: &str) -> String {
 
 /// Check whether the configured API key resolves to a non-empty value.
 fn check_api_key(loaded: &LoadedConfig) -> DoctorCheck {
-    let env: std::collections::BTreeMap<String, String> = std::env::vars().collect();
+    let env: std::collections::BTreeMap<String, String> = genesis_config::env::all_vars();
     let resolved = resolve(
         &loaded.config.provider.backend,
         &loaded.config.provider.model,

--- a/crates/genesis-core/src/moa.rs
+++ b/crates/genesis-core/src/moa.rs
@@ -93,7 +93,7 @@ pub async fn run_moa(
     }
 
     let layers = config.layers.max(1);
-    let env: BTreeMap<String, String> = std::env::vars().collect();
+    let env: BTreeMap<String, String> = genesis_config::env::all_vars();
 
     let mut proposer_responses = Vec::new();
 

--- a/crates/genesis-core/src/sandbox/daytona.rs
+++ b/crates/genesis-core/src/sandbox/daytona.rs
@@ -77,12 +77,11 @@ pub struct DaytonaSandbox {
 
 impl DaytonaSandbox {
     pub fn new() -> Result<Self, SandboxError> {
-        let api_key = std::env::var("DAYTONA_API_KEY").map_err(|_| SandboxError::AuthError {
+        let api_key = genesis_config::env::get(genesis_config::env::DAYTONA_API_KEY).map_err(|_| SandboxError::AuthError {
             reason: "DAYTONA_API_KEY env var not set".into(),
         })?;
 
-        let base_url = std::env::var("DAYTONA_API_URL")
-            .unwrap_or_else(|_| "https://app.daytona.io/api".into());
+        let base_url = genesis_config::env::get_or(genesis_config::env::DAYTONA_API_URL, "https://app.daytona.io/api");
 
         let mut default_headers = HeaderMap::new();
         let auth_value = HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
@@ -340,12 +339,12 @@ mod tests {
     #[test]
     fn missing_api_key_returns_auth_error() {
         // Temporarily ensure the env var is unset
-        let original = std::env::var("DAYTONA_API_KEY").ok();
-        std::env::remove_var("DAYTONA_API_KEY");
+        let original = std::env::var(genesis_config::env::DAYTONA_API_KEY).ok();
+        std::env::remove_var(genesis_config::env::DAYTONA_API_KEY);
         let result = DaytonaSandbox::new();
         // Restore
         if let Some(val) = original {
-            std::env::set_var("DAYTONA_API_KEY", val);
+            std::env::set_var(genesis_config::env::DAYTONA_API_KEY, val);
         }
         assert!(result.is_err());
         assert!(matches!(

--- a/crates/genesis-core/src/sandbox/modal.rs
+++ b/crates/genesis-core/src/sandbox/modal.rs
@@ -66,8 +66,8 @@ impl ModalSandbox {
 
         // Warn if Modal auth is not configured (don't hard-fail — the user may
         // configure auth later or rely on env vars set at runtime).
-        let has_env_auth =
-            std::env::var("MODAL_TOKEN_ID").is_ok() && std::env::var("MODAL_TOKEN_SECRET").is_ok();
+        let has_env_auth = genesis_config::env::is_present(genesis_config::env::MODAL_TOKEN_ID)
+            && genesis_config::env::is_present(genesis_config::env::MODAL_TOKEN_SECRET);
         let has_toml_auth = dirs::home_dir()
             .map(|h| h.join(".modal.toml").exists())
             .unwrap_or(false);

--- a/crates/genesis-core/src/sandbox/singularity.rs
+++ b/crates/genesis-core/src/sandbox/singularity.rs
@@ -47,21 +47,17 @@ pub fn sif_cache_key(image_url: &str) -> String {
 
 fn resolve_scratch_dir() -> PathBuf {
     // 1. TERMINAL_SCRATCH_DIR env var
-    if let Ok(val) = std::env::var("TERMINAL_SCRATCH_DIR") {
-        if !val.is_empty() {
-            return PathBuf::from(val);
-        }
+    if let Some(val) = genesis_config::env::get_opt(genesis_config::env::TERMINAL_SCRATCH_DIR) {
+        return PathBuf::from(val);
     }
 
     // 2. TERMINAL_SANDBOX_DIR + /singularity
-    if let Ok(val) = std::env::var("TERMINAL_SANDBOX_DIR") {
-        if !val.is_empty() {
-            return PathBuf::from(val).join("singularity");
-        }
+    if let Some(val) = genesis_config::env::get_opt(genesis_config::env::TERMINAL_SANDBOX_DIR) {
+        return PathBuf::from(val).join("singularity");
     }
 
     // 3. /scratch/{USER}/genesis — check exists + writable
-    if let Ok(user) = std::env::var("USER") {
+    if let Ok(user) = genesis_config::env::get(genesis_config::env::USER) {
         let candidate = PathBuf::from(format!("/scratch/{user}/genesis"));
         if std::fs::metadata(&candidate)
             .map(|m| !m.permissions().readonly())

--- a/crates/genesis-core/src/skills_hub.rs
+++ b/crates/genesis-core/src/skills_hub.rs
@@ -990,7 +990,7 @@ fn github_get(
     url: &str,
 ) -> Result<reqwest::blocking::Response, SkillHubError> {
     let mut request = client.get(url);
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+    if let Ok(token) = genesis_config::env::get(genesis_config::env::GITHUB_TOKEN) {
         request = request.bearer_auth(token);
     }
 
@@ -1014,7 +1014,7 @@ fn github_get_optional(
     url: &str,
 ) -> Result<Option<reqwest::blocking::Response>, SkillHubError> {
     let mut request = client.get(url);
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+    if let Ok(token) = genesis_config::env::get(genesis_config::env::GITHUB_TOKEN) {
         request = request.bearer_auth(token);
     }
 
@@ -1042,7 +1042,7 @@ fn github_download(
     url: &str,
 ) -> Result<Vec<u8>, SkillHubError> {
     let mut request = client.get(url);
-    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+    if let Ok(token) = genesis_config::env::get(genesis_config::env::GITHUB_TOKEN) {
         request = request.bearer_auth(token);
     }
 

--- a/crates/genesis-gateway/src/platforms/discord.rs
+++ b/crates/genesis-gateway/src/platforms/discord.rs
@@ -24,7 +24,7 @@ use crate::verify::verify_discord_signature;
 use crate::AppState;
 
 pub fn public_key() -> Option<String> {
-    std::env::var("DISCORD_PUBLIC_KEY").ok()
+    genesis_config::env::get_opt(genesis_config::env::DISCORD_PUBLIC_KEY)
 }
 
 // --- Discord API types (subset) ---

--- a/crates/genesis-gateway/src/platforms/homeassistant.rs
+++ b/crates/genesis-gateway/src/platforms/homeassistant.rs
@@ -46,7 +46,7 @@ pub struct HomeAssistantResponse {
 }
 
 fn webhook_token() -> Option<String> {
-    std::env::var("HOMEASSISTANT_TOKEN").ok()
+    genesis_config::env::get_opt(genesis_config::env::HOMEASSISTANT_TOKEN)
 }
 
 fn extract_provided_token(headers: &HeaderMap) -> Option<&str> {

--- a/crates/genesis-gateway/src/platforms/mod.rs
+++ b/crates/genesis-gateway/src/platforms/mod.rs
@@ -124,25 +124,18 @@ pub fn check_pairing(
 
     let platform = platform.to_ascii_lowercase();
 
-    let platform_allow_all = match platform.as_str() {
-        "telegram" => "TELEGRAM_ALLOW_ALL_USERS",
-        "discord" => "DISCORD_ALLOW_ALL_USERS",
-        "whatsapp" => "WHATSAPP_ALLOW_ALL_USERS",
-        "slack" => "SLACK_ALLOW_ALL_USERS",
-        "signal" => "SIGNAL_ALLOW_ALL_USERS",
-        _ => "",
-    };
+    let platform_allow_all = genesis_config::env::platform_allow_all_var(platform.as_str());
 
     if is_truthy_env(platform_allow_all) {
         return Ok(PairingCheck::Approved);
     }
 
     let platform_allowlist =
-        std::env::var(platform_allowlist_env(platform.as_str())).unwrap_or_default();
-    let global_allowlist = std::env::var("GATEWAY_ALLOWED_USERS").unwrap_or_default();
+        genesis_config::env::get_or(genesis_config::env::platform_allowlist_var(platform.as_str()), "");
+    let global_allowlist = genesis_config::env::get_or(genesis_config::env::GATEWAY_ALLOWED_USERS, "");
 
     if platform_allowlist.is_empty() && global_allowlist.is_empty() {
-        if is_truthy_env("GATEWAY_ALLOW_ALL_USERS") {
+        if is_truthy_env(genesis_config::env::GATEWAY_ALLOW_ALL_USERS) {
             return Ok(PairingCheck::Approved);
         }
     } else {
@@ -176,30 +169,11 @@ pub fn check_pairing(
     }
 }
 
-fn platform_allowlist_env(platform: &str) -> &'static str {
-    match platform {
-        "telegram" => "TELEGRAM_ALLOWED_USERS",
-        "discord" => "DISCORD_ALLOWED_USERS",
-        "whatsapp" => "WHATSAPP_ALLOWED_USERS",
-        "slack" => "SLACK_ALLOWED_USERS",
-        "signal" => "SIGNAL_ALLOWED_USERS",
-        _ => "",
-    }
-}
-
 fn is_truthy_env(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
-
-    matches!(
-        std::env::var(name)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    genesis_config::env::get_bool(name, false)
 }
 
 fn parse_env_id_set(value: &str) -> HashSet<String> {
@@ -317,12 +291,13 @@ mod tests {
 
     #[test]
     fn platform_allowlist_env_maps_known_platforms() {
-        assert_eq!(platform_allowlist_env("telegram"), "TELEGRAM_ALLOWED_USERS");
-        assert_eq!(platform_allowlist_env("discord"), "DISCORD_ALLOWED_USERS");
-        assert_eq!(platform_allowlist_env("whatsapp"), "WHATSAPP_ALLOWED_USERS");
-        assert_eq!(platform_allowlist_env("slack"), "SLACK_ALLOWED_USERS");
-        assert_eq!(platform_allowlist_env("signal"), "SIGNAL_ALLOWED_USERS");
-        assert_eq!(platform_allowlist_env("unknown"), "");
+        use genesis_config::env::platform_allowlist_var;
+        assert_eq!(platform_allowlist_var("telegram"), "TELEGRAM_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_var("discord"), "DISCORD_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_var("whatsapp"), "WHATSAPP_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_var("slack"), "SLACK_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_var("signal"), "SIGNAL_ALLOWED_USERS");
+        assert_eq!(platform_allowlist_var("unknown"), "");
     }
 
     #[test]

--- a/crates/genesis-gateway/src/platforms/signal.rs
+++ b/crates/genesis-gateway/src/platforms/signal.rs
@@ -38,25 +38,24 @@ use crate::AppState;
 
 /// Base URL of the signal-cli HTTP daemon.
 fn signal_http_url() -> String {
-    std::env::var("SIGNAL_HTTP_URL").unwrap_or_else(|_| "http://127.0.0.1:8080".to_owned())
+    genesis_config::env::get_or(genesis_config::env::SIGNAL_HTTP_URL, "http://127.0.0.1:8080")
 }
 
 /// The registered Signal account (phone number) this agent uses.
 fn signal_account() -> Option<String> {
-    std::env::var("SIGNAL_ACCOUNT").ok()
+    genesis_config::env::get_opt(genesis_config::env::SIGNAL_ACCOUNT)
 }
 
 /// Optional shared secret for webhook endpoint authentication.
 /// When set, incoming requests must include an `X-Signal-Secret` header
 /// matching this value; otherwise the request is rejected with 401.
 fn webhook_secret() -> Option<String> {
-    std::env::var("SIGNAL_WEBHOOK_SECRET").ok()
+    genesis_config::env::get_opt(genesis_config::env::SIGNAL_WEBHOOK_SECRET)
 }
 
 /// Comma-separated list of phone numbers allowed to interact in group chats.
 fn group_allowed_users() -> Vec<String> {
-    std::env::var("SIGNAL_GROUP_ALLOWED_USERS")
-        .unwrap_or_default()
+    genesis_config::env::get_or(genesis_config::env::SIGNAL_GROUP_ALLOWED_USERS, "")
         .split(',')
         .map(|s| s.trim().to_owned())
         .filter(|s| !s.is_empty())

--- a/crates/genesis-gateway/src/platforms/slack.rs
+++ b/crates/genesis-gateway/src/platforms/slack.rs
@@ -24,11 +24,11 @@ use crate::verify::verify_slack_signature;
 use crate::AppState;
 
 pub fn bot_token() -> Option<String> {
-    std::env::var("SLACK_BOT_TOKEN").ok()
+    genesis_config::env::get_opt(genesis_config::env::SLACK_BOT_TOKEN)
 }
 
 fn signing_secret() -> Option<String> {
-    std::env::var("SLACK_SIGNING_SECRET").ok()
+    genesis_config::env::get_opt(genesis_config::env::SLACK_SIGNING_SECRET)
 }
 
 // --- Slack API types ---

--- a/crates/genesis-gateway/src/platforms/telegram.rs
+++ b/crates/genesis-gateway/src/platforms/telegram.rs
@@ -28,11 +28,11 @@ use crate::AppState;
 
 /// Telegram Bot API token, loaded from environment.
 pub fn bot_token() -> Option<String> {
-    std::env::var("TELEGRAM_BOT_TOKEN").ok()
+    genesis_config::env::get_opt(genesis_config::env::TELEGRAM_BOT_TOKEN)
 }
 
 pub fn webhook_secret() -> Option<String> {
-    std::env::var("TELEGRAM_WEBHOOK_SECRET").ok()
+    genesis_config::env::get_opt(genesis_config::env::TELEGRAM_WEBHOOK_SECRET)
 }
 
 // --- Telegram API types (subset we need) ---
@@ -227,14 +227,17 @@ async fn transcribe_telegram_audio(
     let (audio_bytes, file_path) = telegram_fetch_file(client, token, file_id).await?;
 
     // Transcribe via Whisper API.
-    let api_key =
-        std::env::var("OPENAI_API_KEY").map_err(|_| super::PlatformError::ConfigMissing {
+    let api_key = genesis_config::env::get(genesis_config::env::OPENAI_API_KEY).map_err(
+        |_| super::PlatformError::ConfigMissing {
             platform: DeliveryPlatform::Telegram,
             detail: "OPENAI_API_KEY not set, cannot transcribe".to_owned(),
-        })?;
+        },
+    )?;
 
-    let api_base =
-        std::env::var("OPENAI_API_BASE").unwrap_or_else(|_| "https://api.openai.com/v1".to_owned());
+    let api_base = genesis_config::env::get_or(
+        genesis_config::env::OPENAI_API_BASE,
+        "https://api.openai.com/v1",
+    );
 
     // Determine file extension from file_path.
     let ext = file_path.rsplit('.').next().unwrap_or("ogg");
@@ -389,7 +392,7 @@ async fn analyze_sticker_image(
     let data_uri = format!("data:{mime};base64,{b64}");
 
     // Step 4: Call the vision LLM.
-    let env: BTreeMap<String, String> = std::env::vars().collect();
+    let env: BTreeMap<String, String> = genesis_config::env::all_vars();
     let provider = genesis_provider::resolve(
         &config.provider.backend,
         &config.provider.model,

--- a/crates/genesis-gateway/src/platforms/whatsapp.rs
+++ b/crates/genesis-gateway/src/platforms/whatsapp.rs
@@ -28,19 +28,19 @@ const MAX_WHATSAPP_MESSAGE_LEN: usize = 4096;
 // --- Environment config ---
 
 fn whatsapp_token() -> Option<String> {
-    std::env::var("WHATSAPP_TOKEN").ok()
+    genesis_config::env::get_opt(genesis_config::env::WHATSAPP_TOKEN)
 }
 
 fn phone_number_id() -> Option<String> {
-    std::env::var("WHATSAPP_PHONE_NUMBER_ID").ok()
+    genesis_config::env::get_opt(genesis_config::env::WHATSAPP_PHONE_NUMBER_ID)
 }
 
 fn verify_token() -> Option<String> {
-    std::env::var("WHATSAPP_VERIFY_TOKEN").ok()
+    genesis_config::env::get_opt(genesis_config::env::WHATSAPP_VERIFY_TOKEN)
 }
 
 fn app_secret() -> Option<String> {
-    std::env::var("WHATSAPP_APP_SECRET").ok()
+    genesis_config::env::get_opt(genesis_config::env::WHATSAPP_APP_SECRET)
 }
 
 // --- WhatsApp Cloud API types ---

--- a/crates/genesis-lua/Cargo.toml
+++ b/crates/genesis-lua/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
+genesis-config = { path = "../genesis-config" }
 genesis-storage = { path = "../genesis-storage" }
 genesis-types = { path = "../genesis-types" }
 mlua.workspace = true

--- a/crates/genesis-lua/src/runtime.rs
+++ b/crates/genesis-lua/src/runtime.rs
@@ -226,21 +226,11 @@ fn config_bool(values: &BTreeMap<String, String>, key: &str, default: bool) -> b
 }
 
 fn env_u64(name: &str) -> Option<u64> {
-    std::env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
+    genesis_config::env::get_u64(name)
 }
 
 fn env_bool(name: &str, default: bool) -> bool {
-    std::env::var(name)
-        .ok()
-        .map(|value| {
-            matches!(
-                value.to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(default)
+    genesis_config::env::get_bool(name, default)
 }
 
 fn strip_unsafe_globals(lua: &Lua) -> Result<(), LuaRuntimeError> {

--- a/crates/genesis-provider/src/lib.rs
+++ b/crates/genesis-provider/src/lib.rs
@@ -69,7 +69,7 @@ pub async fn client_from_config(
         }
     }
 
-    let env: BTreeMap<String, String> = std::env::vars().collect();
+    let env: BTreeMap<String, String> = genesis_config::env::all_vars();
     let provider = resolve(backend, model, base_url, api_key_env, &env);
     let client = ChatClient::new(&provider)?;
     spawn_warmup(&client);

--- a/crates/genesis-tools/src/builtins/browser.rs
+++ b/crates/genesis-tools/src/builtins/browser.rs
@@ -64,9 +64,7 @@ impl Default for BrowserManager {
 
 impl BrowserManager {
     pub fn new() -> Self {
-        let timeout_secs: u64 = std::env::var("BROWSER_INACTIVITY_TIMEOUT")
-            .ok()
-            .and_then(|v| v.parse().ok())
+        let timeout_secs: u64 = genesis_config::env::get_u64(genesis_config::env::BROWSER_INACTIVITY_TIMEOUT)
             .unwrap_or(DEFAULT_SESSION_TIMEOUT_SECS);
         Self {
             sessions: Mutex::new(HashMap::new()),
@@ -350,7 +348,8 @@ fn check_bot_detection(title: &str) -> bool {
 
 /// Returns true if both BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID are set.
 fn is_cloud_mode() -> bool {
-    std::env::var("BROWSERBASE_API_KEY").is_ok() && std::env::var("BROWSERBASE_PROJECT_ID").is_ok()
+    genesis_config::env::is_present(genesis_config::env::BROWSERBASE_API_KEY)
+        && genesis_config::env::is_present(genesis_config::env::BROWSERBASE_PROJECT_ID)
 }
 
 /// Create a local (non-cloud) session.
@@ -416,7 +415,7 @@ fn apply_browser_env(cmd: &mut Command, session_name: &str) {
     cmd.env("AGENT_BROWSER_SOCKET_DIR", socket_dir);
 
     // Ensure /usr/bin is in PATH (systemd/container deployments may have minimal PATH)
-    let current_path = std::env::var("PATH").unwrap_or_default();
+    let current_path = genesis_config::env::get_or(genesis_config::env::PATH, "");
     if !current_path.contains("/usr/bin") {
         if current_path.is_empty() {
             cmd.env("PATH", "/usr/bin:/usr/local/bin");
@@ -599,12 +598,12 @@ struct BrowserbaseConfig {
 }
 
 fn get_browserbase_config() -> Result<BrowserbaseConfig, ToolError> {
-    let api_key = std::env::var("BROWSERBASE_API_KEY").map_err(|_| ToolError::ExecutionFailed {
+    let api_key = genesis_config::env::get(genesis_config::env::BROWSERBASE_API_KEY).map_err(|_| ToolError::ExecutionFailed {
         tool: "browser".to_owned(),
         reason: "BROWSERBASE_API_KEY environment variable not set".to_owned(),
     })?;
     let project_id =
-        std::env::var("BROWSERBASE_PROJECT_ID").map_err(|_| ToolError::ExecutionFailed {
+        genesis_config::env::get(genesis_config::env::BROWSERBASE_PROJECT_ID).map_err(|_| ToolError::ExecutionFailed {
             tool: "browser".to_owned(),
             reason: "BROWSERBASE_PROJECT_ID environment variable not set".to_owned(),
         })?;
@@ -659,18 +658,14 @@ fn create_browserbase_session(session_id: &str) -> Result<SessionInfo, ToolError
     let url = "https://api.browserbase.com/v1/sessions";
 
     // Read feature flags from environment (with sensible defaults)
-    let enable_proxies = std::env::var("BROWSERBASE_PROXIES")
+    let enable_proxies = genesis_config::env::get_opt(genesis_config::env::BROWSERBASE_PROXIES)
         .map(|v| v.to_lowercase() != "false")
         .unwrap_or(true);
-    let enable_advanced_stealth = std::env::var("BROWSERBASE_ADVANCED_STEALTH")
-        .map(|v| v.to_lowercase() == "true")
-        .unwrap_or(false); // opt-in, requires Scale plan
-    let enable_keep_alive = std::env::var("BROWSERBASE_KEEP_ALIVE")
+    let enable_advanced_stealth = genesis_config::env::get_bool(genesis_config::env::BROWSERBASE_ADVANCED_STEALTH, false); // opt-in, requires Scale plan
+    let enable_keep_alive = genesis_config::env::get_opt(genesis_config::env::BROWSERBASE_KEEP_ALIVE)
         .map(|v| v.to_lowercase() != "false")
         .unwrap_or(true);
-    let timeout_ms: Option<u64> = std::env::var("BROWSERBASE_SESSION_TIMEOUT")
-        .ok()
-        .and_then(|v| v.parse().ok());
+    let timeout_ms: Option<u64> = genesis_config::env::get_u64(genesis_config::env::BROWSERBASE_SESSION_TIMEOUT);
 
     // Fallback sequence: full features → no keepAlive → no proxies either
     let attempts = [
@@ -1389,13 +1384,12 @@ impl ToolHandler for BrowserVision {
         let b64 = base64::engine::general_purpose::STANDARD.encode(&screenshot_bytes);
 
         // Get vision model config
-        let api_base = std::env::var("OPENAI_API_BASE")
-            .unwrap_or_else(|_| genesis_provider::OPENAI_BASE_URL.to_owned());
-        let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| ToolError::ExecutionFailed {
+        let api_base = genesis_config::env::get_or(genesis_config::env::OPENAI_API_BASE, genesis_provider::OPENAI_BASE_URL);
+        let api_key = genesis_config::env::get(genesis_config::env::OPENAI_API_KEY).map_err(|_| ToolError::ExecutionFailed {
             tool: call.name.clone(),
             reason: "OPENAI_API_KEY environment variable not set".to_owned(),
         })?;
-        let model = std::env::var("AUXILIARY_VISION_MODEL").unwrap_or_else(|_| "gpt-4o".to_owned());
+        let model = genesis_config::env::get_or(genesis_config::env::AUXILIARY_VISION_MODEL, "gpt-4o");
 
         // Build vision API request
         let vision_url = format!("{api_base}/chat/completions");

--- a/crates/genesis-tools/src/builtins/channel_directory.rs
+++ b/crates/genesis-tools/src/builtins/channel_directory.rs
@@ -93,19 +93,19 @@ impl ToolHandler for ListChannelsTool {
 /// Return the list of platforms that have API tokens configured.
 fn configured_platforms() -> Vec<String> {
     let mut platforms = Vec::new();
-    if std::env::var("SLACK_BOT_TOKEN").is_ok() {
+    if genesis_config::env::is_present(genesis_config::env::SLACK_BOT_TOKEN) {
         platforms.push("slack".to_owned());
     }
-    if std::env::var("TELEGRAM_BOT_TOKEN").is_ok() {
+    if genesis_config::env::is_present(genesis_config::env::TELEGRAM_BOT_TOKEN) {
         platforms.push("telegram".to_owned());
     }
-    if std::env::var("DISCORD_BOT_TOKEN").is_ok() {
+    if genesis_config::env::is_present(genesis_config::env::DISCORD_BOT_TOKEN) {
         platforms.push("discord".to_owned());
     }
-    if std::env::var("WHATSAPP_TOKEN").is_ok() {
+    if genesis_config::env::is_present(genesis_config::env::WHATSAPP_TOKEN) {
         platforms.push("whatsapp".to_owned());
     }
-    if std::env::var("HOMEASSISTANT_URL").is_ok() {
+    if genesis_config::env::is_present(genesis_config::env::HOMEASSISTANT_URL) {
         platforms.push("homeassistant".to_owned());
     }
     platforms
@@ -129,7 +129,7 @@ fn fetch_channels(platform: &str, tool_name: &str) -> Result<Vec<CachedChannel>,
 
 /// Fetch Slack channels via conversations.list, paginating through all results.
 fn fetch_slack_channels(tool_name: &str) -> Result<Vec<CachedChannel>, ToolError> {
-    let token = std::env::var("SLACK_BOT_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let token = genesis_config::env::get(genesis_config::env::SLACK_BOT_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "SLACK_BOT_TOKEN environment variable not set".to_owned(),
     })?;
@@ -212,7 +212,7 @@ fn fetch_slack_channels(tool_name: &str) -> Result<Vec<CachedChannel>, ToolError
 
 /// Fetch Discord channels: first get guilds the bot is in, then channels per guild.
 fn fetch_discord_channels(tool_name: &str) -> Result<Vec<CachedChannel>, ToolError> {
-    let token = std::env::var("DISCORD_BOT_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let token = genesis_config::env::get(genesis_config::env::DISCORD_BOT_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "DISCORD_BOT_TOKEN environment variable not set".to_owned(),
     })?;
@@ -301,13 +301,13 @@ fn fetch_discord_channels(tool_name: &str) -> Result<Vec<CachedChannel>, ToolErr
 /// WhatsApp Cloud API doesn't support listing contacts, but we can show the
 /// configured phone number ID so the agent knows the platform is available.
 fn fetch_whatsapp_info(tool_name: &str) -> Result<Vec<CachedChannel>, ToolError> {
-    let _token = std::env::var("WHATSAPP_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let _token = genesis_config::env::get(genesis_config::env::WHATSAPP_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "WHATSAPP_TOKEN environment variable not set".to_owned(),
     })?;
 
     let phone_id =
-        std::env::var("WHATSAPP_PHONE_NUMBER_ID").map_err(|_| ToolError::ExecutionFailed {
+        genesis_config::env::get(genesis_config::env::WHATSAPP_PHONE_NUMBER_ID).map_err(|_| ToolError::ExecutionFailed {
             tool: tool_name.to_owned(),
             reason: "WHATSAPP_PHONE_NUMBER_ID environment variable not set".to_owned(),
         })?;
@@ -326,12 +326,12 @@ fn fetch_whatsapp_info(tool_name: &str) -> Result<Vec<CachedChannel>, ToolError>
 
 /// Fetch available notification services from Home Assistant REST API.
 fn fetch_homeassistant_services(tool_name: &str) -> Result<Vec<CachedChannel>, ToolError> {
-    let ha_url = std::env::var("HOMEASSISTANT_URL").map_err(|_| ToolError::ExecutionFailed {
+    let ha_url = genesis_config::env::get(genesis_config::env::HOMEASSISTANT_URL).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "HOMEASSISTANT_URL environment variable not set".to_owned(),
     })?;
 
-    let ha_token = std::env::var("HOMEASSISTANT_LONG_LIVED_TOKEN").map_err(|_| {
+    let ha_token = genesis_config::env::get(genesis_config::env::HOMEASSISTANT_LONG_LIVED_TOKEN).map_err(|_| {
         ToolError::ExecutionFailed {
             tool: tool_name.to_owned(),
             reason: "HOMEASSISTANT_LONG_LIVED_TOKEN environment variable not set".to_owned(),

--- a/crates/genesis-tools/src/builtins/code_execution.rs
+++ b/crates/genesis-tools/src/builtins/code_execution.rs
@@ -88,7 +88,7 @@ impl ToolHandler for CodeExecutionTool {
         // Sandbox: clear env, only pass safe vars through
         cmd.env_clear();
         for key in ALLOWED_ENV {
-            if let Ok(val) = std::env::var(key) {
+            if let Ok(val) = genesis_config::env::get(key) {
                 cmd.env(key, val);
             }
         }
@@ -691,7 +691,7 @@ fn build_sandbox_env(sock_path: &std::path::Path) -> Vec<(String, String)> {
     ];
 
     let mut env: Vec<(String, String)> = Vec::new();
-    for (k, v) in std::env::vars() {
+    for (k, v) in genesis_config::env::all_vars() {
         let k_upper = k.to_uppercase();
         if secret_substrings.iter().any(|s| k_upper.contains(s)) {
             continue;

--- a/crates/genesis-tools/src/builtins/homeassistant.rs
+++ b/crates/genesis-tools/src/builtins/homeassistant.rs
@@ -36,9 +36,11 @@ fn is_blocked_domain(domain: &str) -> bool {
 }
 
 fn ha_config() -> (String, String) {
-    let url =
-        std::env::var("HASS_URL").unwrap_or_else(|_| "http://homeassistant.local:8123".to_owned());
-    let token = std::env::var("HASS_TOKEN").unwrap_or_default();
+    let url = genesis_config::env::get_or(
+        genesis_config::env::HASS_URL,
+        "http://homeassistant.local:8123",
+    );
+    let token = genesis_config::env::get_or(genesis_config::env::HASS_TOKEN, "");
     (url.trim_end_matches('/').to_owned(), token)
 }
 

--- a/crates/genesis-tools/src/builtins/image_gen.rs
+++ b/crates/genesis-tools/src/builtins/image_gen.rs
@@ -76,14 +76,14 @@ impl ToolHandler for ImageGenerationTool {
             .arguments
             .get("api_base")
             .cloned()
-            .or_else(|| std::env::var("OPENAI_API_BASE").ok())
+            .or_else(|| genesis_config::env::get_opt(genesis_config::env::OPENAI_API_BASE))
             .unwrap_or_else(|| genesis_provider::OPENAI_BASE_URL.to_owned());
 
         let api_key = call
             .arguments
             .get("api_key")
             .cloned()
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+            .or_else(|| genesis_config::env::get_opt(genesis_config::env::OPENAI_API_KEY))
             .ok_or_else(|| ToolError::ExecutionFailed {
                 tool: call.name.clone(),
                 reason: "No API key provided. Set OPENAI_API_KEY or pass api_key argument."

--- a/crates/genesis-tools/src/builtins/mixture.rs
+++ b/crates/genesis-tools/src/builtins/mixture.rs
@@ -75,7 +75,7 @@ impl ToolHandler for MixtureOfAgentsTool {
         // Query all models in parallel using threads (since ToolHandler::run is sync).
         // Capture the Tokio handle before spawning scoped threads so each thread
         // can block_on async HTTP calls without needing block_in_place.
-        let env: BTreeMap<String, String> = std::env::vars().collect();
+        let env: BTreeMap<String, String> = genesis_config::env::all_vars();
         let handle = tokio::runtime::Handle::current();
         type MoaResult = Vec<(String, String, Result<String, String>)>;
         let responses: Arc<Mutex<MoaResult>> = Arc::new(Mutex::new(Vec::new()));

--- a/crates/genesis-tools/src/builtins/reason.rs
+++ b/crates/genesis-tools/src/builtins/reason.rs
@@ -50,7 +50,7 @@ impl ToolHandler for ReasonWithModelTool {
 
         // Build provider and client. We use the sync wrapper since ToolHandler::run is sync.
         // The actual HTTP call happens in a blocking tokio runtime context.
-        let env: BTreeMap<String, String> = std::env::vars().collect();
+        let env: BTreeMap<String, String> = genesis_config::env::all_vars();
         let resolved = genesis_provider::resolve(backend, model, None, None, &env);
         let client = genesis_provider::ChatClient::new(&resolved).map_err(|e| {
             ToolError::ExecutionFailed {

--- a/crates/genesis-tools/src/builtins/send_message.rs
+++ b/crates/genesis-tools/src/builtins/send_message.rs
@@ -73,7 +73,7 @@ fn send_slack(
     thread_ts: Option<&String>,
     tool_name: &str,
 ) -> Result<ToolOutput, ToolError> {
-    let token = std::env::var("SLACK_BOT_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let token = genesis_config::env::get(genesis_config::env::SLACK_BOT_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "SLACK_BOT_TOKEN environment variable not set".to_owned(),
     })?;
@@ -131,7 +131,7 @@ fn send_telegram(
     reply_to: Option<&String>,
     tool_name: &str,
 ) -> Result<ToolOutput, ToolError> {
-    let token = std::env::var("TELEGRAM_BOT_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let token = genesis_config::env::get(genesis_config::env::TELEGRAM_BOT_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "TELEGRAM_BOT_TOKEN environment variable not set".to_owned(),
     })?;
@@ -201,7 +201,7 @@ fn send_telegram(
 }
 
 fn send_discord(channel_id: &str, content: &str, tool_name: &str) -> Result<ToolOutput, ToolError> {
-    let token = std::env::var("DISCORD_BOT_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let token = genesis_config::env::get(genesis_config::env::DISCORD_BOT_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "DISCORD_BOT_TOKEN environment variable not set".to_owned(),
     })?;
@@ -249,13 +249,13 @@ fn send_discord(channel_id: &str, content: &str, tool_name: &str) -> Result<Tool
 }
 
 fn send_whatsapp(recipient: &str, text: &str, tool_name: &str) -> Result<ToolOutput, ToolError> {
-    let token = std::env::var("WHATSAPP_TOKEN").map_err(|_| ToolError::ExecutionFailed {
+    let token = genesis_config::env::get(genesis_config::env::WHATSAPP_TOKEN).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "WHATSAPP_TOKEN environment variable not set".to_owned(),
     })?;
 
     let phone_number_id =
-        std::env::var("WHATSAPP_PHONE_NUMBER_ID").map_err(|_| ToolError::ExecutionFailed {
+        genesis_config::env::get(genesis_config::env::WHATSAPP_PHONE_NUMBER_ID).map_err(|_| ToolError::ExecutionFailed {
             tool: tool_name.to_owned(),
             reason: "WHATSAPP_PHONE_NUMBER_ID environment variable not set".to_owned(),
         })?;
@@ -317,12 +317,12 @@ fn send_homeassistant(
     message: &str,
     tool_name: &str,
 ) -> Result<ToolOutput, ToolError> {
-    let ha_url = std::env::var("HOMEASSISTANT_URL").map_err(|_| ToolError::ExecutionFailed {
+    let ha_url = genesis_config::env::get(genesis_config::env::HOMEASSISTANT_URL).map_err(|_| ToolError::ExecutionFailed {
         tool: tool_name.to_owned(),
         reason: "HOMEASSISTANT_URL environment variable not set".to_owned(),
     })?;
 
-    let ha_token = std::env::var("HOMEASSISTANT_LONG_LIVED_TOKEN").map_err(|_| {
+    let ha_token = genesis_config::env::get(genesis_config::env::HOMEASSISTANT_LONG_LIVED_TOKEN).map_err(|_| {
         ToolError::ExecutionFailed {
             tool: tool_name.to_owned(),
             reason: "HOMEASSISTANT_LONG_LIVED_TOKEN environment variable not set".to_owned(),

--- a/crates/genesis-tools/src/builtins/transcribe.rs
+++ b/crates/genesis-tools/src/builtins/transcribe.rs
@@ -48,14 +48,14 @@ impl ToolHandler for TranscribeTool {
             .arguments
             .get("api_base")
             .cloned()
-            .or_else(|| std::env::var("OPENAI_API_BASE").ok())
+            .or_else(|| genesis_config::env::get_opt(genesis_config::env::OPENAI_API_BASE))
             .unwrap_or_else(|| genesis_provider::OPENAI_BASE_URL.to_owned());
 
         let api_key = call
             .arguments
             .get("api_key")
             .cloned()
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+            .or_else(|| genesis_config::env::get_opt(genesis_config::env::OPENAI_API_KEY))
             .ok_or_else(|| ToolError::ExecutionFailed {
                 tool: call.name.clone(),
                 reason: "No API key provided. Set OPENAI_API_KEY or pass api_key argument."

--- a/crates/genesis-tools/src/builtins/vision.rs
+++ b/crates/genesis-tools/src/builtins/vision.rs
@@ -49,14 +49,14 @@ impl ToolHandler for VisionTool {
             .arguments
             .get("api_base")
             .cloned()
-            .or_else(|| std::env::var("OPENAI_API_BASE").ok())
+            .or_else(|| genesis_config::env::get_opt(genesis_config::env::OPENAI_API_BASE))
             .unwrap_or_else(|| genesis_provider::OPENAI_BASE_URL.to_owned());
 
         let api_key = call
             .arguments
             .get("api_key")
             .cloned()
-            .or_else(|| std::env::var("OPENAI_API_KEY").ok())
+            .or_else(|| genesis_config::env::get_opt(genesis_config::env::OPENAI_API_KEY))
             .ok_or_else(|| ToolError::ExecutionFailed {
                 tool: call.name.clone(),
                 reason: "No API key provided. Set OPENAI_API_KEY or pass api_key argument."

--- a/crates/genesis-tools/src/builtins/web_search.rs
+++ b/crates/genesis-tools/src/builtins/web_search.rs
@@ -48,7 +48,7 @@ impl ToolHandler for WebSearchTool {
             .min(MAX_RESULTS);
 
         // Try Brave Search API first, fall back to DuckDuckGo
-        let content = match std::env::var("BRAVE_API_KEY") {
+        let content = match genesis_config::env::get(genesis_config::env::BRAVE_API_KEY) {
             Ok(api_key) if !api_key.is_empty() => {
                 search_brave(query, count, &api_key).map_err(|e| ToolError::ExecutionFailed {
                     tool: call.name.clone(),

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -194,8 +194,8 @@ pub async fn run_tui(
     );
 
     let animations_enabled =
-        config.tui.animations && std::env::var("REDUCE_MOTION").map_or(true, |v| v != "1");
-    let no_color = std::env::var("NO_COLOR").is_ok();
+        config.tui.animations && genesis_config::env::get_opt(genesis_config::env::REDUCE_MOTION).is_none_or(|v| v != "1");
+    let no_color = genesis_config::env::is_present(genesis_config::env::NO_COLOR);
 
     let mut status_bar =
         crate::widgets::status_bar::StatusBarWidget::new(config.provider.model.clone());

--- a/crates/genesis-tui/src/theme.rs
+++ b/crates/genesis-tui/src/theme.rs
@@ -359,7 +359,7 @@ pub fn theme_by_name(name: &str) -> Box<dyn Theme> {
 /// Check if NO_COLOR is set and return the appropriate theme.
 /// Falls back to the configured theme name if NO_COLOR is not set.
 pub fn resolve_theme(configured_name: &str) -> Box<dyn Theme> {
-    if std::env::var("NO_COLOR").is_ok() {
+    if genesis_config::env::is_present(genesis_config::env::NO_COLOR) {
         return Box::new(NoColorTheme);
     }
     theme_by_name(configured_name)
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn resolve_theme_without_no_color_uses_configured() {
         // When NO_COLOR is not set, resolve_theme returns the configured theme.
-        if std::env::var("NO_COLOR").is_err() {
+        if !genesis_config::env::is_present(genesis_config::env::NO_COLOR) {
             let theme = resolve_theme("dracula");
             assert_eq!(theme.name(), "dracula");
         }

--- a/crates/genesis-ui/Cargo.toml
+++ b/crates/genesis-ui/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
+genesis-config = { path = "../genesis-config" }
 crossterm.workspace = true
 owo-colors.workspace = true
 unicode-width.workspace = true

--- a/crates/genesis-ui/src/banner/mod.rs
+++ b/crates/genesis-ui/src/banner/mod.rs
@@ -148,7 +148,7 @@ fn print_session_info_plain(info: &BannerInfo) {
 
 /// Shorten home directory prefix to ~.
 fn shorten_home(path: &str) -> String {
-    if let Ok(home) = std::env::var("HOME") {
+    if let Ok(home) = genesis_config::env::get(genesis_config::env::HOME) {
         if path.starts_with(&home) {
             return format!("~{}", &path[home.len()..]);
         }
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn shorten_home_replaces_prefix() {
-        if let Ok(home) = std::env::var("HOME") {
+        if let Ok(home) = genesis_config::env::get(genesis_config::env::HOME) {
             let path = format!("{home}/projects/genesis");
             let short = shorten_home(&path);
             assert!(short.starts_with("~/"), "expected ~/..., got: {short}");

--- a/crates/genesis-ui/src/terminal.rs
+++ b/crates/genesis-ui/src/terminal.rs
@@ -37,7 +37,7 @@ impl ColorMode {
             Self::Always => true,
             Self::Never => false,
             Self::Auto => {
-                if std::env::var_os("NO_COLOR").is_some() {
+                if genesis_config::env::get_os(genesis_config::env::NO_COLOR).is_some() {
                     return false;
                 }
                 std::io::stdout().is_terminal()
@@ -48,7 +48,7 @@ impl ColorMode {
 
 /// Returns `true` if we are running inside tmux.
 pub fn is_tmux() -> bool {
-    std::env::var_os("TMUX").is_some()
+    genesis_config::env::get_os(genesis_config::env::TMUX).is_some()
 }
 
 /// Returns `true` if we are running inside Zellij.
@@ -56,7 +56,7 @@ pub fn is_tmux() -> bool {
 /// Zellij has strict xterm spec compliance — alternate screen and some
 /// DECSTBM features behave differently than in other multiplexers.
 pub fn is_zellij() -> bool {
-    std::env::var_os("ZELLIJ_SESSION_NAME").is_some()
+    genesis_config::env::get_os(genesis_config::env::ZELLIJ_SESSION_NAME).is_some()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes #290

- Create `genesis-config/src/env.rs` as the single source of truth for all environment variable names and accessor functions used across Genesis
- Replace ~80 scattered `std::env::var(...)` calls across 12 crates with centralized `genesis_config::env::*` constants and helpers
- Add typed accessor functions (`get`, `get_opt`, `get_or`, `get_bool`, `get_u64`, `get_u32`, `is_set`, `is_present`, `get_os`, `all_vars`) that provide consistent loading semantics
- Add platform-specific lookup helpers (`platform_allowlist_var`, `platform_allow_all_var`) replacing duplicated match blocks
- Add `validate_startup()` that warns about partially-configured platform integrations (e.g. bot token set but webhook secret missing)
- Consolidate and eliminate duplicate `is_truthy_env`, `env_bool`, `env_u64` helper functions from `genesis-gateway`, `genesis-lua`, `genesis-core`, and `genesis-cli` by delegating to the centralized accessors
- Add `genesis-config` dependency to `genesis-lua` and `genesis-ui` (the only two crates that did not already depend on it)

**No behavioral changes** -- this is a pure refactor that centralizes the loading point without altering runtime semantics.

### Env var categories documented in `env.rs`:

| Group | Examples |
|---|---|
| Genesis core | `GENESIS_LOG_FORMAT`, `GENESIS_API_KEY`, `GENESIS_ENV`, `GENESIS_TRUSTED_PROXIES` |
| Provider keys | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `BRAVE_API_KEY` |
| Platform tokens | `TELEGRAM_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, `SLACK_BOT_TOKEN`, `WHATSAPP_TOKEN`, `SIGNAL_ACCOUNT` |
| Home Assistant | `HOMEASSISTANT_TOKEN`, `HASS_URL`, `HASS_TOKEN` |
| Browser | `BROWSERBASE_API_KEY`, `BROWSER_INACTIVITY_TIMEOUT` |
| Sandbox | `DAYTONA_API_KEY`, `MODAL_TOKEN_ID`, `TERMINAL_SCRATCH_DIR` |
| Gateway ACL | `GATEWAY_ALLOWED_USERS`, `GATEWAY_ALLOW_ALL_USERS` |
| Shell/OS | `HOME`, `EDITOR`, `PATH`, `NO_COLOR`, `TMUX`, `WAYLAND_DISPLAY` |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes with zero warnings
- [x] `cargo test --workspace` passes (~2700 tests, 0 failures)
- [x] New `env.rs` module has 15 unit tests covering all accessor functions and lookup helpers
- [ ] Verify no remaining raw `std::env::var` calls outside `genesis-config/src/env.rs` (only test setup/teardown in daytona.rs uses `std::env::set_var`/`remove_var`)