### PR TITLE
fix(tui): correct scroll direction, preserve hard newlines, fix wide-char cursor

### DIFF
--- a/crates/genesis-tui/src/custom_terminal.rs
+++ b/crates/genesis-tui/src/custom_terminal.rs
@@ -19,6 +19,7 @@ use ratatui::backend::{CrosstermBackend, IntoCrossterm};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier};
+use unicode_width::UnicodeWidthStr as _;
 
 /// A custom terminal that owns a crossterm backend and two ratatui buffers.
 ///
@@ -112,14 +113,18 @@ impl CustomTerminal {
 
         for (x, y, cell) in &updates {
             // Move cursor only when not adjacent to the previous position.
+            // After writing a cell with display width `w`, the terminal cursor
+            // is at column `x + w`, not `x + 1`. Track the actual cursor
+            // column to avoid unnecessary MoveTo commands for wide characters.
             let need_move = match last_pos {
-                Some((px, py)) => !(*x == px + 1 && *y == py),
+                Some((cursor_x, cursor_y)) => !(*x == cursor_x && *y == cursor_y),
                 None => true,
             };
             if need_move {
                 queue!(self.backend, MoveTo(*x, *y))?;
             }
-            last_pos = Some((*x, *y));
+            let cell_width = cell.symbol().width().max(1) as u16;
+            last_pos = Some((*x + cell_width, *y));
 
             // Apply modifier changes.
             if cell.modifier != modifier {

--- a/crates/genesis-tui/src/history/user_cell.rs
+++ b/crates/genesis-tui/src/history/user_cell.rs
@@ -65,13 +65,29 @@ impl UserCell {
 }
 
 /// Simple word-wrap: split `text` into lines that fit within `max_width` columns.
-/// Splits on any Unicode whitespace boundary; individual words wider than
+/// Hard newlines (`\n`) are preserved as line breaks. Each resulting paragraph
+/// is then wrapped on Unicode whitespace boundaries; individual words wider than
 /// `max_width` are kept as-is. Returns at least one (possibly empty) element.
 pub(crate) fn word_wrap(text: &str, max_width: u16) -> Vec<String> {
     if max_width == 0 {
         return vec![text.to_string()];
     }
 
+    let mut result = Vec::new();
+    for paragraph in text.split('\n') {
+        let wrapped = wrap_single_line(paragraph, max_width);
+        result.extend(wrapped);
+    }
+    if result.is_empty() {
+        result.push(String::new());
+    }
+    result
+}
+
+/// Word-wrap a single paragraph (no embedded newlines) to fit within
+/// `max_width` columns. Splits on any Unicode whitespace boundary; individual
+/// words wider than `max_width` are kept as-is.
+fn wrap_single_line(text: &str, max_width: u16) -> Vec<String> {
     let max = max_width as usize;
     let mut lines: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -180,5 +196,37 @@ mod tests {
         // Non-breaking space (U+00A0) should also split.
         let result = word_wrap("hello\u{00A0}world", 6);
         assert_eq!(result.len(), 2, "expected 2 lines, got: {result:?}");
+    }
+
+    #[test]
+    fn word_wrap_preserves_hard_newlines() {
+        // Hard newlines should produce separate lines, not be collapsed.
+        let result = word_wrap("line one\nline two\nline three", 40);
+        assert_eq!(result.len(), 3, "expected 3 lines, got: {result:?}");
+        assert_eq!(result[0], "line one");
+        assert_eq!(result[1], "line two");
+        assert_eq!(result[2], "line three");
+    }
+
+    #[test]
+    fn word_wrap_hard_newline_with_wrapping() {
+        // Hard newlines + word-wrapping within each paragraph.
+        let result = word_wrap("hello world\nfoo bar baz", 6);
+        // "hello world" wraps to ["hello", "world"], "foo bar baz" wraps to ["foo", "bar", "baz"]
+        assert_eq!(result.len(), 5, "expected 5 lines, got: {result:?}");
+        assert_eq!(result[0], "hello");
+        assert_eq!(result[1], "world");
+        assert_eq!(result[2], "foo");
+        assert_eq!(result[3], "bar");
+        assert_eq!(result[4], "baz");
+    }
+
+    #[test]
+    fn word_wrap_trailing_newline() {
+        // A trailing newline should produce an extra empty line.
+        let result = word_wrap("hello\n", 40);
+        assert_eq!(result.len(), 2, "expected 2 lines, got: {result:?}");
+        assert_eq!(result[0], "hello");
+        assert_eq!(result[1], "");
     }
 }

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -411,7 +411,7 @@ impl ChatWidget {
                 let skip = cell_height.saturating_sub(rows_to_use);
                 let paragraph = Paragraph::new(lines)
                     .wrap(Wrap { trim: false })
-                    .scroll((0, skip));
+                    .scroll((skip, 0));
                 paragraph.render(cell_area, buf);
 
                 bottom_y -= rows_to_use;


### PR DESCRIPTION
## Summary

- **Scroll tuple inversion (critical):** `Paragraph::scroll((0, skip))` in `chat_widget.rs` placed the vertical offset in the horizontal position. When the active streaming cell exceeded the viewport height, content scrolled horizontally (showing blanks) instead of vertically. Fixed to `.scroll((skip, 0))`.

- **Hard newlines ignored in word_wrap (high):** `word_wrap()` in `user_cell.rs` split only on `char::is_whitespace`, which treats `\n` the same as spaces. Multi-line user messages (Shift+Enter) were collapsed into a single wrapped block. Fixed by splitting on `\n` first, then word-wrapping each paragraph independently via a new `wrap_single_line` helper.

- **Wide-char cursor tracking in draw_diff (medium):** `draw_diff()` in `custom_terminal.rs` assumed every cell advances the cursor by 1 column (`px + 1`). After writing wide characters (CJK, emoji, etc.) the terminal cursor advances by the cell's display width (typically 2). This caused unnecessary `MoveTo` commands on every cell following a wide character, producing flicker. Fixed by tracking the actual cursor column using `cell.symbol().width()`.

## Test plan

- [x] All 444 existing `genesis-tui` tests pass
- [x] 3 new tests added for hard-newline preservation (`word_wrap_preserves_hard_newlines`, `word_wrap_hard_newline_with_wrapping`, `word_wrap_trailing_newline`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo build --workspace` succeeds
- [ ] Manual: verify streaming long responses scroll vertically (not horizontally)
- [ ] Manual: type multi-line message with Shift+Enter, verify line breaks are preserved
- [ ] Manual: paste CJK/emoji text in chat, verify no flicker on redraw