### PR TITLE
fix: audit silent .ok() calls across 17 files

### DIFF
--- a/crates/genesis-cli/src/commands/init.rs
+++ b/crates/genesis-cli/src/commands/init.rs
@@ -541,12 +541,16 @@ pub(crate) async fn run_update() -> Result<String, CliError> {
     steps.push("[ok] Build succeeded.".to_owned());
 
     // Step 3: Report new version
-    let version_out = StdCommand::new(repo_dir.join("target/release/genesis"))
+    let version_out = match StdCommand::new(repo_dir.join("target/release/genesis"))
         .arg("--version")
         .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .unwrap_or_else(|| "unknown".to_owned());
+    {
+        Ok(o) => String::from_utf8(o.stdout).unwrap_or_else(|_| "unknown".to_owned()),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to get version from new binary");
+            "unknown".to_owned()
+        }
+    };
     steps.push(format!("[ok] Updated to: {}", version_out.trim()));
 
     Ok(steps.join("\n"))

--- a/crates/genesis-cli/src/commands/misc.rs
+++ b/crates/genesis-cli/src/commands/misc.rs
@@ -956,7 +956,13 @@ pub(crate) async fn run_benchmark(
                 let stream_start = std::time::Instant::now();
                 if let Ok(mut stream) = client.complete_stream(request).await {
                     use futures_util::TryStreamExt;
-                    if let Some(_chunk) = stream.try_next().await.ok().flatten() {
+                    if let Some(_chunk) = match stream.try_next().await {
+                        Ok(chunk) => chunk,
+                        Err(e) => {
+                            tracing::debug!(error = %e, "TTFT stream read failed");
+                            None
+                        }
+                    } {
                         ttft_times.push(stream_start.elapsed());
                     }
                 }
@@ -1211,7 +1217,13 @@ pub(crate) async fn run_model(
                     .collect();
                 Ok(serde_json::to_string_pretty(&json_models)?)
             } else {
-                let loaded = load(config_path.as_deref()).ok();
+                let loaded = match load(config_path.as_deref()) {
+                    Ok(l) => Some(l),
+                    Err(e) => {
+                        tracing::debug!(error = %e, "failed to load config for model listing");
+                        None
+                    }
+                };
                 let active_model = loaded.as_ref().map(|l| l.config.provider.model.as_str());
                 let mut current_provider = String::new();
                 let mut lines = Vec::new();

--- a/crates/genesis-cli/src/slash.rs
+++ b/crates/genesis-cli/src/slash.rs
@@ -144,7 +144,13 @@ pub(crate) fn handle_chat_command(
                 .to_owned(),
         ),
         "history" => {
-            let messages = store.load_messages(session_id).ok()?;
+            let messages = match store.load_messages(session_id) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load messages for /history");
+                    return Some(format!("Error loading messages: {e}"));
+                }
+            };
             let recent = if messages.len() > 10 {
                 &messages[messages.len() - 10..]
             } else {
@@ -153,11 +159,24 @@ pub(crate) fn handle_chat_command(
             Some(format_session_messages(session_id, recent))
         }
         "export" => {
-            let messages = store.load_messages(session_id).ok()?;
+            let messages = match store.load_messages(session_id) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load messages for /export");
+                    return Some(format!("Error loading messages: {e}"));
+                }
+            };
             Some(export_session_markdown(session_id, &messages))
         }
         "tokens" | "usage" => {
-            let session = store.get_session(session_id).ok()??;
+            let session = match store.get_session(session_id) {
+                Ok(Some(s)) => s,
+                Ok(None) => return Some("Session not found.".to_owned()),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load session for /tokens");
+                    return Some(format!("Error loading session: {e}"));
+                }
+            };
             let total = session.total_input_tokens + session.total_output_tokens;
             // Rough cost estimate based on common pricing
             let cost_estimate = estimate_token_cost(
@@ -175,7 +194,13 @@ pub(crate) fn handle_chat_command(
         }
         "session" => Some(format!("Current session: {session_id}")),
         "compress" => {
-            let messages = store.load_messages(session_id).ok()?;
+            let messages = match store.load_messages(session_id) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load messages for /compress");
+                    return Some(format!("Error loading messages: {e}"));
+                }
+            };
             let total = messages.len();
             if total <= 10 {
                 return Some(format!(
@@ -247,7 +272,14 @@ pub(crate) fn handle_chat_command(
         }
         "tree" => {
             // Show the conversation tree rooted at the current session
-            let _session = store.get_session(session_id).ok()??;
+            let _session = match store.get_session(session_id) {
+                Ok(Some(s)) => s,
+                Ok(None) => return Some("Session not found.".to_owned()),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load session for /tree");
+                    return Some(format!("Error loading session: {e}"));
+                }
+            };
             // Walk up to the root
             let mut root_id = session_id.to_owned();
             let mut visited = std::collections::HashSet::new();
@@ -272,12 +304,10 @@ pub(crate) fn handle_chat_command(
                 lines: &mut Vec<String>,
             ) {
                 let connector = if prefix.is_empty() { "" } else if is_last { "└── " } else { "├── " };
-                let title = store
-                    .get_session(id)
-                    .ok()
-                    .flatten()
-                    .and_then(|s| s.title)
-                    .unwrap_or_else(|| "(untitled)".to_owned());
+                let title = match store.get_session(id) {
+                    Ok(s) => s.and_then(|s| s.title).unwrap_or_else(|| "(untitled)".to_owned()),
+                    Err(_) => "(untitled)".to_owned(),
+                };
                 let marker = if id == current { " ← you" } else { "" };
                 lines.push(format!("{prefix}{connector}{id} — {title}{marker}"));
                 if let Ok(children) = store.list_children(id) {
@@ -341,8 +371,21 @@ pub(crate) fn handle_chat_command(
             }
         }
         "stats" => {
-            let messages = store.load_messages(session_id).ok()?;
-            let session = store.get_session(session_id).ok()??;
+            let messages = match store.load_messages(session_id) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load messages for /stats");
+                    return Some(format!("Error loading messages: {e}"));
+                }
+            };
+            let session = match store.get_session(session_id) {
+                Ok(Some(s)) => s,
+                Ok(None) => return Some("Session not found.".to_owned()),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load session for /stats");
+                    return Some(format!("Error loading session: {e}"));
+                }
+            };
             let user_msgs = messages.iter().filter(|m| m.role == "user").count();
             let assistant_msgs = messages.iter().filter(|m| m.role == "assistant").count();
             let tool_msgs = messages.iter().filter(|m| m.role == "tool").count();
@@ -574,7 +617,13 @@ pub(crate) fn handle_chat_command(
         "undo" => {
             // Remove the last user-assistant exchange (user message + all
             // subsequent assistant/tool messages until the next user or start).
-            let messages = store.load_messages(session_id).ok()?;
+            let messages = match store.load_messages(session_id) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to load messages for /undo");
+                    return Some(format!("Error loading messages: {e}"));
+                }
+            };
             if messages.is_empty() {
                 return Some("Nothing to undo.".to_owned());
             }

--- a/crates/genesis-core/src/agent_loop.rs
+++ b/crates/genesis-core/src/agent_loop.rs
@@ -1098,9 +1098,15 @@ impl AgentLoop {
             };
 
             let cached = cache_key.as_ref().and_then(|key| {
-                self.response_cache
-                    .as_ref()
-                    .and_then(|cache| cache.get(key).ok().flatten())
+                self.response_cache.as_ref().and_then(|cache| {
+                    match cache.get(key) {
+                        Ok(hit) => hit,
+                        Err(e) => {
+                            debug!(error = %e, "response cache lookup failed");
+                            None
+                        }
+                    }
+                })
             });
 
             self.hooks
@@ -1116,7 +1122,13 @@ impl AgentLoop {
                 let tool_calls: Option<Vec<ToolCallEntry>> = hit
                     .tool_calls_json
                     .as_deref()
-                    .and_then(|json| serde_json::from_str(json).ok());
+                    .and_then(|json| match serde_json::from_str(json) {
+                        Ok(tc) => Some(tc),
+                        Err(e) => {
+                            debug!(error = %e, "failed to deserialize cached tool calls");
+                            None
+                        }
+                    });
                 let choice = genesis_provider::ChatChoice {
                     index: 0,
                     message: ChatMessage {
@@ -1180,7 +1192,13 @@ impl AgentLoop {
                         .message
                         .tool_calls
                         .as_ref()
-                        .and_then(|tc| serde_json::to_string(tc).ok());
+                        .and_then(|tc| match serde_json::to_string(tc) {
+                            Ok(s) => Some(s),
+                            Err(e) => {
+                                debug!(error = %e, "failed to serialize tool calls for cache");
+                                None
+                            }
+                        });
                     let (in_tok, out_tok) = response
                         .usage
                         .as_ref()

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -603,7 +603,13 @@ impl<'a> SessionExecutionService<'a> {
     fn load_user_model_section(&self) -> Option<String> {
         let db_path = &self.loaded.config.storage.database_path;
         let store = UserModelStore::new(db_path);
-        let traits = store.confident_traits(0.5).ok()?;
+        let traits = match store.confident_traits(0.5) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to load user model traits");
+                return None;
+            }
+        };
         format_user_traits(&traits)
     }
 
@@ -619,7 +625,13 @@ impl<'a> SessionExecutionService<'a> {
             return None;
         }
 
-        let memories = store.search(prompt, 5).ok()?;
+        let memories = match store.search(prompt, 5) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to search memories for recall");
+                return None;
+            }
+        };
         if memories.is_empty() {
             return None;
         }

--- a/crates/genesis-core/src/guardrails.rs
+++ b/crates/genesis-core/src/guardrails.rs
@@ -182,39 +182,52 @@ pub struct CompiledGuardrails {
 impl CompiledGuardrails {
     /// Compile all regex patterns from the given configuration.
     ///
-    /// Invalid patterns are silently skipped (matching the previous behaviour).
+    /// Invalid patterns are logged and skipped so the remaining guardrails
+    /// still apply.
     pub fn new(config: &GuardrailConfig) -> Self {
         let forbidden_input = config
             .forbidden_input_patterns
             .iter()
-            .filter_map(|p| {
-                Regex::new(p).ok().map(|r| CompiledPattern {
+            .filter_map(|p| match Regex::new(p) {
+                Ok(r) => Some(CompiledPattern {
                     source: p.clone(),
                     regex: r,
-                })
+                }),
+                Err(e) => {
+                    tracing::warn!(pattern = %p, error = %e, "skipping invalid forbidden_input guardrail pattern");
+                    None
+                }
             })
             .collect();
         let forbidden_output = config
             .forbidden_output_patterns
             .iter()
-            .filter_map(|p| {
-                Regex::new(p).ok().map(|r| CompiledPattern {
+            .filter_map(|p| match Regex::new(p) {
+                Ok(r) => Some(CompiledPattern {
                     source: p.clone(),
                     regex: r,
-                })
+                }),
+                Err(e) => {
+                    tracing::warn!(pattern = %p, error = %e, "skipping invalid forbidden_output guardrail pattern");
+                    None
+                }
             })
             .collect();
         let custom_rules = config
             .custom_rules
             .iter()
-            .filter_map(|rule| {
-                Regex::new(&rule.pattern).ok().map(|r| CompiledCustomRule {
+            .filter_map(|rule| match Regex::new(&rule.pattern) {
+                Ok(r) => Some(CompiledCustomRule {
                     name: rule.name.clone(),
                     regex: r,
                     applies_to: rule.applies_to.clone(),
                     action: rule.action.clone(),
                     message: rule.message.clone(),
-                })
+                }),
+                Err(e) => {
+                    tracing::warn!(rule = %rule.name, pattern = %rule.pattern, error = %e, "skipping invalid custom guardrail rule");
+                    None
+                }
             })
             .collect();
         Self {

--- a/crates/genesis-core/src/hooks.rs
+++ b/crates/genesis-core/src/hooks.rs
@@ -81,11 +81,26 @@ fn run_hook(config: &HookConfig, context: &serde_json::Value) -> HookResult {
                     Ok(Some(status)) => break status.code().unwrap_or(-1),
                     Ok(None) if started.elapsed() >= timeout => {
                         let _ = child.kill();
-                        let status = child.wait().ok();
+                        let status = match child.wait() {
+                            Ok(s) => Some(s),
+                            Err(e) => {
+                                tracing::warn!(
+                                    command = %config.command,
+                                    error = %e,
+                                    "failed to wait on timed-out hook process"
+                                );
+                                None
+                            }
+                        };
                         break status.and_then(|s| s.code()).unwrap_or(-1);
                     }
                     Ok(None) => thread::sleep(Duration::from_millis(5)),
-                    Err(_) => {
+                    Err(e) => {
+                        tracing::warn!(
+                            command = %config.command,
+                            error = %e,
+                            "error polling hook process status"
+                        );
                         let _ = child.kill();
                         break -1;
                     }

--- a/crates/genesis-core/src/lib.rs
+++ b/crates/genesis-core/src/lib.rs
@@ -890,8 +890,13 @@ impl ToolRuntime {
                             }
                         })?;
                         let arguments = call.arguments.get("arguments").and_then(|v| {
-                            serde_json::from_str::<std::collections::HashMap<String, String>>(v)
-                                .ok()
+                            match serde_json::from_str::<std::collections::HashMap<String, String>>(v) {
+                                Ok(args) => Some(args),
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "failed to parse MCP prompt arguments");
+                                    None
+                                }
+                            }
                         });
                         let result =
                             mcp.get_prompt(server, name, arguments).await.map_err(|e| {

--- a/crates/genesis-core/src/nudge.rs
+++ b/crates/genesis-core/src/nudge.rs
@@ -112,25 +112,38 @@ pub async fn run_nudge(
 }
 
 fn load_memories_section(db_path: &std::path::Path) -> Option<String> {
-    let connection = rusqlite::Connection::open(db_path).ok()?;
-    let mut stmt = connection
-        .prepare(
-            "SELECT kind, content, created_at FROM memories
+    let connection = match rusqlite::Connection::open(db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open database for nudge memories");
+            return None;
+        }
+    };
+    let mut stmt = match connection.prepare(
+        "SELECT kind, content, created_at FROM memories
              ORDER BY created_at DESC LIMIT 50",
-        )
-        .ok()?;
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to prepare memories query for nudge");
+            return None;
+        }
+    };
 
-    let memories: Vec<(String, String, String)> = stmt
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, String>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, String>(2)?,
-            ))
-        })
-        .ok()?
-        .filter_map(|r| r.ok())
-        .collect();
+    let rows = match stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    }) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to query memories for nudge");
+            return None;
+        }
+    };
+    let memories: Vec<(String, String, String)> = rows.filter_map(|r| r.ok()).collect();
 
     if memories.is_empty() {
         return None;
@@ -146,7 +159,13 @@ fn load_memories_section(db_path: &std::path::Path) -> Option<String> {
 
 fn load_user_model_section(db_path: &std::path::Path) -> Option<String> {
     let store = UserModelStore::new(db_path);
-    let traits = store.list_all().ok()?;
+    let traits = match store.list_all() {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load user model traits for nudge");
+            return None;
+        }
+    };
     format_user_traits(&traits)
 }
 
@@ -157,14 +176,26 @@ fn load_user_model_section(db_path: &std::path::Path) -> Option<String> {
 fn load_skills_performance_section(db_path: &std::path::Path) -> Option<String> {
     let skill_store = SkillStore::new(db_path);
     let usage_store = SkillUsageStore::new(db_path);
-    let skills = skill_store.list_all().ok()?;
+    let skills = match skill_store.list_all() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load skills for nudge");
+            return None;
+        }
+    };
     if skills.is_empty() {
         return None;
     }
 
     let mut lines = Vec::new();
     for skill in &skills {
-        let stats = usage_store.stats(&skill.name).ok();
+        let stats = match usage_store.stats(&skill.name) {
+            Ok(s) => Some(s),
+            Err(e) => {
+                tracing::debug!(skill = %skill.name, error = %e, "failed to load skill usage stats");
+                None
+            }
+        };
         let (uses, successes, failures) = match stats {
             Some(ref s) if s.total_uses > 0 => (s.total_uses, s.successes, s.failures),
             _ => {
@@ -195,7 +226,13 @@ fn load_skills_performance_section(db_path: &std::path::Path) -> Option<String> 
 
 fn load_recent_sessions_section(db_path: &std::path::Path) -> Option<String> {
     let store = SessionStore::new(db_path);
-    let sessions = store.list_recent_sessions(10).ok()?;
+    let sessions = match store.list_recent_sessions(10) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load recent sessions for nudge");
+            return None;
+        }
+    };
     if sessions.is_empty() {
         return None;
     }

--- a/crates/genesis-core/src/sandbox/singularity.rs
+++ b/crates/genesis-core/src/sandbox/singularity.rs
@@ -13,13 +13,16 @@ use super::{ExecResult, SandboxBackend, SandboxConfig, SandboxError, SandboxInst
 
 fn detect_binary() -> Result<String, SandboxError> {
     for name in &["apptainer", "singularity"] {
-        let output = std::process::Command::new("which").arg(name).output().ok();
-        if let Some(out) = output {
-            if out.status.success() {
+        match std::process::Command::new("which").arg(name).output() {
+            Ok(out) if out.status.success() => {
                 let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
                 if !path.is_empty() {
                     return Ok(name.to_string());
                 }
+            }
+            Ok(_) => {} // command ran but binary not found — expected
+            Err(e) => {
+                tracing::debug!(binary = %name, error = %e, "failed to check for sandbox binary");
             }
         }
     }
@@ -187,7 +190,13 @@ impl SandboxBackend for SingularitySandbox {
             let dir = config
                 .snapshot_data
                 .as_deref()
-                .and_then(|snap| serde_json::from_str::<serde_json::Value>(snap).ok())
+                .and_then(|snap| match serde_json::from_str::<serde_json::Value>(snap) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to parse sandbox snapshot data");
+                        None
+                    }
+                })
                 .and_then(|v| v["overlay_path"].as_str().map(|s| s.to_owned()))
                 .unwrap_or_else(|| {
                     self.scratch_dir

--- a/crates/genesis-core/src/scheduler.rs
+++ b/crates/genesis-core/src/scheduler.rs
@@ -120,7 +120,18 @@ pub fn check_due_schedules_at(
         .iter()
         .filter(|s| s.enabled)
         .filter_map(|s| {
-            let expr = CronExpr::parse(&s.cron_expression).ok()?;
+            let expr = match CronExpr::parse(&s.cron_expression) {
+                Ok(expr) => expr,
+                Err(e) => {
+                    tracing::warn!(
+                        schedule_id = %s.id,
+                        cron = %s.cron_expression,
+                        error = %e,
+                        "skipping schedule with invalid cron expression"
+                    );
+                    return None;
+                }
+            };
             if now.matches_expr(&expr) {
                 Some(DueSchedule {
                     id: s.id.clone(),

--- a/crates/genesis-core/src/skills.rs
+++ b/crates/genesis-core/src/skills.rs
@@ -69,7 +69,13 @@ pub fn format_skills_for_prompt_with_stats(
 /// since skill loading should not block agent startup).
 pub fn load_skills_prompt(database_path: &std::path::Path) -> Option<String> {
     let store = SkillStore::new(database_path);
-    let skills = store.list_all().ok()?;
+    let skills = match store.list_all() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load skills for prompt");
+            return None;
+        }
+    };
     let usage_store = SkillUsageStore::new(database_path);
     format_skills_for_prompt_with_stats(&skills, Some(&usage_store))
 }
@@ -85,7 +91,13 @@ pub fn load_skills_prompt_for_prompt(
     user_prompt: &str,
 ) -> Option<String> {
     let store = SkillStore::new(database_path);
-    let all_skills = store.list_all().ok()?;
+    let all_skills = match store.list_all() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load skills for prompt filtering");
+            return None;
+        }
+    };
     if all_skills.is_empty() {
         return None;
     }
@@ -97,7 +109,13 @@ pub fn load_skills_prompt_for_prompt(
     }
 
     // Many skills: brief listing of all + full instructions for matched ones.
-    let matched = store.find_matching(user_prompt, 5).ok()?;
+    let matched = match store.find_matching(user_prompt, 5) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to find matching skills");
+            return None;
+        }
+    };
     let matched_names: std::collections::HashSet<&str> =
         matched.iter().map(|s| s.name.as_str()).collect();
 

--- a/crates/genesis-gateway/src/commands.rs
+++ b/crates/genesis-gateway/src/commands.rs
@@ -74,7 +74,13 @@ pub(crate) fn handle_command(
         "/id" => CommandResult::Reply(format!("Session ID: `{session_id}`")),
 
         "/config" => {
-            let session = store.get_session(session_id).ok().flatten();
+            let session = match store.get_session(session_id) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "failed to load session for /config");
+                    None
+                }
+            };
             let message_count = store
                 .load_messages(session_id)
                 .map(|m| m.len())
@@ -105,7 +111,13 @@ pub(crate) fn handle_command(
         )),
 
         "/cost" => {
-            let session = store.get_session(session_id).ok().flatten();
+            let session = match store.get_session(session_id) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "failed to load session for /cost");
+                    None
+                }
+            };
             match session {
                 Some(s) => {
                     let model = &config.provider.model;

--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -637,7 +637,16 @@ const LOCALHOST_ORIGINS: &[&str] = &[
 ];
 
 fn parse_origin_values(origins: &[&str]) -> Vec<axum::http::HeaderValue> {
-    origins.iter().filter_map(|o| o.parse().ok()).collect()
+    origins
+        .iter()
+        .filter_map(|o| match o.parse() {
+            Ok(v) => Some(v),
+            Err(e) => {
+                warn!(origin = %o, error = %e, "skipping invalid CORS origin");
+                None
+            }
+        })
+        .collect()
 }
 
 /// Build CORS layer from gateway config.
@@ -1469,7 +1478,13 @@ async fn export_session_handler(
 ) -> Result<Response, (StatusCode, String)> {
     let store = SessionStore::new(&state.loaded.config.storage.database_path);
 
-    let session_title = store.get_session(&id).ok().flatten().and_then(|s| s.title);
+    let session_title = match store.get_session(&id) {
+        Ok(s) => s.and_then(|s| s.title),
+        Err(e) => {
+            warn!(error = %e, session_id = %id, "failed to load session title for export");
+            None
+        }
+    };
 
     let stored = store.load_messages(&id).map_err(storage_err)?;
 
@@ -2975,7 +2990,13 @@ async fn bus_publish_handler(
 
     let metadata: std::collections::HashMap<String, String> = body
         .get("metadata")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .and_then(|v| match serde_json::from_value(v.clone()) {
+            Ok(m) => Some(m),
+            Err(e) => {
+                warn!(error = %e, "invalid metadata in bus publish request, ignoring");
+                None
+            }
+        })
         .unwrap_or_default();
 
     let msg = genesis_core::agent_bus::AgentMessage {
@@ -3116,7 +3137,13 @@ async fn guardrails_check_handler(
     // Parse config from request body, or use a sensible default
     let config: genesis_core::guardrails::GuardrailConfig = body
         .get("config")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .and_then(|v| match serde_json::from_value(v.clone()) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                warn!(error = %e, "invalid guardrail config in request body, using defaults");
+                None
+            }
+        })
         .unwrap_or_else(|| genesis_core::guardrails::GuardrailConfig {
             detect_pii: true,
             pii_action: genesis_core::guardrails::ViolationAction::Warn,

--- a/crates/genesis-tools/src/builtins/code_execution.rs
+++ b/crates/genesis-tools/src/builtins/code_execution.rs
@@ -435,7 +435,9 @@ fn rpc_server_loop(
         Some(s) => s,
         None => return,
     };
-    stream.set_read_timeout(Some(Duration::from_secs(timeouts::CODE_EXEC_READ_SECS))).ok();
+    if let Err(e) = stream.set_read_timeout(Some(Duration::from_secs(timeouts::CODE_EXEC_READ_SECS))) {
+        tracing::warn!(error = %e, "failed to set read timeout on code execution socket");
+    }
 
     let mut reader = std::io::BufReader::new(&stream);
     let mut writer = &stream;
@@ -526,7 +528,9 @@ fn accept_with_timeout(
     listener: &std::os::unix::net::UnixListener,
     timeout: Duration,
 ) -> Option<std::os::unix::net::UnixStream> {
-    listener.set_nonblocking(true).ok();
+    if let Err(e) = listener.set_nonblocking(true) {
+        tracing::warn!(error = %e, "failed to set non-blocking mode on code execution listener");
+    }
     let deadline = std::time::Instant::now() + timeout;
     loop {
         match listener.accept() {

--- a/crates/genesis-tools/src/builtins/export.rs
+++ b/crates/genesis-tools/src/builtins/export.rs
@@ -33,11 +33,13 @@ impl ToolHandler for SessionExportTool {
         let store = SessionStore::new(&db_path);
 
         // Load session title
-        let session_title = store
-            .get_session(&session_id)
-            .ok()
-            .flatten()
-            .and_then(|s| s.title);
+        let session_title = match store.get_session(&session_id) {
+            Ok(s) => s.and_then(|s| s.title),
+            Err(e) => {
+                tracing::warn!(error = %e, session_id = %session_id, "failed to load session title for export");
+                None
+            }
+        };
 
         // Load messages via storage layer
         let stored_messages =

--- a/crates/genesis-tools/src/builtins/process.rs
+++ b/crates/genesis-tools/src/builtins/process.rs
@@ -310,12 +310,13 @@ fn format_section(title: &str, body: &str) -> String {
 }
 
 fn run_cmd(program: &str, args: &[&str]) -> String {
-    Command::new(program)
-        .args(args)
-        .output()
-        .ok()
-        .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
-        .unwrap_or_else(|| "(command failed)".to_owned())
+    match Command::new(program).args(args).output() {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).into_owned(),
+        Err(e) => {
+            tracing::debug!(program = %program, error = %e, "system info command failed");
+            "(command failed)".to_owned()
+        }
+    }
 }
 
 fn get_cpu_info() -> String {


### PR DESCRIPTION
Closes #281

## Summary

- Audited 100+ `.ok()` calls across the codebase, identifying ~40 dangerous cases in production code paths where errors were silently swallowed
- Replaced silent `.ok()` with explicit `match` + `tracing::warn!` / `tracing::debug!` logging across **17 files** (339 insertions, 90 deletions)
- Left safe `.ok()` calls unchanged: env var lookups (`std::env::var().ok()`), HTTP header parsing (`.to_str().ok()`), best-effort cleanup, test code, and functions that return `Option` by design (jwt.rs, codex.rs)

## Changes by severity

### Security (guardrails, scheduler)
- **guardrails.rs**: Invalid regex patterns in `forbidden_input_patterns`, `forbidden_output_patterns`, and `custom_rules` now log `warn!` with the pattern and error instead of being silently skipped
- **scheduler.rs**: Invalid cron expressions now log `warn!` with schedule ID instead of silently dropping the schedule

### I/O (sockets, processes)
- **code_execution.rs**: `set_read_timeout()` and `set_nonblocking()` failures now logged
- **hooks.rs**: Child process `wait()` errors after timeout kill now logged; `try_wait()` errors now logged
- **singularity.rs**: Binary detection and snapshot JSON parse failures now logged
- **process.rs**: `run_cmd()` system info command failures now logged with `debug!`

### Database operations
- **nudge.rs**: DB open, prepare, query, store.list_all, store.stats, and list_recent_sessions errors now logged (6 fixes)
- **execution.rs**: `confident_traits()` and `store.search()` errors now logged
- **skills.rs**: `list_all()` and `find_matching()` errors now logged (3 fixes)
- **gateway/commands.rs**: `get_session()` errors in `/config` and `/cost` handlers now logged
- **gateway/lib.rs**: Session title load, guardrail config parse, CORS origin parse, and bus metadata parse errors now logged (4 fixes)
- **slash.rs**: `/history`, `/export`, `/tokens`, `/compress`, `/tree`, `/stats`, `/undo` now show error messages to user instead of silently failing (7 fixes)
- **export.rs**: Session title load error now logged

### Cache / serialization
- **agent_loop.rs**: Response cache lookup, cached tool call deserialization, and tool call serialization errors now logged (3 fixes)

### Config / CLI
- **init.rs**: Version binary execution failure now logged
- **misc.rs**: Config load failure and TTFT stream read errors now logged

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes clean
- [x] `cargo test --workspace` — all 2,740 tests pass, 0 failures