### PR TITLE
fix(tui): initial prompt, @-file completion position, transcript scroll

### DIFF
--- a/crates/genesis-cli/src/chat.rs
+++ b/crates/genesis-cli/src/chat.rs
@@ -80,7 +80,7 @@ pub(crate) async fn run_chat_tui(
     config_path: Option<PathBuf>,
     session_id: Option<String>,
     resume: Option<String>,
-    _initial_prompt: Option<String>,
+    initial_prompt: Option<String>,
     system_override: Option<String>,
     last: bool,
     worktree: bool,
@@ -124,7 +124,7 @@ pub(crate) async fn run_chat_tui(
 
     service.ensure_session(&session_id, "cli", None)?;
 
-    genesis_tui::run_tui(&loaded.config, &mut service, &session_id)
+    genesis_tui::run_tui(&loaded.config, &mut service, &session_id, initial_prompt)
         .await
         .map_err(|e| CliError::Tui(e.to_string()))?;
 

--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -124,7 +124,7 @@ impl App {
                 // that lines are re-wrapped at the new width and scroll bounds
                 // reflect the new height.
                 if let Some(ActiveOverlay::Transcript(_)) = &self.overlay {
-                    let visible_rows = self.viewport_height.saturating_sub(2).max(1);
+                    let visible_rows = self.viewport_height.saturating_sub(1).max(1);
                     self.overlay = Some(ActiveOverlay::Transcript(TranscriptOverlay::from_cells(
                         self.chat.committed_cells(),
                         self.viewport_width,
@@ -305,7 +305,7 @@ impl App {
             }
             AppEvent::ShowOverlay(OverlayKind::Transcript) => {
                 self.command_popup.hide();
-                let visible_rows = self.viewport_height.saturating_sub(2).max(1);
+                let visible_rows = self.viewport_height.saturating_sub(1).max(1);
                 let width = if self.viewport_width > 0 {
                     self.viewport_width
                 } else {
@@ -376,7 +376,7 @@ impl App {
                 }
                 "/transcript" => {
                     self.command_popup.hide();
-                    let visible_rows = self.viewport_height.saturating_sub(2).max(1);
+                    let visible_rows = self.viewport_height.saturating_sub(1).max(1);
                     self.overlay = Some(ActiveOverlay::Transcript(TranscriptOverlay::from_cells(
                         self.chat.committed_cells(),
                         self.viewport_width,
@@ -453,7 +453,7 @@ impl App {
 
         // When an overlay is active, route all keys to it.
         if let Some(overlay) = &mut self.overlay {
-            let visible_rows = self.viewport_height.saturating_sub(2).max(1);
+            let visible_rows = self.viewport_height.saturating_sub(1).max(1);
             let (should_close, model_selected) = match overlay {
                 ActiveOverlay::Transcript(t) => (
                     matches!(t.handle_key(key, visible_rows), TranscriptAction::Close),
@@ -501,7 +501,7 @@ impl App {
         // Ctrl+T — toggle transcript overlay.
         if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
             self.command_popup.hide();
-            let visible_rows = self.viewport_height.saturating_sub(2).max(1);
+            let visible_rows = self.viewport_height.saturating_sub(1).max(1);
             let width = if self.viewport_width > 0 {
                 self.viewport_width
             } else {
@@ -578,7 +578,15 @@ impl App {
                     // Replace @query with the selected path, preserving
                     // any text before and after the @-query token.
                     let text = self.chat.input.text().to_owned();
-                    if let Some(at_pos) = text.rfind('@') {
+                    // Use the stored trigger position to find the exact `@`
+                    // that started this completion, avoiding false matches
+                    // with `@` characters in previously inserted text.
+                    let at_pos = self
+                        .file_completion
+                        .trigger_pos()
+                        .filter(|&p| p < text.len() && text.as_bytes().get(p) == Some(&b'@'))
+                        .or_else(|| text.rfind('@'));
+                    if let Some(at_pos) = at_pos {
                         // Find end of the @-query: next space or end of text.
                         let query_end = text[at_pos + 1..]
                             .find(' ')
@@ -603,11 +611,22 @@ impl App {
                 FileCompletionAction::None => {}
             }
 
-            // Update file completion query from input.
+            // Update file completion query from input using the recorded
+            // trigger position for accuracy.
             let input_text = self.chat.input.text().to_owned();
-            if let Some(at_pos) = input_text.rfind('@') {
+            let at_pos = self
+                .file_completion
+                .trigger_pos()
+                .filter(|&p| p < input_text.len() && input_text.as_bytes().get(p) == Some(&b'@'));
+            if let Some(at_pos) = at_pos {
                 let query = &input_text[at_pos + 1..];
-                self.file_completion.update_query(query);
+                // If the query contains a space, the user moved past the
+                // @-token — close the popup.
+                if query.contains(' ') {
+                    self.file_completion.hide();
+                } else {
+                    self.file_completion.update_query(query);
+                }
             } else {
                 self.file_completion.hide();
             }
@@ -661,7 +680,11 @@ impl App {
                 // Only triggers when @ was just typed (last char), not when the
                 // buffer just happens to contain @ from earlier.
                 if input_text.ends_with('@') && !self.file_completion.is_visible() {
-                    self.file_completion.show();
+                    // Record the byte position of this `@` so we can replace
+                    // exactly this span later, even if the buffer contains
+                    // other `@` characters from earlier text.
+                    let at_byte_pos = input_text.len() - 1;
+                    self.file_completion.show(at_byte_pos);
                 }
 
                 match action {

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -129,6 +129,7 @@ pub async fn run_tui(
     config: &GenesisConfig,
     service: &mut SessionExecutionService<'_>,
     session_id: &str,
+    initial_prompt: Option<String>,
 ) -> Result<(), TuiError> {
     terminal::init()?;
 
@@ -248,6 +249,16 @@ pub async fn run_tui(
         active_theme: crate::theme::resolve_theme(&config.tui.theme),
     };
 
+    // If an initial prompt was provided, skip the welcome screen and submit
+    // the prompt as the first user message once the event loop starts.
+    let pending_initial_prompt = if initial_prompt.is_some() {
+        app.screen = AppScreen::Chat;
+        app.clear_after_welcome = true;
+        initial_prompt
+    } else {
+        None
+    };
+
     // Schedule an initial frame so the UI renders immediately.
     app.frame_requester.schedule_frame();
 
@@ -258,6 +269,17 @@ pub async fn run_tui(
     let mut turn_future: Option<Pin<Box<dyn Future<Output = TurnResult> + '_>>> = None;
 
     let mut pending_model_switch: Option<String> = None;
+
+    // Submit the initial prompt (from `genesis chat --tui "prompt"`) as the
+    // first user message. This fires before the first select! iteration so it
+    // will be picked up immediately by the submission_rx arm.
+    if let Some(prompt) = pending_initial_prompt {
+        app.chat.add_user_message(prompt.clone());
+        let _ = app.submission_tx.send(Submission::UserMessage {
+            text: prompt,
+            images: vec![],
+        });
+    }
 
     loop {
         // Process deferred model switch — must drop turn_future first

--- a/crates/genesis-tui/src/widgets/file_completion.rs
+++ b/crates/genesis-tui/src/widgets/file_completion.rs
@@ -56,6 +56,10 @@ pub struct FileCompletion {
     visible: bool,
     /// Cached directory scan metadata (directory + timestamp).
     last_scan: Option<ScanCache>,
+    /// Byte position of the `@` character that triggered this completion.
+    /// Used for accurate replacement instead of `rfind('@')`, which can match
+    /// stale `@` characters from previously inserted text (emails, git refs).
+    trigger_pos: Option<usize>,
 }
 
 impl FileCompletion {
@@ -67,18 +71,25 @@ impl FileCompletion {
             selected: 0,
             visible: false,
             last_scan: None,
+            trigger_pos: None,
         }
     }
 
     /// Show the popup, scanning the cwd for files if the cache is stale.
     ///
+    /// `at_byte_pos` is the byte offset of the `@` character in the input
+    /// buffer that triggered this completion. It is used later when inserting
+    /// the selected path so we replace exactly the right `@...query` span,
+    /// rather than relying on `rfind('@')` which can match the wrong `@`.
+    ///
     /// The file scan is skipped when the working directory has not changed and
     /// the previous scan is younger than [`SCAN_CACHE_TTL`]. This avoids
     /// blocking the async runtime with repeated `read_dir` syscalls each time
     /// the popup is opened.
-    pub fn show(&mut self) {
+    pub fn show(&mut self, at_byte_pos: usize) {
         self.visible = true;
         self.query.clear();
+        self.trigger_pos = Some(at_byte_pos);
 
         let cwd = std::env::current_dir().ok();
         let cache_fresh = match (&self.last_scan, &cwd) {
@@ -107,6 +118,12 @@ impl FileCompletion {
 
     pub fn is_visible(&self) -> bool {
         self.visible
+    }
+
+    /// The byte position of the `@` that triggered this completion session,
+    /// or `None` if the popup is not active.
+    pub fn trigger_pos(&self) -> Option<usize> {
+        self.trigger_pos
     }
 
     /// Update the query and refilter.
@@ -384,7 +401,7 @@ mod tests {
     #[test]
     fn show_makes_visible() {
         let mut fc = FileCompletion::new();
-        fc.show();
+        fc.show(0);
         assert!(fc.is_visible());
         // Should have discovered some files in the cwd.
         assert!(!fc.all_files.is_empty(), "should find files in cwd");
@@ -393,7 +410,7 @@ mod tests {
     #[test]
     fn esc_dismisses() {
         let mut fc = FileCompletion::new();
-        fc.show();
+        fc.show(0);
         let action = fc.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         assert_eq!(action, FileCompletionAction::Dismiss);
         assert!(!fc.is_visible());
@@ -402,7 +419,7 @@ mod tests {
     #[test]
     fn enter_selects() {
         let mut fc = FileCompletion::new();
-        fc.show();
+        fc.show(0);
         if !fc.filtered.is_empty() {
             let action = fc.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
             assert!(matches!(action, FileCompletionAction::Select(_)));
@@ -412,7 +429,7 @@ mod tests {
     #[test]
     fn tab_selects() {
         let mut fc = FileCompletion::new();
-        fc.show();
+        fc.show(0);
         if !fc.filtered.is_empty() {
             let action = fc.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
             assert!(matches!(action, FileCompletionAction::Select(_)));
@@ -422,7 +439,7 @@ mod tests {
     #[test]
     fn space_dismisses() {
         let mut fc = FileCompletion::new();
-        fc.show();
+        fc.show(0);
         let action = fc.handle_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
         assert_eq!(action, FileCompletionAction::Dismiss);
     }
@@ -430,7 +447,7 @@ mod tests {
     #[test]
     fn typing_filters() {
         let mut fc = FileCompletion::new();
-        fc.show();
+        fc.show(0);
         let before = fc.filtered.len();
         // Type something specific to narrow results.
         fc.handle_key(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::SHIFT));


### PR DESCRIPTION
## Summary

- **Bug 1 (HIGH):** `genesis chat --tui "do something"` silently discarded the initial prompt — the `_initial_prompt` parameter in `run_chat_tui` was unused. Now threaded through to `run_tui()`, which skips the welcome screen and submits the prompt as the first user message.

- **Bug 2 (MEDIUM):** @-file completion used `rfind('@')` to locate the trigger when inserting the selected path. If the buffer already contained `@` from earlier text (emails, git refs), the replacement targeted the wrong position. `FileCompletion` now records the byte position of the triggering `@` in a `trigger_pos` field and uses it for both replacement and query sync.

- **Bug 3 (LOW):** Transcript/help overlay `visible_rows` was `viewport_height - 2`, but overlays only use 1 header row, leaving `viewport_height - 1` content rows. The off-by-one let users scroll 1 line past the end. Changed to `saturating_sub(1)`.

## Test plan

- [x] `cargo fmt --all` — no changes
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo test -p genesis-tui` — 441 tests pass
- [x] `cargo test -p genesis-cli` — 241 tests pass
- [ ] Manual: `genesis chat --tui "hello"` should skip welcome and immediately send "hello"
- [ ] Manual: type `user@example.com then @` and verify the second `@` triggers completion correctly
- [ ] Manual: open transcript overlay (Ctrl+T), scroll to bottom, verify no blank lines past content