### PR TITLE
fix(dev): prevent formatting drift with rustfmt.toml and pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# pre-commit hook: auto-format staged Rust files with cargo fmt.
+#
+# Setup (run once per clone):
+#   git config core.hooksPath .githooks
+#
+# How it works:
+#   1. Identifies .rs files in the staging area.
+#   2. Runs `cargo fmt` on the whole workspace (fast, <2s).
+#   3. Re-stages any files that were reformatted.
+#   4. The commit proceeds with correctly formatted code.
+#
+# To bypass in exceptional cases:  git commit --no-verify
+
+set -euo pipefail
+
+# Only act if there are staged Rust files.
+STAGED_RS=$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs' || true)
+if [ -z "$STAGED_RS" ]; then
+    exit 0
+fi
+
+# Run cargo fmt on the workspace.
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "pre-commit: cargo not found, skipping format check"
+    exit 0
+fi
+
+echo "pre-commit: formatting staged Rust files..."
+cargo fmt --all 2>&1
+
+# Re-stage any files that cargo fmt modified.
+for file in $STAGED_RS; do
+    if [ -f "$file" ]; then
+        git add "$file"
+    fi
+done
+
+echo "pre-commit: formatting complete"

--- a/justfile
+++ b/justfile
@@ -1,3 +1,16 @@
+# First-time setup: install git hooks
+setup:
+    git config core.hooksPath .githooks
+    @echo "Git hooks installed (.githooks/pre-commit)"
+
+# Format all Rust code
+fmt:
+    cargo fmt --all
+
+# Check formatting without modifying files
+fmt-check:
+    cargo fmt --all -- --check
+
 # Web dashboard
 build-web:
     cd web && npm ci && npm run build
@@ -14,6 +27,7 @@ dev:
 
 # Lint everything
 lint:
+    cargo fmt --all -- --check
     cargo clippy --workspace -- -D warnings
     cd web && npm run lint
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+# Workspace-wide rustfmt configuration.
+# All options here are stable defaults, pinned explicitly so that
+# formatting never drifts when the toolchain is upgraded.
+edition = "2021"
+max_width = 100
+tab_spaces = 4
+use_small_heuristics = "Default"


### PR DESCRIPTION
## Summary

Formatting issues have been causing CI failures across branches and worktrees (see `fix/fmt-workspace-v3` and prior attempts). This adds three layers of prevention so `cargo fmt` failures stop being a recurring problem:

- **`rustfmt.toml`**: Pins `edition = "2021"`, `max_width = 100`, `tab_spaces = 4`, and `use_small_heuristics = "Default"` explicitly. Even though these are current defaults, pinning them ensures formatting stays consistent if upstream defaults ever change across toolchain versions.
- **`.githooks/pre-commit`**: Auto-formats staged `.rs` files before every commit, then re-stages them. This means formatting is always correct at commit time — no manual `cargo fmt` step needed. Activated with `just setup` (or `git config core.hooksPath .githooks`).
- **`justfile` updates**: Adds `setup`, `fmt`, and `fmt-check` recipes. Also adds `cargo fmt --all -- --check` to the existing `lint` recipe so `just lint` catches formatting too.

## Setup (one-time per clone)

```bash
just setup
```

This configures git to use `.githooks/` as the hooks directory. After that, every `git commit` touching `.rs` files will auto-format before committing.

## Test plan

- [ ] Verify `cargo fmt --all -- --check` still passes (no formatting changes introduced)
- [ ] Clone fresh, run `just setup`, make a badly-formatted `.rs` change, commit — verify it gets auto-formatted
- [ ] Run `just lint` and confirm it includes the fmt check
- [ ] CI `cargo fmt` step passes