### PR TITLE
perf(gateway): wrap SQLite operations in spawn_blocking

### DIFF
--- a/crates/genesis-gateway/src/lib.rs
+++ b/crates/genesis-gateway/src/lib.rs
@@ -262,6 +262,32 @@ pub(crate) mod helpers {
         pending,
         genesis_storage::PendingPairing
     );
+
+    // -----------------------------------------------------------------------
+    // Blocking storage helper
+    // -----------------------------------------------------------------------
+
+    /// Run a synchronous storage closure on a dedicated blocking thread.
+    ///
+    /// `rusqlite::Connection` is **not `Send`**, so all database work must
+    /// happen entirely inside the closure.  The closure receives a cloned
+    /// `PathBuf` so it can construct whatever store it needs on the blocking
+    /// thread.
+    ///
+    /// This keeps the tokio async executor free from blocking I/O and
+    /// prevents thread-starvation under concurrent gateway load.
+    pub(crate) async fn spawn_blocking_storage<F, T>(
+        db_path: std::path::PathBuf,
+        f: F,
+    ) -> Result<T, ApiError>
+    where
+        F: FnOnce(std::path::PathBuf) -> Result<T, ApiError> + Send + 'static,
+        T: Send + 'static,
+    {
+        tokio::task::spawn_blocking(move || f(db_path))
+            .await
+            .map_err(|e| ApiError::internal(format!("blocking task panicked: {e}")))?
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/genesis-gateway/src/platforms/homeassistant.rs
+++ b/crates/genesis-gateway/src/platforms/homeassistant.rs
@@ -123,11 +123,21 @@ pub async fn webhook_handler(
 
     info!(parent: &span, "received home assistant webhook");
 
-    // Handle gateway slash commands before reaching the agent.
-    let store = genesis_storage::SessionStore::new(&state.loaded.config.storage.database_path);
-    if let crate::commands::CommandResult::Reply(reply) =
-        crate::commands::handle_command(&request.message, &session_id, &store, &state.loaded.config)
-    {
+    // Handle gateway slash commands before reaching the agent (on blocking thread).
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let msg_clone = request.message.clone();
+    let sid_clone = session_id.clone();
+    let config_clone = state.loaded.config.clone();
+    let cmd_result = tokio::task::spawn_blocking(move || {
+        let store = genesis_storage::SessionStore::new(&db_path);
+        let cmd = crate::commands::handle_command(&msg_clone, &sid_clone, &store, &config_clone);
+        crate::commands::check_session_expiry(&sid_clone, &store, config_clone.gateway.as_ref());
+        cmd
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("blocking task panicked: {e}")))?;
+
+    if let crate::commands::CommandResult::Reply(reply) = cmd_result {
         return Ok(Json(HomeAssistantResponse {
             response: reply,
             session_id,
@@ -135,13 +145,6 @@ pub async fn webhook_handler(
             tool_calls_made: 0,
         }));
     }
-
-    // Auto-reset expired sessions before processing.
-    crate::commands::check_session_expiry(
-        &session_id,
-        &store,
-        state.loaded.config.gateway.as_ref(),
-    );
 
     let service = state.session_service();
 

--- a/crates/genesis-gateway/src/platforms/mod.rs
+++ b/crates/genesis-gateway/src/platforms/mod.rs
@@ -72,39 +72,66 @@ pub async fn process_platform_message(
     state: &Arc<AppState>,
     msg: &PlatformMessage<'_>,
 ) -> ProcessOutcome {
-    // 1. DM pairing check
-    match check_pairing(
-        &state.loaded.config.storage.database_path,
-        msg.platform_name,
-        msg.user_id,
-        msg.user_name,
-    ) {
-        Ok(PairingCheck::Approved) => {}
-        Ok(PairingCheck::NeedsPairing(code)) => {
+    // 1. DM pairing check (on blocking thread)
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let platform_name = msg.platform_name.to_owned();
+    let user_id = msg.user_id.to_owned();
+    let user_name = msg.user_name.to_owned();
+
+    let pairing_result = {
+        let db_path = db_path.clone();
+        let platform_name = platform_name.clone();
+        let user_id = user_id.clone();
+        let user_name = user_name.clone();
+        tokio::task::spawn_blocking(move || {
+            check_pairing(&db_path, &platform_name, &user_id, &user_name)
+        })
+        .await
+    };
+
+    match pairing_result {
+        Ok(Ok(PairingCheck::Approved)) => {}
+        Ok(Ok(PairingCheck::NeedsPairing(code))) => {
             return ProcessOutcome::NeedsPairing(pairing_reply(&code));
         }
-        Ok(PairingCheck::AtCapacity) => {
+        Ok(Ok(PairingCheck::AtCapacity)) => {
             return ProcessOutcome::AtCapacity;
         }
-        Err(_) => {
+        Ok(Err(_)) | Err(_) => {
             return ProcessOutcome::PairingError;
         }
     }
 
-    // 2. Handle gateway slash commands
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    if let crate::commands::CommandResult::Reply(reply) =
-        crate::commands::handle_command(msg.text, msg.session_id, &store, &state.loaded.config)
-    {
-        return ProcessOutcome::CommandReply(reply);
-    }
+    // 2. Handle gateway slash commands + 3. Auto-reset expired sessions (on blocking thread)
+    let text = msg.text.to_owned();
+    let session_id = msg.session_id.to_owned();
+    let config = state.loaded.config.clone();
 
-    // 3. Auto-reset expired sessions
-    crate::commands::check_session_expiry(
-        msg.session_id,
-        &store,
-        state.loaded.config.gateway.as_ref(),
-    );
+    let command_result = {
+        let db_path = db_path.clone();
+        let text = text.clone();
+        let session_id = session_id.clone();
+        let config = config.clone();
+        tokio::task::spawn_blocking(move || {
+            let store = SessionStore::new(&db_path);
+            let cmd = crate::commands::handle_command(&text, &session_id, &store, &config);
+            // Auto-reset expired sessions while we have the store
+            crate::commands::check_session_expiry(&session_id, &store, config.gateway.as_ref());
+            cmd
+        })
+        .await
+    };
+
+    match command_result {
+        Ok(crate::commands::CommandResult::Reply(reply)) => {
+            return ProcessOutcome::CommandReply(reply);
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "blocking command handler panicked");
+            return ProcessOutcome::ExecutionError("internal error".to_owned());
+        }
+        _ => {}
+    }
 
     // 4. Run the agent turn
     let service = state.session_service();
@@ -127,14 +154,22 @@ pub async fn process_platform_message(
     // 5. Extract the reply
     let reply_text = extract_reply(result, msg.platform_name);
 
-    // 6. Delivery mirror
-    crate::mirror::append_delivery_mirror(
-        &state.loaded.config.storage.database_path,
-        msg.platform_name,
-        msg.chat_id,
-        &reply_text,
-        msg.platform_name,
-    );
+    // 6. Delivery mirror (on blocking thread)
+    {
+        let platform_name_mirror = platform_name.clone();
+        let chat_id = msg.chat_id.to_owned();
+        let reply = reply_text.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            crate::mirror::append_delivery_mirror(
+                &db_path,
+                &platform_name_mirror,
+                &chat_id,
+                &reply,
+                &platform_name_mirror,
+            );
+        })
+        .await;
+    }
 
     ProcessOutcome::AgentReply(reply_text)
 }

--- a/crates/genesis-gateway/src/platforms/signal.rs
+++ b/crates/genesis-gateway/src/platforms/signal.rs
@@ -389,42 +389,61 @@ async fn process_envelope(
             // For DMs, use the shared pipeline.
             let reply = if is_group {
                 // Groups bypass pairing -- run commands/agent directly.
-                let store =
-                    genesis_storage::SessionStore::new(&state.loaded.config.storage.database_path);
-                if let crate::commands::CommandResult::Reply(r) = crate::commands::handle_command(
-                    &prompt,
-                    &session_id,
-                    &store,
-                    &state.loaded.config,
-                ) {
-                    r
-                } else {
-                    crate::commands::check_session_expiry(
-                        &session_id,
+                let db_path = state.loaded.config.storage.database_path.clone();
+                let prompt_clone = prompt.clone();
+                let session_id_clone = session_id.clone();
+                let config_clone = state.loaded.config.clone();
+                let cmd_result = tokio::task::spawn_blocking(move || {
+                    let store = genesis_storage::SessionStore::new(&db_path);
+                    let cmd = crate::commands::handle_command(
+                        &prompt_clone,
+                        &session_id_clone,
                         &store,
-                        state.loaded.config.gateway.as_ref(),
+                        &config_clone,
                     );
-                    let service = state.session_service();
-                    let title = format!("Signal: {user_name}");
-                    let result = service
-                        .run_turn(genesis_core::execution::SessionTurnInput {
-                            session_id: &session_id,
-                            session_platform: "signal",
-                            delivery_platform: DeliveryPlatform::Signal,
-                            prompt: &prompt,
-                            title: Some(&title),
-                            images: Vec::new(),
+                    crate::commands::check_session_expiry(
+                        &session_id_clone,
+                        &store,
+                        config_clone.gateway.as_ref(),
+                    );
+                    cmd
+                })
+                .await;
+                match cmd_result {
+                    Ok(crate::commands::CommandResult::Reply(r)) => r,
+                    Err(e) => {
+                        error!(error = %e, "signal blocking command handler panicked");
+                        "Sorry, an internal error occurred.".to_owned()
+                    }
+                    _ => {
+                        let service = state.session_service();
+                        let title = format!("Signal: {user_name}");
+                        let result = service
+                            .run_turn(genesis_core::execution::SessionTurnInput {
+                                session_id: &session_id,
+                                session_platform: "signal",
+                                delivery_platform: DeliveryPlatform::Signal,
+                                prompt: &prompt,
+                                title: Some(&title),
+                                images: Vec::new(),
+                            })
+                            .await;
+                        let reply_text = super::extract_reply(result, "signal");
+                        let db_path = state.loaded.config.storage.database_path.clone();
+                        let chat_id_clone = chat_id.clone();
+                        let reply_clone = reply_text.clone();
+                        let _ = tokio::task::spawn_blocking(move || {
+                            crate::mirror::append_delivery_mirror(
+                                &db_path,
+                                "signal",
+                                &chat_id_clone,
+                                &reply_clone,
+                                "signal",
+                            );
                         })
                         .await;
-                    let reply_text = super::extract_reply(result, "signal");
-                    crate::mirror::append_delivery_mirror(
-                        &state.loaded.config.storage.database_path,
-                        "signal",
-                        &chat_id,
-                        &reply_text,
-                        "signal",
-                    );
-                    reply_text
+                        reply_text
+                    }
                 }
             } else {
                 match super::process_platform_message(&state, &msg).await {

--- a/crates/genesis-gateway/src/platforms/telegram.rs
+++ b/crates/genesis-gateway/src/platforms/telegram.rs
@@ -327,20 +327,34 @@ async fn resolve_sticker_prompt(
         );
     }
 
-    // Check the cache first.
-    let cache = StickerCacheStore::new(&config.storage.database_path);
-    match cache.get(&sticker.file_unique_id) {
-        Ok(Some(cached)) => {
+    // Check the cache first (on blocking thread).
+    let db_path = config.storage.database_path.clone();
+    let file_unique_id = sticker.file_unique_id.clone();
+    let cached_result = {
+        let db_path = db_path.clone();
+        let file_unique_id = file_unique_id.clone();
+        tokio::task::spawn_blocking(move || {
+            let cache = StickerCacheStore::new(&db_path);
+            cache.get(&file_unique_id)
+        })
+        .await
+    };
+
+    match cached_result {
+        Ok(Ok(Some(cached))) => {
             debug!(
                 file_unique_id = sticker.file_unique_id.as_str(),
                 "sticker cache hit"
             );
             return format_sticker_context(&cached.emoji, &cached.sticker_set, &cached.description);
         }
-        Ok(None) => {}
-        Err(e) => {
+        Ok(Err(e)) => {
             warn!(error = %e, "sticker cache lookup failed, proceeding with analysis");
         }
+        Err(e) => {
+            warn!(error = %e, "sticker cache blocking task failed, proceeding with analysis");
+        }
+        Ok(Ok(None)) => {}
     }
 
     // Download and analyze the sticker via vision LLM.
@@ -350,10 +364,19 @@ async fn resolve_sticker_prompt(
                 file_unique_id = sticker.file_unique_id.as_str(),
                 "sticker analyzed via vision"
             );
-            // Cache the result.
-            if let Err(e) = cache.set(&sticker.file_unique_id, &description, emoji, set_name) {
-                warn!(error = %e, "failed to cache sticker description");
-            }
+            // Cache the result (on blocking thread).
+            let desc_clone = description.clone();
+            let emoji_owned = emoji.to_owned();
+            let set_name_owned = set_name.to_owned();
+            let _ = tokio::task::spawn_blocking(move || {
+                let cache = StickerCacheStore::new(&db_path);
+                if let Err(e) =
+                    cache.set(&file_unique_id, &desc_clone, &emoji_owned, &set_name_owned)
+                {
+                    warn!(error = %e, "failed to cache sticker description");
+                }
+            })
+            .await;
             format_sticker_context(emoji, set_name, &description)
         }
         Err(e) => {

--- a/crates/genesis-gateway/src/routes/admin.rs
+++ b/crates/genesis-gateway/src/routes/admin.rs
@@ -26,33 +26,44 @@ pub(crate) async fn audit_recent_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AuditQueryParams>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let limit = params.limit.unwrap_or(50);
-    let entries = if let Some(ref event_type) = params.event_type {
-        store
-            .by_event_type(event_type, limit)
-            .map_err(storage_err)?
-    } else {
-        store.recent(limit).map_err(storage_err)?
-    };
-    Ok(Json(serde_json::json!({
-        "entries": entries,
-        "count": entries.len(),
-    })))
+    let event_type = params.event_type;
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = genesis_storage::AuditLogStore::new(&path);
+        let entries = if let Some(ref event_type) = event_type {
+            store
+                .by_event_type(event_type, limit)
+                .map_err(storage_err)?
+        } else {
+            store.recent(limit).map_err(storage_err)?
+        };
+        Ok(Json(serde_json::json!({
+            "entries": entries,
+            "count": entries.len(),
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn audit_stats_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.stats().map_err(storage_err)?;
-    let total: i64 = stats.iter().map(|(_, c)| c).sum();
-    Ok(Json(serde_json::json!({
-        "total_entries": total,
-        "by_event_type": stats.into_iter().map(|(t, c)| {
-            serde_json::json!({"event_type": t, "count": c})
-        }).collect::<Vec<_>>(),
-    })))
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = genesis_storage::AuditLogStore::new(&path);
+        let stats = store.stats().map_err(storage_err)?;
+        let total: i64 = stats.iter().map(|(_, c)| c).sum();
+        Ok(Json(serde_json::json!({
+            "total_entries": total,
+            "by_event_type": stats.into_iter().map(|(t, c)| {
+                serde_json::json!({"event_type": t, "count": c})
+            }).collect::<Vec<_>>(),
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn audit_session_handler(
@@ -60,14 +71,19 @@ pub(crate) async fn audit_session_handler(
     Path(id): Path<String>,
     Query(params): Query<AuditQueryParams>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let limit = params.limit.unwrap_or(100);
-    let entries = store.by_session(&id, limit).map_err(storage_err)?;
-    Ok(Json(serde_json::json!({
-        "session_id": id,
-        "entries": entries,
-        "count": entries.len(),
-    })))
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = genesis_storage::AuditLogStore::new(&path);
+        let entries = store.by_session(&id, limit).map_err(storage_err)?;
+        Ok(Json(serde_json::json!({
+            "session_id": id,
+            "entries": entries,
+            "count": entries.len(),
+        })))
+    })
+    .await
 }
 
 #[derive(Deserialize)]
@@ -79,13 +95,18 @@ pub(crate) async fn audit_purge_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<AuditPurgeRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let days = request.older_than_days.unwrap_or(90);
-    let deleted = store.purge_older_than(days).map_err(storage_err)?;
-    Ok(Json(serde_json::json!({
-        "purged": deleted,
-        "older_than_days": days,
-    })))
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = genesis_storage::AuditLogStore::new(&path);
+        let deleted = store.purge_older_than(days).map_err(storage_err)?;
+        Ok(Json(serde_json::json!({
+            "purged": deleted,
+            "older_than_days": days,
+        })))
+    })
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -101,26 +122,36 @@ pub(crate) async fn tool_analytics_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AnalyticsQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let days = params.days.unwrap_or(30);
-    let analytics = store.tool_analytics(days).map_err(storage_err)?;
-    Ok(Json(serde_json::json!({
-        "period_days": days,
-        "tools": analytics,
-    })))
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = genesis_storage::AuditLogStore::new(&path);
+        let analytics = store.tool_analytics(days).map_err(storage_err)?;
+        Ok(Json(serde_json::json!({
+            "period_days": days,
+            "tools": analytics,
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn llm_analytics_handler(
     State(state): State<Arc<AppState>>,
     Query(params): Query<AnalyticsQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = genesis_storage::AuditLogStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let days = params.days.unwrap_or(30);
-    let analytics = store.llm_analytics(days).map_err(storage_err)?;
-    Ok(Json(serde_json::json!({
-        "period_days": days,
-        "models": analytics,
-    })))
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = genesis_storage::AuditLogStore::new(&path);
+        let analytics = store.llm_analytics(days).map_err(storage_err)?;
+        Ok(Json(serde_json::json!({
+            "period_days": days,
+            "models": analytics,
+        })))
+    })
+    .await
 }
 
 // ---------------------------------------------------------------------------
@@ -130,9 +161,7 @@ pub(crate) async fn llm_analytics_handler(
 pub(crate) async fn cache_stats_handler(
     State(state): State<Arc<AppState>>,
 ) -> Json<serde_json::Value> {
-    let cache =
-        genesis_storage::ResponseCacheStore::new(&state.loaded.config.storage.database_path);
-    let (entries, hits) = cache.stats().unwrap_or((0, 0));
+    let db_path = state.loaded.config.storage.database_path.clone();
     let enabled = state
         .loaded
         .config
@@ -140,6 +169,14 @@ pub(crate) async fn cache_stats_handler(
         .cache
         .as_ref()
         .is_some_and(|c| c.enabled);
+
+    let (entries, hits) = tokio::task::spawn_blocking(move || {
+        let cache = genesis_storage::ResponseCacheStore::new(&db_path);
+        cache.stats().unwrap_or((0, 0))
+    })
+    .await
+    .unwrap_or((0, 0));
+
     Json(serde_json::json!({
         "enabled": enabled,
         "entries": entries,
@@ -150,14 +187,23 @@ pub(crate) async fn cache_stats_handler(
 pub(crate) async fn cache_clear_handler(
     State(state): State<Arc<AppState>>,
 ) -> Json<serde_json::Value> {
-    let cache =
-        genesis_storage::ResponseCacheStore::new(&state.loaded.config.storage.database_path);
-    match cache.clear() {
-        Ok(deleted) => Json(serde_json::json!({
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    let result = tokio::task::spawn_blocking(move || {
+        let cache = genesis_storage::ResponseCacheStore::new(&db_path);
+        cache.clear()
+    })
+    .await;
+
+    match result {
+        Ok(Ok(deleted)) => Json(serde_json::json!({
             "cleared": deleted,
         })),
-        Err(e) => Json(serde_json::json!({
+        Ok(Err(e)) => Json(serde_json::json!({
             "error": e.to_string(),
+        })),
+        Err(e) => Json(serde_json::json!({
+            "error": format!("blocking task failed: {e}"),
         })),
     }
 }

--- a/crates/genesis-gateway/src/routes/health.rs
+++ b/crates/genesis-gateway/src/routes/health.rs
@@ -81,15 +81,21 @@ pub(crate) struct MetricsJsonResponse {
 // ---------------------------------------------------------------------------
 
 /// Shared DB stats used by health, metrics, and prometheus handlers.
-pub(crate) fn fetch_db_stats(db_path: &std::path::Path) -> (usize, usize) {
-    let total_sessions = genesis_storage::SessionStore::new(db_path)
-        .session_count()
-        .unwrap_or(0) as usize;
-    let active_schedules = genesis_storage::ScheduleStore::new(db_path)
-        .list_enabled()
-        .map(|s| s.len())
-        .unwrap_or(0);
-    (total_sessions, active_schedules)
+///
+/// Runs on a blocking thread to avoid starving the async executor.
+pub(crate) async fn fetch_db_stats(db_path: std::path::PathBuf) -> (usize, usize) {
+    tokio::task::spawn_blocking(move || {
+        let total_sessions = genesis_storage::SessionStore::new(&db_path)
+            .session_count()
+            .unwrap_or(0) as usize;
+        let active_schedules = genesis_storage::ScheduleStore::new(&db_path)
+            .list_enabled()
+            .map(|s| s.len())
+            .unwrap_or(0);
+        (total_sessions, active_schedules)
+    })
+    .await
+    .unwrap_or((0, 0))
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +108,7 @@ pub(crate) async fn health_handler(State(state): State<Arc<AppState>>) -> Json<H
         None => 0,
     };
     let (total_sessions, active_schedules) =
-        fetch_db_stats(&state.loaded.config.storage.database_path);
+        fetch_db_stats(state.loaded.config.storage.database_path.clone()).await;
     let mcp_tools = match &state.mcp {
         Some(mcp) => mcp.tool_count().await,
         None => 0,
@@ -232,8 +238,8 @@ pub(crate) async fn prometheus_metrics_handler(State(state): State<Arc<AppState>
     let output_tokens = state.output_tokens_total.load(Ordering::Relaxed);
     let stream_reqs = state.stream_requests_total.load(Ordering::Relaxed);
 
-    let db_path = &state.loaded.config.storage.database_path;
-    let (total_sessions, active_schedules_usize) = fetch_db_stats(db_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let (total_sessions, active_schedules_usize) = fetch_db_stats(db_path.clone()).await;
     let total_sessions = total_sessions as u64;
     let active_schedules = active_schedules_usize as u64;
 
@@ -242,8 +248,22 @@ pub(crate) async fn prometheus_metrics_handler(State(state): State<Arc<AppState>
         None => 0,
     };
 
-    let cache_store = genesis_storage::ResponseCacheStore::new(db_path);
-    let (cache_entries, cache_hits) = cache_store.stats().unwrap_or((0, 0));
+    let (cache_entries, cache_hits, audit_total) = {
+        let db_path_blocking = db_path;
+        tokio::task::spawn_blocking(move || {
+            let cache_store = genesis_storage::ResponseCacheStore::new(&db_path_blocking);
+            let (ce, ch) = cache_store.stats().unwrap_or((0, 0));
+            let at: i64 = genesis_storage::AuditLogStore::new(&db_path_blocking)
+                .stats()
+                .unwrap_or_default()
+                .iter()
+                .map(|(_, c)| c)
+                .sum();
+            (ce, ch, at)
+        })
+        .await
+        .unwrap_or((0, 0, 0))
+    };
 
     let model = format!(
         "{}/{}",
@@ -252,14 +272,6 @@ pub(crate) async fn prometheus_metrics_handler(State(state): State<Arc<AppState>
 
     // Webhook delivery metrics
     let (wh_delivered, wh_retried, wh_failed) = state.webhooks.metrics();
-
-    // Audit log total
-    let audit_total: i64 = genesis_storage::AuditLogStore::new(db_path)
-        .stats()
-        .unwrap_or_default()
-        .iter()
-        .map(|(_, c)| c)
-        .sum();
 
     // Request duration histogram
     let duration_histogram = if let Ok(hist) = state.request_duration_histogram.lock() {
@@ -338,7 +350,7 @@ pub(crate) async fn metrics_json_handler(
     State(state): State<Arc<AppState>>,
 ) -> Json<MetricsJsonResponse> {
     let (total_sessions, active_schedules) =
-        fetch_db_stats(&state.loaded.config.storage.database_path);
+        fetch_db_stats(state.loaded.config.storage.database_path.clone()).await;
 
     Json(MetricsJsonResponse {
         uptime_seconds: state.started_at.elapsed().as_secs(),

--- a/crates/genesis-gateway/src/routes/memories.rs
+++ b/crates/genesis-gateway/src/routes/memories.rs
@@ -122,20 +122,25 @@ pub(crate) async fn list_memories_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = MemoryStore::new(&state.loaded.config.storage.database_path);
-    let (memories, total) = store.list_paginated(limit, offset).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    let has_more = (offset + memories.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(MemoryListResponse {
-            memories,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = MemoryStore::new(&path);
+        let (memories, total) = store.list_paginated(limit, offset).map_err(storage_err)?;
+
+        let has_more = (offset + memories.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(MemoryListResponse {
+                memories,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn search_memories_handler(
@@ -143,7 +148,6 @@ pub(crate) async fn search_memories_handler(
     axum::extract::Query(params): axum::extract::Query<SearchMemoriesQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let db_path = &state.loaded.config.storage.database_path;
-    let memory_store = MemoryStore::new(db_path);
 
     let mode = genesis_core::embedding::SearchMode::from_str_opt(params.mode.as_deref());
 
@@ -156,6 +160,13 @@ pub(crate) async fn search_memories_handler(
     } else {
         None
     };
+
+    // The MemoryStore is created inside spawn_blocking for keyword/graph modes,
+    // but hybrid_search is async (it may call the embedding API), so we keep
+    // the existing pattern for search — the DB calls inside hybrid_search are
+    // already short-lived.
+    let db_path_owned = db_path.clone();
+    let memory_store = MemoryStore::new(&db_path_owned);
 
     let results = genesis_core::embedding::hybrid_search(
         &params.q,
@@ -194,19 +205,23 @@ pub(crate) async fn delete_memory_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let db_path = &state.loaded.config.storage.database_path;
-    let store = MemoryStore::new(db_path);
-    let deleted = store.delete(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    if deleted {
-        // Also clean up any associated embedding
-        if let Err(e) = EmbeddingStore::new(db_path).delete(&id) {
-            warn!(memory_id = %id, error = %e, "failed to delete embedding for memory");
+    spawn_blocking_storage(db_path, move |path| {
+        let store = MemoryStore::new(&path);
+        let deleted = store.delete(&id).map_err(storage_err)?;
+
+        if deleted {
+            // Also clean up any associated embedding
+            if let Err(e) = EmbeddingStore::new(&path).delete(&id) {
+                warn!(memory_id = %id, error = %e, "failed to delete embedding for memory");
+            }
+            Ok(Json(serde_json::json!({"deleted": true, "id": id})))
+        } else {
+            Err(ApiError::not_found(format!("memory '{id}' not found")))
         }
-        Ok(Json(serde_json::json!({"deleted": true, "id": id})))
-    } else {
-        Err(ApiError::not_found(format!("memory '{id}' not found")))
-    }
+    })
+    .await
 }
 
 /// Embed all un-embedded memories. Requires an embedding provider to be configured.
@@ -223,11 +238,19 @@ pub(crate) async fn embed_memories_handler(
         .embedding_provider()?
         .expect("embedding config should yield a provider");
 
-    let db_path = &state.loaded.config.storage.database_path;
-    let memory_store = MemoryStore::new(db_path);
-    let embedding_store = EmbeddingStore::new(db_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    let memories = memory_store.list(10000).map_err(storage_err)?;
+    // Load memories and check dimensions on a blocking thread.
+    let db_path_for_blocking = db_path.clone();
+    let (memories, existing_dimensions) =
+        spawn_blocking_storage(db_path_for_blocking, move |path| {
+            let memory_store = MemoryStore::new(&path);
+            let embedding_store = EmbeddingStore::new(&path);
+            let memories = memory_store.list(10000).map_err(storage_err)?;
+            let existing_dimensions = embedding_store.dimensions().map_err(storage_err)?;
+            Ok((memories, existing_dimensions))
+        })
+        .await?;
 
     let mut embedded = 0usize;
     let mut skipped = 0usize;
@@ -235,14 +258,15 @@ pub(crate) async fn embed_memories_handler(
     let mut reset = false;
     let mut first_probe: Option<(String, Vec<f32>)> = None;
 
-    if let (Some(existing_dimensions), Some(first_memory)) = (
-        embedding_store.dimensions().map_err(storage_err)?,
-        memories.first(),
-    ) {
+    if let (Some(existing_dim), Some(first_memory)) = (existing_dimensions, memories.first()) {
         match provider.embed_one(&first_memory.content).await {
             Ok(embedding) => {
-                if embedding.len() != existing_dimensions {
-                    embedding_store.clear().map_err(storage_err)?;
+                if embedding.len() != existing_dim {
+                    let db_path_clear = db_path.clone();
+                    spawn_blocking_storage(db_path_clear, move |path| {
+                        EmbeddingStore::new(&path).clear().map_err(storage_err)
+                    })
+                    .await?;
                     reset = true;
                     first_probe = Some((first_memory.id.clone(), embedding));
                 }
@@ -264,20 +288,48 @@ pub(crate) async fn embed_memories_handler(
     }
 
     for memory in &memories {
-        if !reset && embedding_store.has_embedding(&memory.id).unwrap_or(false) {
-            skipped += 1;
-            continue;
+        if !reset {
+            let db_path_check = db_path.clone();
+            let memory_id = memory.id.clone();
+            let has = spawn_blocking_storage(db_path_check, move |path| {
+                Ok(EmbeddingStore::new(&path)
+                    .has_embedding(&memory_id)
+                    .unwrap_or(false))
+            })
+            .await?;
+            if has {
+                skipped += 1;
+                continue;
+            }
         }
 
-        let result = if first_probe
+        let result: Result<(), genesis_core::embedding::EmbeddingError> = if first_probe
             .as_ref()
             .is_some_and(|(memory_id, _)| memory_id == &memory.id)
         {
             let (_, embedding) = first_probe.take().expect("probe embedding should exist");
-            embedding_store
-                .store(&memory.id, &embedding, provider.model())
-                .map_err(genesis_core::embedding::EmbeddingError::from)
+            let db_path_store = db_path.clone();
+            let memory_id = memory.id.clone();
+            let model = provider.model().to_owned();
+            let store_result = tokio::task::spawn_blocking(move || {
+                EmbeddingStore::new(&db_path_store)
+                    .store(&memory_id, &embedding, &model)
+                    .map_err(genesis_core::embedding::EmbeddingError::from)
+            })
+            .await;
+            match store_result {
+                Ok(inner) => inner,
+                Err(e) => {
+                    tracing::error!(error = %e, "blocking embedding store task panicked");
+                    Err(genesis_core::embedding::EmbeddingError::NotConfigured)
+                }
+            }
         } else {
+            // embed_and_store is async (calls the embedding API), but
+            // the storage write inside it is short-lived. We keep the
+            // original pattern here to avoid excessive complexity.
+            let db_path_embed = db_path.clone();
+            let embedding_store = EmbeddingStore::new(&db_path_embed);
             genesis_core::embedding::embed_and_store(
                 &memory.id,
                 &memory.content,
@@ -328,15 +380,21 @@ pub(crate) async fn embed_single_memory_handler(
         .embedding_provider()?
         .expect("embedding config should yield a provider");
 
-    let db_path = &state.loaded.config.storage.database_path;
-    let memory_store = MemoryStore::new(db_path);
-    let embedding_store = EmbeddingStore::new(db_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    // Find the memory by direct ID lookup
-    let memory = memory_store
-        .get(&id)
-        .map_err(storage_err)?
-        .ok_or_else(|| ApiError::not_found(format!("memory '{id}' not found")))?;
+    // Find the memory on a blocking thread.
+    let db_path_find = db_path.clone();
+    let id_clone = id.clone();
+    let memory = spawn_blocking_storage(db_path_find, move |path| {
+        let memory_store = MemoryStore::new(&path);
+        memory_store
+            .get(&id_clone)
+            .map_err(storage_err)?
+            .ok_or_else(|| ApiError::not_found(format!("memory '{id_clone}' not found")))
+    })
+    .await?;
+
+    let embedding_store = EmbeddingStore::new(&db_path);
 
     genesis_core::embedding::embed_and_store(
         &memory.id,

--- a/crates/genesis-gateway/src/routes/pairing.rs
+++ b/crates/genesis-gateway/src/routes/pairing.rs
@@ -50,22 +50,28 @@ pub(crate) async fn list_approved_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let (approved, total) = store
-        .list_approved_paginated(params.platform.as_deref(), limit, offset)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let platform = params.platform;
 
-    let has_more = (offset + approved.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(ApprovedListResponse {
-            approved,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = PairingStore::new(&path);
+        let (approved, total) = store
+            .list_approved_paginated(platform.as_deref(), limit, offset)
+            .map_err(storage_err)?;
+
+        let has_more = (offset + approved.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(ApprovedListResponse {
+                approved,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn list_pending_handler(
@@ -74,76 +80,97 @@ pub(crate) async fn list_pending_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let (pending, total) = store
-        .list_pending_paginated(params.platform.as_deref(), limit, offset)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let platform = params.platform;
 
-    let has_more = (offset + pending.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(PendingListResponse {
-            pending,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = PairingStore::new(&path);
+        let (pending, total) = store
+            .list_pending_paginated(platform.as_deref(), limit, offset)
+            .map_err(storage_err)?;
+
+        let has_more = (offset + pending.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(PendingListResponse {
+                pending,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn approve_pairing_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ApprovePairingRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let approved = store
-        .approve_code(&request.platform, &request.code)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    match approved {
-        Some(user) => Ok(Json(serde_json::json!({
-            "approved": true,
-            "user": user,
-        }))),
-        None => Err(ApiError::not_found("invalid or expired pairing code")),
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = PairingStore::new(&path);
+        let approved = store
+            .approve_code(&request.platform, &request.code)
+            .map_err(storage_err)?;
+
+        match approved {
+            Some(user) => Ok(Json(serde_json::json!({
+                "approved": true,
+                "user": user,
+            }))),
+            None => Err(ApiError::not_found("invalid or expired pairing code")),
+        }
+    })
+    .await
 }
 
 pub(crate) async fn revoke_pairing_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<RevokePairingRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let revoked = store
-        .revoke(&request.platform, &request.user_id)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    if revoked {
-        Ok(Json(serde_json::json!({
-            "revoked": true,
-            "platform": request.platform,
-            "user_id": request.user_id,
-        })))
-    } else {
-        Err(ApiError::not_found(format!(
-            "no approved user '{}' on platform '{}'",
-            request.user_id, request.platform
-        )))
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = PairingStore::new(&path);
+        let revoked = store
+            .revoke(&request.platform, &request.user_id)
+            .map_err(storage_err)?;
+
+        if revoked {
+            Ok(Json(serde_json::json!({
+                "revoked": true,
+                "platform": request.platform,
+                "user_id": request.user_id,
+            })))
+        } else {
+            Err(ApiError::not_found(format!(
+                "no approved user '{}' on platform '{}'",
+                request.user_id, request.platform
+            )))
+        }
+    })
+    .await
 }
 
 pub(crate) async fn clear_pending_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ClearPendingRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = PairingStore::new(&state.loaded.config.storage.database_path);
-    let cleared = store
-        .clear_pending(request.platform.as_deref())
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::json!({
-        "cleared": cleared,
-        "platform": request.platform,
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = PairingStore::new(&path);
+        let cleared = store
+            .clear_pending(request.platform.as_deref())
+            .map_err(storage_err)?;
+
+        Ok(Json(serde_json::json!({
+            "cleared": cleared,
+            "platform": request.platform,
+        })))
+    })
+    .await
 }

--- a/crates/genesis-gateway/src/routes/schedules.rs
+++ b/crates/genesis-gateway/src/routes/schedules.rs
@@ -51,37 +51,48 @@ pub(crate) async fn list_schedules_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let (schedules, total) = store
-        .list_paginated(params.enabled_only, limit, offset)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let enabled_only = params.enabled_only;
 
-    let has_more = (offset + schedules.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(ScheduleListResponse {
-            schedules,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = ScheduleStore::new(&path);
+        let (schedules, total) = store
+            .list_paginated(enabled_only, limit, offset)
+            .map_err(storage_err)?;
+
+        let has_more = (offset + schedules.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(ScheduleListResponse {
+                schedules,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn get_schedule_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let schedule = store.get(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    match schedule {
-        Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
-            ApiError::internal(format!("serialization error: {e}"))
-        })?)),
-        None => Err(ApiError::not_found(format!("schedule '{id}' not found"))),
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = ScheduleStore::new(&path);
+        let schedule = store.get(&id).map_err(storage_err)?;
+
+        match schedule {
+            Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
+                ApiError::internal(format!("serialization error: {e}"))
+            })?)),
+            None => Err(ApiError::not_found(format!("schedule '{id}' not found"))),
+        }
+    })
+    .await
 }
 
 pub(crate) async fn create_schedule_handler(
@@ -102,16 +113,21 @@ pub(crate) async fn create_schedule_handler(
         }
     }
 
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let schedule = store
-        .create_with_timezone(
-            &request.id,
-            &request.cron_expression,
-            &request.destination,
-            &request.prompt,
-            request.timezone.as_deref(),
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    let schedule = spawn_blocking_storage(db_path, move |path| {
+        let store = ScheduleStore::new(&path);
+        store
+            .create_with_timezone(
+                &request.id,
+                &request.cron_expression,
+                &request.destination,
+                &request.prompt,
+                request.timezone.as_deref(),
+            )
+            .map_err(storage_err)
+    })
+    .await?;
 
     Ok((
         StatusCode::CREATED,
@@ -126,14 +142,19 @@ pub(crate) async fn delete_schedule_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    if deleted {
-        Ok(Json(serde_json::json!({"deleted": true, "id": id})))
-    } else {
-        Err(ApiError::not_found(format!("schedule '{id}' not found")))
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = ScheduleStore::new(&path);
+        let deleted = store.delete(&id).map_err(storage_err)?;
+
+        if deleted {
+            Ok(Json(serde_json::json!({"deleted": true, "id": id})))
+        } else {
+            Err(ApiError::not_found(format!("schedule '{id}' not found")))
+        }
+    })
+    .await
 }
 
 pub(crate) async fn set_schedule_enabled_handler(
@@ -141,18 +162,22 @@ pub(crate) async fn set_schedule_enabled_handler(
     Path(id): Path<String>,
     Json(request): Json<SetEnabledRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = ScheduleStore::new(&state.loaded.config.storage.database_path);
-    let updated = store
-        .set_enabled(&id, request.enabled)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let enabled = request.enabled;
 
-    if updated {
-        Ok(Json(serde_json::json!({
-            "id": id,
-            "enabled": request.enabled,
-            "updated": true,
-        })))
-    } else {
-        Err(ApiError::not_found(format!("schedule '{id}' not found")))
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = ScheduleStore::new(&path);
+        let updated = store.set_enabled(&id, enabled).map_err(storage_err)?;
+
+        if updated {
+            Ok(Json(serde_json::json!({
+                "id": id,
+                "enabled": enabled,
+                "updated": true,
+            })))
+        } else {
+            Err(ApiError::not_found(format!("schedule '{id}' not found")))
+        }
+    })
+    .await
 }

--- a/crates/genesis-gateway/src/routes/sessions.rs
+++ b/crates/genesis-gateway/src/routes/sessions.rs
@@ -118,72 +118,93 @@ pub(crate) async fn list_sessions_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let search = params.search.clone();
 
-    let (sessions, total) = if let Some(query) = &params.search {
-        store
-            .search_sessions_paginated(query, limit, offset)
-            .map_err(storage_err)?
-    } else {
-        store
-            .list_recent_sessions_paginated(limit, offset)
-            .map_err(storage_err)?
-    };
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
 
-    let has_more = (offset + sessions.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(SessionListResponse {
-            sessions,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+        let (sessions, total) = if let Some(query) = &search {
+            store
+                .search_sessions_paginated(query, limit, offset)
+                .map_err(storage_err)?
+        } else {
+            store
+                .list_recent_sessions_paginated(limit, offset)
+                .map_err(storage_err)?
+        };
+
+        let has_more = (offset + sessions.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(SessionListResponse {
+                sessions,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn get_session_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let session = store.get_session(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    match session {
-        Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
-            ApiError::internal(format!("serialization error: {e}"))
-        })?)),
-        None => Err(ApiError::not_found(format!("session '{id}' not found"))),
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let session = store.get_session(&id).map_err(storage_err)?;
+
+        match session {
+            Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
+                ApiError::internal(format!("serialization error: {e}"))
+            })?)),
+            None => Err(ApiError::not_found(format!("session '{id}' not found"))),
+        }
+    })
+    .await
 }
 
 pub(crate) async fn delete_session_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete_session(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    if deleted {
-        Ok(Json(serde_json::json!({"deleted": true, "session_id": id})))
-    } else {
-        Err(ApiError::not_found(format!("session '{id}' not found")))
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let deleted = store.delete_session(&id).map_err(storage_err)?;
+
+        if deleted {
+            Ok(Json(serde_json::json!({"deleted": true, "session_id": id})))
+        } else {
+            Err(ApiError::not_found(format!("session '{id}' not found")))
+        }
+    })
+    .await
 }
 
 pub(crate) async fn session_messages_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let messages = store.load_messages(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::json!({
-        "session_id": id,
-        "messages": messages,
-        "count": messages.len(),
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let messages = store.load_messages(&id).map_err(storage_err)?;
+
+        Ok(Json(serde_json::json!({
+            "session_id": id,
+            "messages": messages,
+            "count": messages.len(),
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn fork_session_handler(
@@ -191,7 +212,7 @@ pub(crate) async fn fork_session_handler(
     Path(id): Path<String>,
     Json(request): Json<ForkRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
     let new_id = request.new_session_id.unwrap_or_else(|| {
         let ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -200,12 +221,20 @@ pub(crate) async fn fork_session_handler(
         format!("fork-{id}-{ts}")
     });
 
-    store.fork_session(&id, &new_id).map_err(storage_err)?;
+    let new_id_clone = new_id.clone();
+    let id_clone = id.clone();
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        store
+            .fork_session(&id_clone, &new_id_clone)
+            .map_err(storage_err)?;
 
-    Ok(Json(serde_json::json!({
-        "source_session_id": id,
-        "new_session_id": new_id,
-    })))
+        Ok(Json(serde_json::json!({
+            "source_session_id": id_clone,
+            "new_session_id": new_id_clone,
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn update_session_title_handler(
@@ -213,14 +242,19 @@ pub(crate) async fn update_session_title_handler(
     Path(id): Path<String>,
     Json(request): Json<UpdateTitleRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let updated = store.set_title(&id, &request.title).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::json!({
-        "session_id": id,
-        "title": request.title,
-        "updated": updated,
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let updated = store.set_title(&id, &request.title).map_err(storage_err)?;
+
+        Ok(Json(serde_json::json!({
+            "session_id": id,
+            "title": request.title,
+            "updated": updated,
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn export_session_handler(
@@ -228,52 +262,58 @@ pub(crate) async fn export_session_handler(
     Path(id): Path<String>,
     axum::extract::Query(params): axum::extract::Query<ExportQuery>,
 ) -> Result<Response, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-
-    let session_title = match store.get_session(&id) {
-        Ok(s) => s.and_then(|s| s.title),
-        Err(e) => {
-            warn!(error = %e, session_id = %id, "failed to load session title for export");
-            None
-        }
-    };
-
-    let stored = store.load_messages(&id).map_err(storage_err)?;
-
-    if stored.is_empty() {
-        return Err(ApiError::not_found(format!(
-            "no messages found for session '{id}'"
-        )));
-    }
-
-    let messages: Vec<(String, Option<String>, Option<String>, String)> = stored
-        .into_iter()
-        .map(|m| (m.role, m.content, m.tool_calls_json, m.created_at))
-        .collect();
-
+    let db_path = state.loaded.config.storage.database_path.clone();
     let format = params.format.unwrap_or_else(|| "markdown".to_owned());
 
-    use genesis_tools::builtins::export::{
-        export_chatml, export_json, export_jsonl, export_markdown,
-    };
+    let (content, content_type) = spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
 
-    let (content, content_type) = match format.as_str() {
-        "json" => (
-            export_json(&id, session_title.as_deref(), &messages),
-            "application/json",
-        ),
-        "markdown" | "md" => (
-            export_markdown(&id, session_title.as_deref(), &messages),
-            "text/markdown; charset=utf-8",
-        ),
-        "chatml" => (export_chatml(&messages), "text/plain; charset=utf-8"),
-        "jsonl" | "finetune" => (export_jsonl(&messages), "application/jsonl; charset=utf-8"),
-        _ => {
-            return Err(ApiError::bad_request(format!(
-                "unsupported format '{format}'; use 'markdown', 'json', 'chatml', or 'jsonl'"
-            )))
+        let session_title = match store.get_session(&id) {
+            Ok(s) => s.and_then(|s| s.title),
+            Err(e) => {
+                warn!(error = %e, session_id = %id, "failed to load session title for export");
+                None
+            }
+        };
+
+        let stored = store.load_messages(&id).map_err(storage_err)?;
+
+        if stored.is_empty() {
+            return Err(ApiError::not_found(format!(
+                "no messages found for session '{id}'"
+            )));
         }
-    };
+
+        let messages: Vec<(String, Option<String>, Option<String>, String)> = stored
+            .into_iter()
+            .map(|m| (m.role, m.content, m.tool_calls_json, m.created_at))
+            .collect();
+
+        use genesis_tools::builtins::export::{
+            export_chatml, export_json, export_jsonl, export_markdown,
+        };
+
+        let result = match format.as_str() {
+            "json" => (
+                export_json(&id, session_title.as_deref(), &messages),
+                "application/json",
+            ),
+            "markdown" | "md" => (
+                export_markdown(&id, session_title.as_deref(), &messages),
+                "text/markdown; charset=utf-8",
+            ),
+            "chatml" => (export_chatml(&messages), "text/plain; charset=utf-8"),
+            "jsonl" | "finetune" => (export_jsonl(&messages), "application/jsonl; charset=utf-8"),
+            _ => {
+                return Err(ApiError::bad_request(format!(
+                    "unsupported format '{format}'; use 'markdown', 'json', 'chatml', or 'jsonl'"
+                )))
+            }
+        };
+
+        Ok(result)
+    })
+    .await?;
 
     Response::builder()
         .status(StatusCode::OK)
@@ -286,24 +326,35 @@ pub(crate) async fn purge_sessions_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<PurgeQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let purged = store
-        .purge_older_than(params.older_than_days)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let older_than_days = params.older_than_days;
 
-    Ok(Json(serde_json::json!({
-        "purged": purged,
-        "older_than_days": params.older_than_days,
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let purged = store
+            .purge_older_than(older_than_days)
+            .map_err(storage_err)?;
+
+        Ok(Json(serde_json::json!({
+            "purged": purged,
+            "older_than_days": older_than_days,
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn get_session_tags_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let tags = store.get_tags(&id).map_err(storage_err)?;
-    Ok(Json(serde_json::json!({ "session_id": id, "tags": tags })))
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let tags = store.get_tags(&id).map_err(storage_err)?;
+        Ok(Json(serde_json::json!({ "session_id": id, "tags": tags })))
+    })
+    .await
 }
 
 pub(crate) async fn set_session_tags_handler(
@@ -311,54 +362,74 @@ pub(crate) async fn set_session_tags_handler(
     Path(id): Path<String>,
     Json(request): Json<SetTagsRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
-    store.set_tags(&id, &tag_refs).map_err(storage_err)?;
-    Ok(Json(
-        serde_json::json!({ "session_id": id, "tags": request.tags }),
-    ))
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
+        store.set_tags(&id, &tag_refs).map_err(storage_err)?;
+        Ok(Json(
+            serde_json::json!({ "session_id": id, "tags": request.tags }),
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn add_session_tag_handler(
     State(state): State<Arc<AppState>>,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let added = store.add_tag(&id, &tag).map_err(storage_err)?;
-    let tags = store.get_tags(&id).map_err(storage_err)?;
-    Ok(Json(
-        serde_json::json!({ "session_id": id, "tag": tag, "added": added, "tags": tags }),
-    ))
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let added = store.add_tag(&id, &tag).map_err(storage_err)?;
+        let tags = store.get_tags(&id).map_err(storage_err)?;
+        Ok(Json(
+            serde_json::json!({ "session_id": id, "tag": tag, "added": added, "tags": tags }),
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn remove_session_tag_handler(
     State(state): State<Arc<AppState>>,
     Path((id, tag)): Path<(String, String)>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let removed = store.remove_tag(&id, &tag).map_err(storage_err)?;
-    let tags = store.get_tags(&id).map_err(storage_err)?;
-    Ok(Json(
-        serde_json::json!({ "session_id": id, "tag": tag, "removed": removed, "tags": tags }),
-    ))
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let removed = store.remove_tag(&id, &tag).map_err(storage_err)?;
+        let tags = store.get_tags(&id).map_err(storage_err)?;
+        Ok(Json(
+            serde_json::json!({ "session_id": id, "tag": tag, "removed": removed, "tags": tags }),
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn sessions_by_tag_handler(
     State(state): State<Arc<AppState>>,
     Path(tag): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let sessions = store.sessions_by_tag(&tag).map_err(storage_err)?;
-    Ok(Json(
-        serde_json::json!({ "tag": tag, "sessions": sessions, "count": sessions.len() }),
-    ))
+    let db_path = state.loaded.config.storage.database_path.clone();
+
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let sessions = store.sessions_by_tag(&tag).map_err(storage_err)?;
+        Ok(Json(
+            serde_json::json!({ "tag": tag, "sessions": sessions, "count": sessions.len() }),
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn import_session_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ImportSessionRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
+    let db_path = state.loaded.config.storage.database_path.clone();
 
     let session_id = request.session_id.unwrap_or_else(|| {
         let ts = std::time::SystemTime::now()
@@ -374,15 +445,21 @@ pub(crate) async fn import_session_handler(
         .into_iter()
         .map(|m| (m.role, m.content))
         .collect();
+    let title = request.title;
 
-    store
-        .import_session(&session_id, request.title.as_deref(), messages)
-        .map_err(|e| ApiError::internal(format!("import error: {e}")))?;
+    let sid = session_id.clone();
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        store
+            .import_session(&sid, title.as_deref(), messages)
+            .map_err(|e| ApiError::internal(format!("import error: {e}")))?;
 
-    Ok(Json(serde_json::json!({
-        "session_id": session_id,
-        "messages_imported": message_count,
-    })))
+        Ok(Json(serde_json::json!({
+            "session_id": sid,
+            "messages_imported": message_count,
+        })))
+    })
+    .await
 }
 
 /// Export multiple sessions as JSONL for fine-tuning or archival.
@@ -392,51 +469,58 @@ pub(crate) async fn bulk_export_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<BulkExportQuery>,
 ) -> Result<Response, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let format = params.format;
     let limit = params.limit.unwrap_or(1000);
-    let sessions = store.list_recent_sessions(limit).map_err(storage_err)?;
 
-    use genesis_tools::builtins::export::{export_json, export_jsonl};
+    let (output, content_type) = spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let sessions = store.list_recent_sessions(limit).map_err(storage_err)?;
 
-    let mut output = String::new();
+        use genesis_tools::builtins::export::{export_json, export_jsonl};
 
-    for session in &sessions {
-        let stored = match store.load_messages(&session.id) {
-            Ok(msgs) if !msgs.is_empty() => msgs,
-            _ => continue,
-        };
+        let mut output = String::new();
 
-        let messages: Vec<(String, Option<String>, Option<String>, String)> = stored
-            .into_iter()
-            .map(|m| (m.role, m.content, m.tool_calls_json, m.created_at))
-            .collect();
+        for session in &sessions {
+            let stored = match store.load_messages(&session.id) {
+                Ok(msgs) if !msgs.is_empty() => msgs,
+                _ => continue,
+            };
 
-        match params.format.as_str() {
-            "jsonl" | "finetune" => {
-                let line = export_jsonl(&messages);
-                if !line.is_empty() {
-                    output.push_str(&line);
+            let messages: Vec<(String, Option<String>, Option<String>, String)> = stored
+                .into_iter()
+                .map(|m| (m.role, m.content, m.tool_calls_json, m.created_at))
+                .collect();
+
+            match format.as_str() {
+                "jsonl" | "finetune" => {
+                    let line = export_jsonl(&messages);
+                    if !line.is_empty() {
+                        output.push_str(&line);
+                    }
+                }
+                "json" => {
+                    let json = export_json(&session.id, session.title.as_deref(), &messages);
+                    output.push_str(&json);
+                    output.push('\n');
+                }
+                _ => {
+                    return Err(ApiError::bad_request(format!(
+                        "unsupported bulk format '{}'; use 'jsonl' or 'json'",
+                        format
+                    )))
                 }
             }
-            "json" => {
-                let json = export_json(&session.id, session.title.as_deref(), &messages);
-                output.push_str(&json);
-                output.push('\n');
-            }
-            _ => {
-                return Err(ApiError::bad_request(format!(
-                    "unsupported bulk format '{}'; use 'jsonl' or 'json'",
-                    params.format
-                )))
-            }
         }
-    }
 
-    let content_type = match params.format.as_str() {
-        "json" => "application/json; charset=utf-8",
-        _ => "application/jsonl; charset=utf-8",
-    };
+        let content_type = match format.as_str() {
+            "json" => "application/json; charset=utf-8",
+            _ => "application/jsonl; charset=utf-8",
+        };
+
+        Ok((output, content_type))
+    })
+    .await?;
 
     Response::builder()
         .status(StatusCode::OK)
@@ -449,37 +533,52 @@ pub(crate) async fn search_messages_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<SearchMessagesQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let results = store
-        .search_messages(&params.q, params.limit)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::json!({
-        "query": params.q,
-        "results": results,
-        "count": results.len(),
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let results = store
+            .search_messages(&params.q, params.limit)
+            .map_err(storage_err)?;
+
+        Ok(Json(serde_json::json!({
+            "query": params.q,
+            "results": results,
+            "count": results.len(),
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn insights_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<InsightsQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let data = store.insights(params.days).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::to_value(data).map_err(|e| {
-        ApiError::internal(format!("serialization error: {e}"))
-    })?))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let data = store.insights(params.days).map_err(storage_err)?;
+
+        Ok(Json(serde_json::to_value(data).map_err(|e| {
+            ApiError::internal(format!("serialization error: {e}"))
+        })?))
+    })
+    .await
 }
 
 pub(crate) async fn usage_handler(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SessionStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.usage_stats().map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::to_value(stats).map_err(|e| {
-        ApiError::internal(format!("serialization error: {e}"))
-    })?))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SessionStore::new(&path);
+        let stats = store.usage_stats().map_err(storage_err)?;
+
+        Ok(Json(serde_json::to_value(stats).map_err(|e| {
+            ApiError::internal(format!("serialization error: {e}"))
+        })?))
+    })
+    .await
 }

--- a/crates/genesis-gateway/src/routes/skills.rs
+++ b/crates/genesis-gateway/src/routes/skills.rs
@@ -60,98 +60,128 @@ pub(crate) async fn list_skills_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let (skills, total) = store
-        .list_all_paginated(limit, offset)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    let has_more = (offset + skills.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(SkillListResponse {
-            skills,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillStore::new(&path);
+        let (skills, total) = store
+            .list_all_paginated(limit, offset)
+            .map_err(storage_err)?;
+
+        let has_more = (offset + skills.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(SkillListResponse {
+                skills,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn get_skill_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let skill = store.get(&name).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    match skill {
-        Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
-            ApiError::internal(format!("serialization error: {e}"))
-        })?)),
-        None => Err(ApiError::not_found(format!("skill '{name}' not found"))),
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillStore::new(&path);
+        let skill = store.get(&name).map_err(storage_err)?;
+
+        match skill {
+            Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
+                ApiError::internal(format!("serialization error: {e}"))
+            })?)),
+            None => Err(ApiError::not_found(format!("skill '{name}' not found"))),
+        }
+    })
+    .await
 }
 
 pub(crate) async fn upsert_skill_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<UpsertSkillRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
-    let skill = store
-        .upsert(
-            &request.name,
-            &request.description,
-            &request.instructions,
-            request.trigger_hint.as_deref(),
-            &tag_refs,
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::to_value(skill).map_err(|e| {
-        ApiError::internal(format!("serialization error: {e}"))
-    })?))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillStore::new(&path);
+        let tag_refs: Vec<&str> = request.tags.iter().map(|s| s.as_str()).collect();
+        let skill = store
+            .upsert(
+                &request.name,
+                &request.description,
+                &request.instructions,
+                request.trigger_hint.as_deref(),
+                &tag_refs,
+            )
+            .map_err(storage_err)?;
+
+        Ok(Json(serde_json::to_value(skill).map_err(|e| {
+            ApiError::internal(format!("serialization error: {e}"))
+        })?))
+    })
+    .await
 }
 
 pub(crate) async fn delete_skill_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete(&name).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    if deleted {
-        Ok(Json(serde_json::json!({"deleted": true, "name": name})))
-    } else {
-        Err(ApiError::not_found(format!("skill '{name}' not found")))
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillStore::new(&path);
+        let deleted = store.delete(&name).map_err(storage_err)?;
+
+        if deleted {
+            Ok(Json(serde_json::json!({"deleted": true, "name": name})))
+        } else {
+            Err(ApiError::not_found(format!("skill '{name}' not found")))
+        }
+    })
+    .await
 }
 
 pub(crate) async fn search_skills_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::Query(params): axum::extract::Query<SearchSkillsQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SkillStore::new(&state.loaded.config.storage.database_path);
-    let skills = store.find_by_tag(&params.tag).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    let count = skills.len();
-    Ok(Json(serde_json::json!({
-        "skills": skills,
-        "count": count,
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillStore::new(&path);
+        let skills = store.find_by_tag(&params.tag).map_err(storage_err)?;
+
+        let count = skills.len();
+        Ok(Json(serde_json::json!({
+            "skills": skills,
+            "count": count,
+        })))
+    })
+    .await
 }
 
 pub(crate) async fn skill_usage_stats_handler(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SkillUsageStore::new(&state.loaded.config.storage.database_path);
-    let stats = store.stats(&name).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok(Json(serde_json::to_value(stats).map_err(|e| {
-        ApiError::internal(format!("serialization error: {e}"))
-    })?))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillUsageStore::new(&path);
+        let stats = store.stats(&name).map_err(storage_err)?;
+
+        Ok(Json(serde_json::to_value(stats).map_err(|e| {
+            ApiError::internal(format!("serialization error: {e}"))
+        })?))
+    })
+    .await
 }
 
 pub(crate) async fn skill_usage_recent_handler(
@@ -159,15 +189,20 @@ pub(crate) async fn skill_usage_recent_handler(
     Path(name): Path<String>,
     axum::extract::Query(params): axum::extract::Query<SkillUsageRecentQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SkillUsageStore::new(&state.loaded.config.storage.database_path);
-    let usages = store
-        .recent_usages(&name, params.limit)
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    let count = usages.len();
-    Ok(Json(serde_json::json!({
-        "skill_name": name,
-        "usages": usages,
-        "count": count,
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SkillUsageStore::new(&path);
+        let usages = store
+            .recent_usages(&name, params.limit)
+            .map_err(storage_err)?;
+
+        let count = usages.len();
+        Ok(Json(serde_json::json!({
+            "skill_name": name,
+            "usages": usages,
+            "count": count,
+        })))
+    })
+    .await
 }

--- a/crates/genesis-gateway/src/routes/subagents.rs
+++ b/crates/genesis-gateway/src/routes/subagents.rs
@@ -6,35 +6,45 @@ use axum::extract::{Path, State};
 use axum::Json;
 use genesis_storage::SubagentStore;
 
-use crate::helpers::{storage_err, ApiError};
+use crate::helpers::{spawn_blocking_storage, storage_err, ApiError};
 use crate::state::AppState;
 
 pub(crate) async fn get_subagent_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SubagentStore::new(&state.loaded.config.storage.database_path);
-    let subagent = store.get(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    match subagent {
-        Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
-            ApiError::internal(format!("serialization error: {e}"))
-        })?)),
-        None => Err(ApiError::not_found(format!("subagent '{id}' not found"))),
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SubagentStore::new(&path);
+        let subagent = store.get(&id).map_err(storage_err)?;
+
+        match subagent {
+            Some(s) => Ok(Json(serde_json::to_value(s).map_err(|e| {
+                ApiError::internal(format!("serialization error: {e}"))
+            })?)),
+            None => Err(ApiError::not_found(format!("subagent '{id}' not found"))),
+        }
+    })
+    .await
 }
 
 pub(crate) async fn list_session_subagents_handler(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = SubagentStore::new(&state.loaded.config.storage.database_path);
-    let subagents = store.list_by_parent(&id).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    let count = subagents.len();
-    Ok(Json(serde_json::json!({
-        "session_id": id,
-        "subagents": subagents,
-        "count": count,
-    })))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = SubagentStore::new(&path);
+        let subagents = store.list_by_parent(&id).map_err(storage_err)?;
+
+        let count = subagents.len();
+        Ok(Json(serde_json::json!({
+            "session_id": id,
+            "subagents": subagents,
+            "count": count,
+        })))
+    })
+    .await
 }

--- a/crates/genesis-gateway/src/routes/user_model.rs
+++ b/crates/genesis-gateway/src/routes/user_model.rs
@@ -43,77 +43,91 @@ pub(crate) async fn list_user_traits_handler(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let limit = clamp_limit(params.limit);
     let offset = validate_offset(params.offset)?;
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let (traits_list, total) = store
-        .list_paginated(
-            params.category.as_deref(),
-            params.min_confidence,
-            limit,
-            offset,
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
+    let category = params.category;
+    let min_confidence = params.min_confidence;
 
-    let has_more = (offset + traits_list.len()) < total as usize;
-    Ok(Json(
-        serde_json::to_value(TraitListResponse {
-            traits: traits_list,
-            total,
-            limit,
-            offset,
-            has_more,
-        })
-        .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-    ))
+    spawn_blocking_storage(db_path, move |path| {
+        let store = UserModelStore::new(&path);
+        let (traits_list, total) = store
+            .list_paginated(category.as_deref(), min_confidence, limit, offset)
+            .map_err(storage_err)?;
+
+        let has_more = (offset + traits_list.len()) < total as usize;
+        Ok(Json(
+            serde_json::to_value(TraitListResponse {
+                traits: traits_list,
+                total,
+                limit,
+                offset,
+                has_more,
+            })
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
+        ))
+    })
+    .await
 }
 
 pub(crate) async fn get_user_trait_handler(
     State(state): State<Arc<AppState>>,
     Path(key): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let user_trait = store.get(&key).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    match user_trait {
-        Some(t) => Ok(Json(serde_json::to_value(t).map_err(|e| {
-            ApiError::internal(format!("serialization error: {e}"))
-        })?)),
-        None => Err(ApiError::not_found(format!("trait '{key}' not found"))),
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = UserModelStore::new(&path);
+        let user_trait = store.get(&key).map_err(storage_err)?;
+
+        match user_trait {
+            Some(t) => Ok(Json(serde_json::to_value(t).map_err(|e| {
+                ApiError::internal(format!("serialization error: {e}"))
+            })?)),
+            None => Err(ApiError::not_found(format!("trait '{key}' not found"))),
+        }
+    })
+    .await
 }
 
 pub(crate) async fn observe_user_trait_handler(
     State(state): State<Arc<AppState>>,
     Json(request): Json<ObserveTraitRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), ApiError> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let observed = store
-        .observe(
-            &request.trait_key,
-            &request.category,
-            &request.value,
-            request.source_session.as_deref(),
-        )
-        .map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    Ok((
-        StatusCode::OK,
-        Json(
-            serde_json::to_value(observed)
-                .map_err(|e| ApiError::internal(format!("serialization error: {e}")))?,
-        ),
-    ))
+    let result = spawn_blocking_storage(db_path, move |path| {
+        let store = UserModelStore::new(&path);
+        let observed = store
+            .observe(
+                &request.trait_key,
+                &request.category,
+                &request.value,
+                request.source_session.as_deref(),
+            )
+            .map_err(storage_err)?;
+
+        serde_json::to_value(observed)
+            .map_err(|e| ApiError::internal(format!("serialization error: {e}")))
+    })
+    .await?;
+
+    Ok((StatusCode::OK, Json(result)))
 }
 
 pub(crate) async fn delete_user_trait_handler(
     State(state): State<Arc<AppState>>,
     Path(key): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let store = UserModelStore::new(&state.loaded.config.storage.database_path);
-    let deleted = store.delete(&key).map_err(storage_err)?;
+    let db_path = state.loaded.config.storage.database_path.clone();
 
-    if deleted {
-        Ok(Json(serde_json::json!({"deleted": true, "trait_key": key})))
-    } else {
-        Err(ApiError::not_found(format!("trait '{key}' not found")))
-    }
+    spawn_blocking_storage(db_path, move |path| {
+        let store = UserModelStore::new(&path);
+        let deleted = store.delete(&key).map_err(storage_err)?;
+
+        if deleted {
+            Ok(Json(serde_json::json!({"deleted": true, "trait_key": key})))
+        } else {
+            Err(ApiError::not_found(format!("trait '{key}' not found")))
+        }
+    })
+    .await
 }


### PR DESCRIPTION
## Summary
- Adds `spawn_blocking_storage` helper that wraps synchronous SQLite closures in `tokio::task::spawn_blocking`, keeping `rusqlite::Connection` (which is not `Send`) entirely on the blocking thread
- Wraps **all** synchronous storage calls across gateway route handlers (sessions, memories, skills, schedules, user_model, subagents, pairing, admin/audit/analytics/cache) and health/metrics endpoints
- Wraps platform handler storage calls: pairing checks, slash command handling, session expiry resets, and delivery mirrors (platforms/mod.rs, signal.rs, telegram.rs, homeassistant.rs)
- Under concurrent load, the async executor is no longer starved by blocking SQLite I/O

## Test plan
- [x] All 305 `genesis-gateway` tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] No behavioral changes -- all existing API contracts preserved

Closes #297