### PR TITLE
fix(tui): resolve resize-related rendering glitches

### DIFF
--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -109,6 +109,25 @@ impl App {
             TuiEvent::Resize { width, height } => {
                 self.viewport_width = width;
                 self.viewport_height = height;
+
+                // Cancel all running effects — they hold stale coordinates
+                // from the pre-resize viewport and would paint into the wrong
+                // region.  They will be recreated on the next status change or
+                // idle transition.
+                self.effects.on_resize();
+
+                // Rebuild the transcript overlay if it is currently open so
+                // that lines are re-wrapped at the new width and scroll bounds
+                // reflect the new height.
+                if let Some(ActiveOverlay::Transcript(_)) = &self.overlay {
+                    let visible_rows = self.viewport_height.saturating_sub(2).max(1);
+                    self.overlay = Some(ActiveOverlay::Transcript(TranscriptOverlay::from_cells(
+                        self.chat.committed_cells(),
+                        self.viewport_width,
+                        visible_rows,
+                    )));
+                }
+
                 self.frame_requester.schedule_frame();
             }
             TuiEvent::Draw | TuiEvent::FocusGained | TuiEvent::FocusLost => {}
@@ -331,10 +350,11 @@ impl App {
                 }
                 "/transcript" => {
                     self.command_popup.hide();
+                    let visible_rows = self.viewport_height.saturating_sub(2).max(1);
                     self.overlay = Some(ActiveOverlay::Transcript(TranscriptOverlay::from_cells(
                         self.chat.committed_cells(),
                         self.viewport_width,
-                        24, // default visible rows
+                        visible_rows,
                     )));
                     self.frame_requester.schedule_frame();
                 }

--- a/crates/genesis-tui/src/custom_terminal.rs
+++ b/crates/genesis-tui/src/custom_terminal.rs
@@ -52,9 +52,16 @@ impl CustomTerminal {
     }
 
     /// Update the viewport area and resize both buffers to match.
+    ///
+    /// The previous buffer is reset after resizing so that `draw_diff` treats
+    /// every cell as changed on the first post-resize frame. Without this,
+    /// stale pre-resize content in the previous buffer can suppress redraws
+    /// where cells happen to match by coincidence, producing ghost artifacts.
     pub fn set_viewport_area(&mut self, area: Rect) {
         self.buffers[self.current].resize(area);
         self.buffers[1 - self.current].resize(area);
+        // Force a full redraw on the next frame by clearing the previous buffer.
+        self.buffers[1 - self.current].reset();
         self.viewport_area = area;
     }
 

--- a/crates/genesis-tui/src/effects/mod.rs
+++ b/crates/genesis-tui/src/effects/mod.rs
@@ -321,6 +321,20 @@ impl GenesisEffects {
         self.manager.cancel_unique_effect(EffectId::IdleBreathing);
     }
 
+    /// Cancel all running effects because the viewport has been resized.
+    ///
+    /// Long-running effects (idle glow, breathing, active pulse) bake their
+    /// target [`Rect`] at creation time.  After a resize those coordinates are
+    /// stale and the effects would paint into the wrong region.  Clearing them
+    /// here lets the normal status-change / idle logic recreate them with
+    /// up-to-date coordinates on the next relevant event.
+    pub fn on_resize(&mut self) {
+        if !self.enabled {
+            return;
+        }
+        self.cancel_all();
+    }
+
     /// Whether effects are enabled.
     pub fn enabled(&self) -> bool {
         self.enabled


### PR DESCRIPTION
## Summary

- **Reset previous buffer on resize** (`custom_terminal.rs`): `set_viewport_area()` now calls `.reset()` on the previous buffer after resizing both buffers, forcing `draw_diff` to treat every cell as changed on the first post-resize frame. This eliminates ghost artifacts caused by stale pre-resize cell data suppressing redraws.
- **Cancel stale effects on resize** (`effects/mod.rs`, `app.rs`): Added `GenesisEffects::on_resize()` which cancels all running effects. Long-running effects (idle glow, breathing, active pulse) bake their target `Rect` at creation time; after a resize those coordinates are invalid. The effects naturally restart on the next status change or idle transition.
- **Rebuild transcript overlay on resize** (`app.rs`): When a resize event occurs while the transcript overlay is open, it is rebuilt with the new dimensions so lines re-wrap at the correct width and scroll bounds are valid.
- **Fix hardcoded visible_rows in `/transcript`** (`app.rs`): Replaced hardcoded `24` with `self.viewport_height.saturating_sub(2).max(1)`, matching the `AppEvent::ShowOverlay` and `Ctrl+T` paths.

## Test plan

- [x] `cargo clippy -p genesis-tui -- -D warnings` passes
- [x] `cargo test -p genesis-tui` passes (432 tests)
- [x] `cargo build --workspace` succeeds
- [ ] Manual: launch TUI, resize the terminal while idle — no ghost cells or stale border fragments
- [ ] Manual: resize while a turn is running (active pulse effect) — effect restarts cleanly
- [ ] Manual: open transcript overlay (`Ctrl+T`), resize terminal — content re-wraps correctly
- [ ] Manual: use `/transcript` command on a short terminal — verify scroll bounds match viewport