### PR TITLE
test(tools): add 78 tests across 15 builtin tool modules

### DIFF
--- a/crates/genesis-tools/src/builtins/clarify.rs
+++ b/crates/genesis-tools/src/builtins/clarify.rs
@@ -117,4 +117,56 @@ mod tests {
         let err = tool.run(&call, &ctx()).unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed { .. }));
     }
+
+    #[test]
+    fn clarify_without_choices_has_no_options() {
+        let tool = ClarifyTool;
+        let call = ToolCall {
+            name: "clarify".to_owned(),
+            arguments: BTreeMap::from([(
+                "question".to_owned(),
+                "What format do you want?".to_owned(),
+            )]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert!(!output.content.contains("Options:"));
+    }
+
+    #[test]
+    fn clarify_metadata_flags_requires_input() {
+        let tool = ClarifyTool;
+        let call = ToolCall {
+            name: "clarify".to_owned(),
+            arguments: BTreeMap::from([(
+                "question".to_owned(),
+                "Are you sure?".to_owned(),
+            )]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert_eq!(
+            output.metadata.get("requires_input").map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            output.metadata.get("tool").map(String::as_str),
+            Some("clarify")
+        );
+    }
+
+    #[test]
+    fn clarify_single_choice() {
+        let tool = ClarifyTool;
+        let call = ToolCall {
+            name: "clarify".to_owned(),
+            arguments: BTreeMap::from([
+                ("question".to_owned(), "Continue?".to_owned()),
+                ("choices".to_owned(), "Yes".to_owned()),
+            ]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert!(output.content.contains("1. Yes"));
+    }
 }

--- a/crates/genesis-tools/src/builtins/docker.rs
+++ b/crates/genesis-tools/src/builtins/docker.rs
@@ -102,4 +102,53 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn docker_exec_requires_both_arguments() {
+        let tool = DockerExecTool;
+        let call = ToolCall {
+            name: "docker_exec".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        // Container is checked first
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "container",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn docker_exec_with_nonexistent_container_fails() {
+        let tool = DockerExecTool;
+        let call = ToolCall {
+            name: "docker_exec".to_owned(),
+            arguments: BTreeMap::from([
+                (
+                    "container".to_owned(),
+                    "nonexistent-container-12345".to_owned(),
+                ),
+                ("command".to_owned(), "echo hello".to_owned()),
+            ]),
+        };
+        // docker exec with a nonexistent container should either fail to spawn
+        // docker or return a non-zero exit code. Either way it should not panic.
+        let result = tool.run(&call, &ctx());
+        match result {
+            Ok(output) => {
+                // Docker ran but failed (exit code != 0)
+                assert!(
+                    output.content.contains("[stderr]")
+                        || output.metadata.get("exit_code").unwrap() != "0"
+                );
+            }
+            Err(ToolError::ExecutionFailed { .. }) => {
+                // Docker binary not found - also acceptable
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
 }

--- a/crates/genesis-tools/src/builtins/fs.rs
+++ b/crates/genesis-tools/src/builtins/fs.rs
@@ -246,4 +246,186 @@ mod tests {
         let err = tool.run(&call, &ctx()).unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed { .. }));
     }
+
+    #[test]
+    fn read_file_requires_path() {
+        let tool = ReadFileTool;
+        let call = ToolCall {
+            name: "read_file".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn write_file_requires_path() {
+        let tool = WriteFileTool;
+        let call = ToolCall {
+            name: "write_file".to_owned(),
+            arguments: BTreeMap::from([("content".to_owned(), "hello".to_owned())]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn write_file_requires_content() {
+        let tool = WriteFileTool;
+        let call = ToolCall {
+            name: "write_file".to_owned(),
+            arguments: BTreeMap::from([("path".to_owned(), "/tmp/test.txt".to_owned())]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "content",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn list_dir_requires_path() {
+        let tool = ListDirTool;
+        let call = ToolCall {
+            name: "list_dir".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "path",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn list_dir_empty_directory() {
+        let dir = tempdir().unwrap();
+
+        let tool = ListDirTool;
+        let call = ToolCall {
+            name: "list_dir".to_owned(),
+            arguments: BTreeMap::from([(
+                "path".to_owned(),
+                dir.path().to_string_lossy().into_owned(),
+            )]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert_eq!(output.content, "(empty directory)");
+    }
+
+    #[test]
+    fn read_file_metadata_includes_path() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("meta.txt");
+        fs::write(&file_path, "content").unwrap();
+
+        let tool = ReadFileTool;
+        let path_str = file_path.to_string_lossy().into_owned();
+        let call = ToolCall {
+            name: "read_file".to_owned(),
+            arguments: BTreeMap::from([("path".to_owned(), path_str.clone())]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert_eq!(output.metadata.get("path").unwrap(), &path_str);
+        assert_eq!(output.metadata.get("tool").unwrap(), "read_file");
+    }
+
+    #[test]
+    fn write_file_metadata_includes_bytes_written() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("bytes.txt");
+
+        let tool = WriteFileTool;
+        let call = ToolCall {
+            name: "write_file".to_owned(),
+            arguments: BTreeMap::from([
+                ("path".to_owned(), file_path.to_string_lossy().into_owned()),
+                ("content".to_owned(), "twelve chars".to_owned()),
+            ]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert_eq!(output.metadata.get("bytes_written").unwrap(), "12");
+    }
+
+    #[test]
+    fn write_file_overwrites_existing() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("overwrite.txt");
+        fs::write(&file_path, "original").unwrap();
+
+        let tool = WriteFileTool;
+        let call = ToolCall {
+            name: "write_file".to_owned(),
+            arguments: BTreeMap::from([
+                ("path".to_owned(), file_path.to_string_lossy().into_owned()),
+                ("content".to_owned(), "replaced".to_owned()),
+            ]),
+        };
+
+        tool.run(&call, &ctx()).expect("should succeed");
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), "replaced");
+    }
+
+    #[test]
+    fn list_dir_sorts_entries() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("zebra.txt"), "").unwrap();
+        fs::write(dir.path().join("apple.txt"), "").unwrap();
+        fs::write(dir.path().join("mango.txt"), "").unwrap();
+
+        let tool = ListDirTool;
+        let call = ToolCall {
+            name: "list_dir".to_owned(),
+            arguments: BTreeMap::from([(
+                "path".to_owned(),
+                dir.path().to_string_lossy().into_owned(),
+            )]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        let lines: Vec<&str> = output.content.lines().collect();
+        assert_eq!(lines[0], "apple.txt");
+        assert_eq!(lines[1], "mango.txt");
+        assert_eq!(lines[2], "zebra.txt");
+    }
+
+    #[test]
+    fn list_dir_metadata_includes_entry_count() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "").unwrap();
+        fs::write(dir.path().join("b.txt"), "").unwrap();
+
+        let tool = ListDirTool;
+        let call = ToolCall {
+            name: "list_dir".to_owned(),
+            arguments: BTreeMap::from([(
+                "path".to_owned(),
+                dir.path().to_string_lossy().into_owned(),
+            )]),
+        };
+
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert_eq!(output.metadata.get("entry_count").unwrap(), "2");
+    }
 }

--- a/crates/genesis-tools/src/builtins/memory.rs
+++ b/crates/genesis-tools/src/builtins/memory.rs
@@ -320,4 +320,177 @@ mod tests {
         assert!(!keywords.contains(&"i".to_owned()));
         assert!(!keywords.contains(&"a".to_owned()));
     }
+
+    #[test]
+    fn memory_store_requires_key() {
+        let dir = tempdir().expect("tempdir");
+        let tool = MemoryStoreTool;
+        let call = ToolCall {
+            name: "memory_store".to_owned(),
+            arguments: BTreeMap::from([("value".to_owned(), "some value".to_owned())]),
+        };
+        let err = tool
+            .run(&call, &ctx(dir.path().to_string_lossy().as_ref()))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::ToolError::MissingArgument {
+                argument: "key",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn memory_store_requires_value() {
+        let dir = tempdir().expect("tempdir");
+        let tool = MemoryStoreTool;
+        let call = ToolCall {
+            name: "memory_store".to_owned(),
+            arguments: BTreeMap::from([("key".to_owned(), "some_key".to_owned())]),
+        };
+        let err = tool
+            .run(&call, &ctx(dir.path().to_string_lossy().as_ref()))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::ToolError::MissingArgument {
+                argument: "value",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn memory_recall_requires_query() {
+        let dir = tempdir().expect("tempdir");
+        let tool = MemoryRecallTool;
+        let call = ToolCall {
+            name: "memory_recall".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = tool
+            .run(&call, &ctx(dir.path().to_string_lossy().as_ref()))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::ToolError::MissingArgument {
+                argument: "query",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn memory_recall_returns_no_memories_when_empty() {
+        let dir = tempdir().expect("tempdir");
+        setup_db(dir.path());
+        let context = ctx(dir.path().to_string_lossy().as_ref());
+
+        let output = MemoryRecallTool
+            .run(
+                &ToolCall {
+                    name: "memory_recall".to_owned(),
+                    arguments: BTreeMap::from([("query".to_owned(), "anything".to_owned())]),
+                },
+                &context,
+            )
+            .expect("should succeed");
+
+        assert_eq!(output.content, "no memories found");
+    }
+
+    #[test]
+    fn memory_recall_respects_custom_limit() {
+        let dir = tempdir().expect("tempdir");
+        setup_db(dir.path());
+        let context = ctx(dir.path().to_string_lossy().as_ref());
+
+        // Store multiple memories
+        for i in 0..5 {
+            MemoryStoreTool
+                .run(
+                    &ToolCall {
+                        name: "memory_store".to_owned(),
+                        arguments: BTreeMap::from([
+                            ("key".to_owned(), format!("fact_{i}")),
+                            ("value".to_owned(), format!("rust fact number {i}")),
+                        ]),
+                    },
+                    &context,
+                )
+                .unwrap();
+        }
+
+        let output = MemoryRecallTool
+            .run(
+                &ToolCall {
+                    name: "memory_recall".to_owned(),
+                    arguments: BTreeMap::from([
+                        ("query".to_owned(), "rust".to_owned()),
+                        ("limit".to_owned(), "2".to_owned()),
+                    ]),
+                },
+                &context,
+            )
+            .expect("should succeed");
+
+        // The result should have at most 2 memories
+        let lines: Vec<&str> = output.content.lines().collect();
+        assert!(lines.len() <= 2, "should respect limit of 2, got {}", lines.len());
+        assert_eq!(output.metadata.get("limit").unwrap(), "2");
+    }
+
+    #[test]
+    fn memory_recall_invalid_limit_returns_error() {
+        let dir = tempdir().expect("tempdir");
+        setup_db(dir.path());
+        let context = ctx(dir.path().to_string_lossy().as_ref());
+
+        let err = MemoryRecallTool
+            .run(
+                &ToolCall {
+                    name: "memory_recall".to_owned(),
+                    arguments: BTreeMap::from([
+                        ("query".to_owned(), "test".to_owned()),
+                        ("limit".to_owned(), "not_a_number".to_owned()),
+                    ]),
+                },
+                &context,
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, crate::ToolError::ExecutionFailed { .. }));
+    }
+
+    #[test]
+    fn extract_keywords_deduplicates() {
+        let keywords = super::extract_keywords("rust_lang", "rust is great");
+        // "rust" appears in both key and value but should only appear once
+        let rust_count = keywords.iter().filter(|k| *k == "rust").count();
+        assert_eq!(rust_count, 1, "keywords should be deduplicated");
+    }
+
+    #[test]
+    fn memory_store_metadata_includes_session_id() {
+        let dir = tempdir().expect("tempdir");
+        setup_db(dir.path());
+        let tool = MemoryStoreTool;
+
+        let output = tool
+            .run(
+                &ToolCall {
+                    name: "memory_store".to_owned(),
+                    arguments: BTreeMap::from([
+                        ("key".to_owned(), "test_key".to_owned()),
+                        ("value".to_owned(), "test_value".to_owned()),
+                    ]),
+                },
+                &ctx(dir.path().to_string_lossy().as_ref()),
+            )
+            .expect("should succeed");
+
+        assert_eq!(output.metadata.get("session_id").unwrap(), "session-42");
+        assert_eq!(output.metadata.get("key").unwrap(), "test_key");
+    }
 }

--- a/crates/genesis-tools/src/builtins/mixture.rs
+++ b/crates/genesis-tools/src/builtins/mixture.rs
@@ -294,4 +294,48 @@ mod tests {
         assert!(DEFAULT_MODELS.len() >= 2);
         assert!(DEFAULT_MODELS.len() <= MAX_MODELS);
     }
+
+    #[test]
+    fn model_spec_parsing_with_default_backend() {
+        // When no slash is present, default backend is "openai"
+        let spec = "gpt-4o-mini";
+        let parsed = spec.split_once('/').or(Some(("openai", spec)));
+        assert_eq!(parsed, Some(("openai", "gpt-4o-mini")));
+    }
+
+    #[test]
+    fn model_spec_parsing_with_explicit_backend() {
+        let spec = "anthropic/claude-sonnet-4-20250514";
+        let parsed = spec.split_once('/').or(Some(("openai", spec)));
+        assert_eq!(parsed, Some(("anthropic", "claude-sonnet-4-20250514")));
+    }
+
+    #[test]
+    fn max_models_limits_specs() {
+        let specs = "a/1, b/2, c/3, d/4, e/5, f/6, g/7";
+        let parsed: Vec<(&str, &str)> = specs
+            .split(',')
+            .filter_map(|s| {
+                let s = s.trim();
+                s.split_once('/').or(Some(("openai", s)))
+            })
+            .take(MAX_MODELS)
+            .collect();
+
+        assert_eq!(parsed.len(), MAX_MODELS);
+    }
+
+    #[test]
+    fn build_synthesis_prompt_numbers_responses() {
+        let responses = vec![
+            ("openai", "gpt-4o", "First"),
+            ("anthropic", "claude", "Second"),
+            ("google", "gemini", "Third"),
+        ];
+        let prompt = build_synthesis_prompt("Test question", &responses);
+        assert!(prompt.contains("Response 1"));
+        assert!(prompt.contains("Response 2"));
+        assert!(prompt.contains("Response 3"));
+        assert!(prompt.contains("3 different AI models"));
+    }
 }

--- a/crates/genesis-tools/src/builtins/mod.rs
+++ b/crates/genesis-tools/src/builtins/mod.rs
@@ -57,3 +57,44 @@ pub(crate) fn combine_command_output(stdout: &str, stderr: &str, exit_code: i32)
         content
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::combine_command_output;
+
+    #[test]
+    fn combine_stdout_only() {
+        let result = combine_command_output("hello world", "", 0);
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn combine_stderr_only() {
+        let result = combine_command_output("", "error occurred", 1);
+        assert_eq!(result, "[stderr]\nerror occurred");
+    }
+
+    #[test]
+    fn combine_both_stdout_and_stderr() {
+        let result = combine_command_output("output", "warning", 0);
+        assert_eq!(result, "output\n[stderr]\nwarning");
+    }
+
+    #[test]
+    fn combine_empty_returns_exit_code() {
+        let result = combine_command_output("", "", 42);
+        assert_eq!(result, "(no output, exit code 42)");
+    }
+
+    #[test]
+    fn combine_empty_zero_exit() {
+        let result = combine_command_output("", "", 0);
+        assert_eq!(result, "(no output, exit code 0)");
+    }
+
+    #[test]
+    fn combine_negative_exit_code() {
+        let result = combine_command_output("", "", -1);
+        assert_eq!(result, "(no output, exit code -1)");
+    }
+}

--- a/crates/genesis-tools/src/builtins/reason.rs
+++ b/crates/genesis-tools/src/builtins/reason.rs
@@ -157,4 +157,22 @@ mod tests {
 
     // Note: Full integration tests require a running LLM endpoint.
     // The tool gracefully handles connection errors via ToolError::ExecutionFailed.
+
+    #[test]
+    fn reason_requires_both_prompt_and_model() {
+        let tool = ReasonWithModelTool;
+        let call = ToolCall {
+            name: "reason_with_model".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        // prompt is checked first
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "prompt",
+                ..
+            }
+        ));
+    }
 }

--- a/crates/genesis-tools/src/builtins/session.rs
+++ b/crates/genesis-tools/src/builtins/session.rs
@@ -321,4 +321,111 @@ mod tests {
         let output = SessionHistoryTool.run(&call, &ctx).expect("history");
         assert!(output.content.contains("..."));
     }
+
+    #[test]
+    fn session_search_requires_query() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "session_search".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = SessionSearchTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(err, ToolError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn session_history_requires_session_id() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "session_history".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = SessionHistoryTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(err, ToolError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn session_history_invalid_limit_returns_error() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "session_history".to_owned(),
+            arguments: BTreeMap::from([
+                ("session_id".to_owned(), "s-1".to_owned()),
+                ("limit".to_owned(), "not_a_number".to_owned()),
+            ]),
+        };
+        let err = SessionHistoryTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(err, ToolError::ExecutionFailed { .. }));
+    }
+
+    #[test]
+    fn session_search_metadata_includes_count() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let store = SessionStore::new(&db_path);
+        store
+            .create_session("s-meta", "cli", Some("Metadata test"))
+            .expect("create session");
+        store
+            .append_message(
+                "s-meta",
+                "user",
+                Some("Metadata is important for tracking"),
+                None,
+                None,
+                None,
+            )
+            .expect("append");
+
+        let call = ToolCall {
+            name: "session_search".to_owned(),
+            arguments: BTreeMap::from([("query".to_owned(), "Metadata".to_owned())]),
+        };
+        let output = SessionSearchTool.run(&call, &ctx).expect("search");
+        let count = output.metadata.get("count").unwrap();
+        assert_eq!(count, "1");
+    }
+
+    #[test]
+    fn session_history_metadata_includes_total_messages() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let store = SessionStore::new(&db_path);
+        store
+            .create_session("s-meta2", "cli", None)
+            .expect("create session");
+        for i in 0..3 {
+            store
+                .append_message(
+                    "s-meta2",
+                    "user",
+                    Some(&format!("Message {i}")),
+                    None,
+                    None,
+                    None,
+                )
+                .expect("append");
+        }
+
+        let call = ToolCall {
+            name: "session_history".to_owned(),
+            arguments: BTreeMap::from([("session_id".to_owned(), "s-meta2".to_owned())]),
+        };
+        let output = SessionHistoryTool.run(&call, &ctx).expect("history");
+        assert_eq!(output.metadata.get("total_messages").unwrap(), "3");
+    }
 }

--- a/crates/genesis-tools/src/builtins/skill.rs
+++ b/crates/genesis-tools/src/builtins/skill.rs
@@ -569,4 +569,246 @@ mod tests {
         let err = SkillRecordUsageTool.run(&usage_call, &ctx).unwrap_err();
         assert!(matches!(err, ToolError::ExecutionFailed { .. }));
     }
+
+    #[test]
+    fn skill_create_requires_description() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_create".to_owned(),
+            arguments: BTreeMap::from([("name".to_owned(), "test".to_owned())]),
+        };
+        let err = SkillCreateTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "description",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn skill_create_requires_instructions() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_create".to_owned(),
+            arguments: BTreeMap::from([
+                ("name".to_owned(), "test".to_owned()),
+                ("description".to_owned(), "desc".to_owned()),
+            ]),
+        };
+        let err = SkillCreateTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "instructions",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn skill_get_requires_name() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_get".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = SkillGetTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "name",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn skill_delete_requires_name() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_delete".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = SkillDeleteTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "name",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn skill_delete_nonexistent_returns_not_found() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_delete".to_owned(),
+            arguments: BTreeMap::from([("name".to_owned(), "nonexistent".to_owned())]),
+        };
+        let output = SkillDeleteTool.run(&call, &ctx).expect("should succeed");
+        assert!(output.content.contains("not found"));
+    }
+
+    #[test]
+    fn skill_upsert_increments_version() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let make_call = |version_hint: &str| ToolCall {
+            name: "skill_create".to_owned(),
+            arguments: BTreeMap::from([
+                ("name".to_owned(), "evolving".to_owned()),
+                ("description".to_owned(), format!("Version {version_hint}")),
+                ("instructions".to_owned(), format!("Steps for v{version_hint}")),
+            ]),
+        };
+
+        let output1 = SkillCreateTool
+            .run(&make_call("1"), &ctx)
+            .expect("first create");
+        assert!(output1.content.contains("version 1"));
+
+        let output2 = SkillCreateTool
+            .run(&make_call("2"), &ctx)
+            .expect("second create");
+        assert!(output2.content.contains("version 2"));
+    }
+
+    #[test]
+    fn skill_get_includes_trigger_hint() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let create_call = ToolCall {
+            name: "skill_create".to_owned(),
+            arguments: BTreeMap::from([
+                ("name".to_owned(), "greeting".to_owned()),
+                ("description".to_owned(), "Greet user".to_owned()),
+                ("instructions".to_owned(), "Say hello nicely".to_owned()),
+                ("trigger_hint".to_owned(), "when user says hi".to_owned()),
+            ]),
+        };
+        SkillCreateTool.run(&create_call, &ctx).expect("create");
+
+        let get_call = ToolCall {
+            name: "skill_get".to_owned(),
+            arguments: BTreeMap::from([("name".to_owned(), "greeting".to_owned())]),
+        };
+        let output = SkillGetTool.run(&get_call, &ctx).expect("get");
+        assert!(output.content.contains("when user says hi"));
+        assert!(output.content.contains("**Trigger:**"));
+    }
+
+    #[test]
+    fn skill_get_includes_tags() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let create_call = ToolCall {
+            name: "skill_create".to_owned(),
+            arguments: BTreeMap::from([
+                ("name".to_owned(), "tagged".to_owned()),
+                ("description".to_owned(), "Tagged skill".to_owned()),
+                ("instructions".to_owned(), "Do tagged thing".to_owned()),
+                ("tags".to_owned(), "rust, dev, testing".to_owned()),
+            ]),
+        };
+        SkillCreateTool.run(&create_call, &ctx).expect("create");
+
+        let get_call = ToolCall {
+            name: "skill_get".to_owned(),
+            arguments: BTreeMap::from([("name".to_owned(), "tagged".to_owned())]),
+        };
+        let output = SkillGetTool.run(&get_call, &ctx).expect("get");
+        assert!(output.content.contains("**Tags:**"));
+        assert!(output.content.contains("rust"));
+        assert!(output.content.contains("dev"));
+        assert!(output.content.contains("testing"));
+    }
+
+    #[test]
+    fn skill_record_usage_requires_skill_name() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_record_usage".to_owned(),
+            arguments: BTreeMap::from([("outcome".to_owned(), "success".to_owned())]),
+        };
+        let err = SkillRecordUsageTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "skill_name",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn skill_record_usage_requires_outcome() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_record_usage".to_owned(),
+            arguments: BTreeMap::from([("skill_name".to_owned(), "test".to_owned())]),
+        };
+        let err = SkillRecordUsageTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "outcome",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn skill_list_with_tags_shows_tag_info() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "skill_create".to_owned(),
+            arguments: BTreeMap::from([
+                ("name".to_owned(), "tagged_skill".to_owned()),
+                ("description".to_owned(), "A tagged skill".to_owned()),
+                ("instructions".to_owned(), "Do something".to_owned()),
+                ("tags".to_owned(), "rust, testing".to_owned()),
+            ]),
+        };
+        SkillCreateTool.run(&call, &ctx).expect("create");
+
+        let list_call = ToolCall {
+            name: "skill_list".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let output = SkillListTool.run(&list_call, &ctx).expect("list");
+        assert!(output.content.contains("[rust, testing]"));
+        assert_eq!(output.metadata.get("count").unwrap(), "1");
+    }
 }

--- a/crates/genesis-tools/src/builtins/ssh.rs
+++ b/crates/genesis-tools/src/builtins/ssh.rs
@@ -111,4 +111,77 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn ssh_exec_requires_both_arguments() {
+        let tool = SshExecTool;
+        let call = ToolCall {
+            name: "ssh_exec".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        // Host is checked first
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "host",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn ssh_exec_to_unreachable_host_fails_gracefully() {
+        let tool = SshExecTool;
+        let call = ToolCall {
+            name: "ssh_exec".to_owned(),
+            arguments: BTreeMap::from([
+                ("host".to_owned(), "192.0.2.1".to_owned()), // TEST-NET, unreachable
+                ("command".to_owned(), "echo hello".to_owned()),
+                ("port".to_owned(), "22222".to_owned()),
+            ]),
+        };
+        // SSH to an unreachable host should either time out or fail without panic.
+        let result = tool.run(&call, &ctx());
+        match result {
+            Ok(output) => {
+                // SSH ran but couldn't connect
+                assert!(
+                    output.metadata.get("exit_code").unwrap() != "0",
+                    "should have non-zero exit code"
+                );
+            }
+            Err(ToolError::ExecutionFailed { .. }) => {
+                // SSH binary issue - also acceptable
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ssh_exec_metadata_includes_user_prefix() {
+        // We can only test the metadata format since we cannot really SSH.
+        // A connection to a bogus host will include user@host in metadata.
+        let tool = SshExecTool;
+        let call = ToolCall {
+            name: "ssh_exec".to_owned(),
+            arguments: BTreeMap::from([
+                ("host".to_owned(), "192.0.2.1".to_owned()),
+                ("command".to_owned(), "whoami".to_owned()),
+                ("user".to_owned(), "admin".to_owned()),
+                ("port".to_owned(), "22222".to_owned()),
+            ]),
+        };
+        // The result will fail (unreachable) but we can check the metadata host field
+        let result = tool.run(&call, &ctx());
+        match result {
+            Ok(output) => {
+                assert_eq!(output.metadata.get("host").unwrap(), "admin@192.0.2.1");
+            }
+            Err(ToolError::ExecutionFailed { .. }) => {
+                // SSH binary missing - skip metadata check
+            }
+            Err(other) => panic!("unexpected error: {other:?}"),
+        }
+    }
 }

--- a/crates/genesis-tools/src/builtins/subagent.rs
+++ b/crates/genesis-tools/src/builtins/subagent.rs
@@ -355,4 +355,127 @@ mod tests {
         let err = SpawnSubagentTool.run(&call, &ctx).unwrap_err();
         assert!(matches!(err, ToolError::MissingArgument { .. }));
     }
+
+    #[test]
+    fn check_requires_subagent_id() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "check_subagent".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+
+        let err = CheckSubagentTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "subagent_id",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn check_nonexistent_subagent_errors() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "check_subagent".to_owned(),
+            arguments: BTreeMap::from([("subagent_id".to_owned(), "nonexistent".to_owned())]),
+        };
+
+        let err = CheckSubagentTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(err, ToolError::ExecutionFailed { .. }));
+    }
+
+    #[test]
+    fn spawn_uses_default_name_when_not_provided() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        SessionStore::new(&db_path)
+            .create_session("parent-session", "cli", None)
+            .expect("parent session");
+
+        let call = ToolCall {
+            name: "spawn_subagent".to_owned(),
+            arguments: BTreeMap::from([(
+                "task".to_owned(),
+                "Do something".to_owned(),
+            )]),
+        };
+
+        let output = SpawnSubagentTool.run(&call, &ctx).expect("spawn");
+        assert!(output.content.contains("subagent"));
+    }
+
+    #[test]
+    fn check_shows_error_for_failed_subagent() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        SessionStore::new(&db_path)
+            .create_session("parent-session", "cli", None)
+            .expect("parent session");
+        SessionStore::new(&db_path)
+            .create_session("child-err", "subagent", None)
+            .expect("child session");
+
+        let store = SubagentStore::new(&db_path);
+        store
+            .create("sub-err", "parent-session", "child-err", "worker", "fail task")
+            .expect("create");
+        store
+            .set_failed("sub-err", "something went wrong")
+            .expect("fail");
+
+        let call = ToolCall {
+            name: "check_subagent".to_owned(),
+            arguments: BTreeMap::from([("subagent_id".to_owned(), "sub-err".to_owned())]),
+        };
+
+        let output = CheckSubagentTool.run(&call, &ctx).expect("check");
+        assert!(output.content.contains("failed"));
+        assert!(output.content.contains("something went wrong"));
+    }
+
+    #[test]
+    fn list_shows_completed_result_truncated() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        SessionStore::new(&db_path)
+            .create_session("parent-session", "cli", None)
+            .expect("parent session");
+        SessionStore::new(&db_path)
+            .create_session("child-done", "subagent", None)
+            .expect("child session");
+
+        let store = SubagentStore::new(&db_path);
+        store
+            .create("sub-done", "parent-session", "child-done", "worker", "big task")
+            .expect("create");
+        store
+            .set_completed("sub-done", "Result of the big task")
+            .expect("complete");
+
+        let call = ToolCall {
+            name: "list_subagents".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+
+        let output = ListSubagentsTool.run(&call, &ctx).expect("list");
+        assert!(output.content.contains("[completed]"));
+        assert!(output.content.contains("Result of the big task"));
+    }
 }

--- a/crates/genesis-tools/src/builtins/think.rs
+++ b/crates/genesis-tools/src/builtins/think.rs
@@ -84,4 +84,29 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn think_with_long_thought_succeeds() {
+        let tool = ThinkTool;
+        let long_thought = "a".repeat(10_000);
+        let call = ToolCall {
+            name: "think".to_owned(),
+            arguments: BTreeMap::from([("thought".to_owned(), long_thought)]),
+        };
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert!(output.content.is_empty());
+    }
+
+    #[test]
+    fn think_with_empty_thought_still_succeeds() {
+        // The think tool accepts any non-missing thought, even empty
+        let tool = ThinkTool;
+        let call = ToolCall {
+            name: "think".to_owned(),
+            arguments: BTreeMap::from([("thought".to_owned(), String::new())]),
+        };
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert!(output.content.is_empty());
+        assert!(output.metadata.is_empty());
+    }
 }

--- a/crates/genesis-tools/src/builtins/todo.rs
+++ b/crates/genesis-tools/src/builtins/todo.rs
@@ -420,4 +420,234 @@ mod tests {
         let output_b = tool.run(&call, &ctx_with_session("session-b")).unwrap();
         assert!(output_b.content.contains("task for B"));
     }
+
+    #[test]
+    fn todo_requires_action() {
+        let tool = TodoTool;
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(err, ToolError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn todo_add_requires_text() {
+        let tool = TodoTool;
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "add".to_owned())]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(err, ToolError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn todo_update_requires_id() {
+        let tool = TodoTool;
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "update".to_owned()),
+                ("status".to_owned(), "done".to_owned()),
+            ]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(err, ToolError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn todo_update_requires_status() {
+        let tool = TodoTool;
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "update".to_owned()),
+                ("id".to_owned(), "1".to_owned()),
+            ]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(err, ToolError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn todo_update_rejects_invalid_id() {
+        let tool = TodoTool;
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "update".to_owned()),
+                ("id".to_owned(), "abc".to_owned()),
+                ("status".to_owned(), "done".to_owned()),
+            ]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(err, ToolError::ExecutionFailed { .. }));
+    }
+
+    #[test]
+    fn todo_update_rejects_invalid_status() {
+        clear_todos("test");
+        let tool = TodoTool;
+        // Add an item first
+        let add = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "add".to_owned()),
+                ("text".to_owned(), "item".to_owned()),
+            ]),
+        };
+        tool.run(&add, &ctx()).unwrap();
+
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "update".to_owned()),
+                ("id".to_owned(), "1".to_owned()),
+                ("status".to_owned(), "completed".to_owned()),
+            ]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        match err {
+            ToolError::ExecutionFailed { reason, .. } => {
+                assert!(reason.contains("invalid status"));
+            }
+            _ => panic!("expected ExecutionFailed"),
+        }
+    }
+
+    #[test]
+    fn todo_update_nonexistent_id() {
+        clear_todos("test");
+        let tool = TodoTool;
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "update".to_owned()),
+                ("id".to_owned(), "999".to_owned()),
+                ("status".to_owned(), "done".to_owned()),
+            ]),
+        };
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        match err {
+            ToolError::ExecutionFailed { reason, .. } => {
+                assert!(reason.contains("no todo with id"));
+            }
+            _ => panic!("expected ExecutionFailed"),
+        }
+    }
+
+    #[test]
+    fn todo_in_progress_marker() {
+        clear_todos("test");
+        let tool = TodoTool;
+
+        let add = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "add".to_owned()),
+                ("text".to_owned(), "working on it".to_owned()),
+            ]),
+        };
+        tool.run(&add, &ctx()).unwrap();
+
+        let update = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "update".to_owned()),
+                ("id".to_owned(), "1".to_owned()),
+                ("status".to_owned(), "in_progress".to_owned()),
+            ]),
+        };
+        tool.run(&update, &ctx()).unwrap();
+
+        let list = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "list".to_owned())]),
+        };
+        let output = tool.run(&list, &ctx()).unwrap();
+        assert!(output.content.contains("[~]"));
+        assert!(output.content.contains("1 in progress"));
+    }
+
+    #[test]
+    fn todo_clear_empty_list() {
+        clear_todos("test");
+        let tool = TodoTool;
+
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "clear".to_owned())]),
+        };
+        let output = tool.run(&call, &ctx()).expect("should succeed");
+        assert!(output.content.contains("cleared 0"));
+    }
+
+    #[test]
+    fn todo_add_returns_id_in_metadata() {
+        clear_todos("test");
+        let tool = TodoTool;
+
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "add".to_owned()),
+                ("text".to_owned(), "first".to_owned()),
+            ]),
+        };
+        let output = tool.run(&call, &ctx()).unwrap();
+        assert_eq!(output.metadata.get("id").unwrap(), "1");
+
+        let call = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([
+                ("action".to_owned(), "add".to_owned()),
+                ("text".to_owned(), "second".to_owned()),
+            ]),
+        };
+        let output = tool.run(&call, &ctx()).unwrap();
+        assert_eq!(output.metadata.get("id").unwrap(), "2");
+    }
+
+    #[test]
+    fn todo_list_summary_counts() {
+        clear_todos("test");
+        let tool = TodoTool;
+
+        // Add three items with mixed statuses
+        for text in &["task a", "task b", "task c"] {
+            let call = ToolCall {
+                name: "todo".to_owned(),
+                arguments: BTreeMap::from([
+                    ("action".to_owned(), "add".to_owned()),
+                    ("text".to_owned(), (*text).to_owned()),
+                ]),
+            };
+            tool.run(&call, &ctx()).unwrap();
+        }
+
+        // Mark #1 as done, #2 as in_progress
+        for (id, status) in &[("1", "done"), ("2", "in_progress")] {
+            let call = ToolCall {
+                name: "todo".to_owned(),
+                arguments: BTreeMap::from([
+                    ("action".to_owned(), "update".to_owned()),
+                    ("id".to_owned(), (*id).to_owned()),
+                    ("status".to_owned(), (*status).to_owned()),
+                ]),
+            };
+            tool.run(&call, &ctx()).unwrap();
+        }
+
+        let list = ToolCall {
+            name: "todo".to_owned(),
+            arguments: BTreeMap::from([("action".to_owned(), "list".to_owned())]),
+        };
+        let output = tool.run(&list, &ctx()).unwrap();
+        assert!(output.content.contains("1 pending"));
+        assert!(output.content.contains("1 in progress"));
+        assert!(output.content.contains("1 done"));
+        assert_eq!(output.metadata.get("count").unwrap(), "3");
+    }
 }

--- a/crates/genesis-tools/src/builtins/tts.rs
+++ b/crates/genesis-tools/src/builtins/tts.rs
@@ -120,4 +120,28 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn tts_requires_both_arguments() {
+        let tool = TextToSpeechTool;
+        let call = ToolCall {
+            name: "text_to_speech".to_owned(),
+            arguments: BTreeMap::new(),
+        };
+
+        // "text" is checked first
+        let err = tool.run(&call, &ctx()).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "text",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn default_voice_is_set() {
+        assert_eq!(DEFAULT_VOICE, "en-US-AriaNeural");
+    }
 }

--- a/crates/genesis-tools/src/builtins/user_model.rs
+++ b/crates/genesis-tools/src/builtins/user_model.rs
@@ -236,4 +236,140 @@ mod tests {
         let err = UserObserveTool.run(&call, &ctx).unwrap_err();
         assert!(matches!(err, ToolError::MissingArgument { .. }));
     }
+
+    #[test]
+    fn observe_requires_category() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "user_observe".to_owned(),
+            arguments: BTreeMap::from([("trait_key".to_owned(), "likes_rust".to_owned())]),
+        };
+        let err = UserObserveTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "category",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn observe_requires_value() {
+        let dir = tempdir().expect("tempdir");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "user_observe".to_owned(),
+            arguments: BTreeMap::from([
+                ("trait_key".to_owned(), "likes_rust".to_owned()),
+                ("category".to_owned(), "preference".to_owned()),
+            ]),
+        };
+        let err = UserObserveTool.run(&call, &ctx).unwrap_err();
+        assert!(matches!(
+            err,
+            ToolError::MissingArgument {
+                argument: "value",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn observe_multiple_times_increases_confidence() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let make_call = || ToolCall {
+            name: "user_observe".to_owned(),
+            arguments: BTreeMap::from([
+                ("trait_key".to_owned(), "prefers_tabs".to_owned()),
+                ("category".to_owned(), "preference".to_owned()),
+                ("value".to_owned(), "Uses tabs over spaces".to_owned()),
+            ]),
+        };
+
+        let output1 = UserObserveTool
+            .run(&make_call(), &ctx)
+            .expect("first observe");
+        let output2 = UserObserveTool
+            .run(&make_call(), &ctx)
+            .expect("second observe");
+
+        // Confidence should increase with more observations
+        let conf1: f64 = output1
+            .metadata
+            .get("confidence")
+            .unwrap()
+            .parse()
+            .unwrap();
+        let conf2: f64 = output2
+            .metadata
+            .get("confidence")
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        assert!(conf2 >= conf1, "confidence should increase: {conf1} -> {conf2}");
+    }
+
+    #[test]
+    fn user_model_min_confidence_filter() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        // Add a single observation (low confidence)
+        UserObserveTool
+            .run(
+                &ToolCall {
+                    name: "user_observe".to_owned(),
+                    arguments: BTreeMap::from([
+                        ("trait_key".to_owned(), "low_conf".to_owned()),
+                        ("category".to_owned(), "preference".to_owned()),
+                        ("value".to_owned(), "Some preference".to_owned()),
+                    ]),
+                },
+                &ctx,
+            )
+            .unwrap();
+
+        // Query with high min_confidence
+        let call = ToolCall {
+            name: "user_model".to_owned(),
+            arguments: BTreeMap::from([("min_confidence".to_owned(), "0.99".to_owned())]),
+        };
+        let output = UserModelTool.run(&call, &ctx).expect("recall");
+        // A single observation starts at 50% confidence, so filtering at 99% should be empty
+        assert!(
+            output.content.contains("No user model data"),
+            "high min_confidence should filter out low-confidence traits"
+        );
+    }
+
+    #[test]
+    fn observe_metadata_includes_confidence() {
+        let dir = tempdir().expect("tempdir");
+        let db_path = dir.path().join("genesis.db");
+        bootstrap(&db_path).expect("bootstrap");
+        let ctx = ctx_with_dir(&dir.path().display().to_string());
+
+        let call = ToolCall {
+            name: "user_observe".to_owned(),
+            arguments: BTreeMap::from([
+                ("trait_key".to_owned(), "test_key".to_owned()),
+                ("category".to_owned(), "test".to_owned()),
+                ("value".to_owned(), "test_value".to_owned()),
+            ]),
+        };
+        let output = UserObserveTool.run(&call, &ctx).expect("observe");
+        assert!(output.metadata.contains_key("confidence"));
+        assert!(output.metadata.contains_key("trait_key"));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #282 (partial -- focuses on the most testable tools first).

- Adds **78 new tests** across **15 builtin tool modules**, increasing `genesis-tools` test count from 433 to 511
- All tests pass (`cargo test -p genesis-tools`) and zero clippy warnings (`cargo clippy -p genesis-tools -- -D warnings`)

### Coverage additions by module

| Module | Before | After | Tests Added |
|--------|--------|-------|-------------|
| `todo.rs` | 6 | 17 | +11 (missing args, invalid id/status, in_progress marker, clear empty, summary counts, add metadata) |
| `skill.rs` | 10 | 21 | +11 (missing args for all 5 tools, version increment on upsert, delete nonexistent, trigger/tags in get, list with tags) |
| `fs.rs` | 6 | 16 | +10 (missing args for all 3 tools, empty dir, overwrite, sort order, metadata for read/write/list) |
| `memory.rs` | 5 | 13 | +8 (missing args, empty recall, custom limit, invalid limit, keyword dedup, metadata) |
| `mod.rs` | 0 | 6 | +6 (`combine_command_output`: stdout only, stderr only, both, empty, zero exit, negative exit) |
| `session.rs` | 6 | 11 | +5 (missing query/session_id, invalid limit, metadata count/total_messages) |
| `subagent.rs` | 5 | 10 | +5 (missing subagent_id, nonexistent check, default name, failed status, completed list) |
| `user_model.rs` | 4 | 9 | +5 (missing category/value, confidence increase, min_confidence filter, metadata) |
| `mixture.rs` | 4 | 8 | +4 (model spec default/explicit backend, max_models limit, synthesis prompt numbering) |
| `clarify.rs` | 4 | 7 | +3 (no choices, metadata flags, single choice) |
| `ssh.rs` | 2 | 5 | +3 (missing both args, unreachable host, user@host metadata) |
| `docker.rs` | 2 | 4 | +2 (missing both args, nonexistent container) |
| `tts.rs` | 2 | 4 | +2 (missing both args, default voice constant) |
| `think.rs` | 2 | 4 | +2 (long thought, empty thought) |
| `reason.rs` | 2 | 3 | +1 (missing both args) |

### What's tested

- **Missing argument validation** for every required parameter on every tool
- **Error paths**: invalid IDs, nonexistent entities, invalid status values, unreachable hosts
- **Edge cases**: empty directories, empty todo lists, long inputs, keyword deduplication
- **Metadata correctness**: verifying tool output metadata fields are populated correctly
- **State management**: todo list session isolation, confidence accumulation, version incrementing

## Test plan

- [x] `cargo clippy -p genesis-tools -- -D warnings` passes with zero warnings
- [x] `cargo test -p genesis-tools` passes with 511 tests, 0 failures
- [x] All tests use `tempdir()` for filesystem isolation and `bootstrap()` for DB isolation