### PR TITLE
fix(tui): reserve rows for scroll hints, preserve AgentCell cache, add terminal cleanup guard

### DIFF
--- a/crates/genesis-tui/src/history/agent_cell.rs
+++ b/crates/genesis-tui/src/history/agent_cell.rs
@@ -20,7 +20,7 @@ use crate::render::markdown::markdown_to_lines;
 const PREFIX: &str = "eve> ";
 
 /// A single agent (Eve) response cell.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AgentCell {
     /// The raw response text (private — use `text()` accessor).
     text: String,
@@ -31,6 +31,21 @@ pub struct AgentCell {
     /// the width hasn't changed.  Uses interior mutability so `height()` can
     /// stay `&self`.
     cached_height: Cell<Option<(u16, u16)>>,
+}
+
+impl Clone for AgentCell {
+    fn clone(&self) -> Self {
+        let cached_lines = OnceCell::new();
+        // Preserve the cached lines from the source to avoid re-parsing markdown.
+        if let Some(lines) = self.cached_lines.get() {
+            let _ = cached_lines.set(lines.clone());
+        }
+        Self {
+            text: self.text.clone(),
+            cached_lines,
+            cached_height: self.cached_height.clone(),
+        }
+    }
 }
 
 impl AgentCell {

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -125,6 +125,16 @@ fn make_turn_future<'a>(
 /// The user's prompt text is moved into the future via [`make_turn_future`],
 /// so there is no separate `pending_text` variable that would create
 /// cross-borrow issues in the `select!` macro expansion.
+/// RAII guard that calls `terminal::restore()` on drop, ensuring the terminal
+/// is cleaned up even if `run_tui` returns early via `?`.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = terminal::restore();
+    }
+}
+
 pub async fn run_tui(
     config: &GenesisConfig,
     service: &mut SessionExecutionService<'_>,
@@ -132,6 +142,7 @@ pub async fn run_tui(
     initial_prompt: Option<String>,
 ) -> Result<(), TuiError> {
     terminal::init()?;
+    let _guard = TerminalGuard;
 
     let size = crossterm::terminal::size()?;
     let mut term = custom_terminal::CustomTerminal::new(size.0, size.1)?;
@@ -568,7 +579,8 @@ pub async fn run_tui(
         }
     }
 
-    terminal::restore()?;
+    // TerminalGuard handles terminal::restore() on drop, covering both
+    // normal exit and early `?` returns.
     Ok(())
 }
 

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -400,7 +400,7 @@ impl ChatWidget {
         }
 
         let mut remaining_rows = area.height;
-        let mut bottom_y = area.y + area.height;
+        let bottom_y = area.y + area.height;
 
         // ── Active cell (if any) ───────────────────────────────────────
         // Only show the active streaming cell when not scrolled up.
@@ -456,7 +456,6 @@ impl ChatWidget {
                     .scroll((skip, 0));
                 paragraph.render(cell_area, buf);
 
-                bottom_y -= rows_to_use;
                 remaining_rows -= rows_to_use;
             }
         }
@@ -652,18 +651,37 @@ impl ChatWidget {
             0
         };
 
+        // ── Determine hint rows ────────────────────────────────────────
+        // Reserve rows for overflow hints so they don't overwrite content.
+        let dim_style = Style::default().fg(crate::history::rgb(genesis_ui::colors::UI_DIM));
+        let show_top_hint = skipped_message_count > 0;
+        let show_bottom_hint = self.scroll_locked && below_count > 0;
+
+        // Adjust content area to leave room for hints.
+        let content_y = area.y + if show_top_hint { 1 } else { 0 };
+        let content_height = area
+            .height
+            .saturating_sub(if show_top_hint { 1 } else { 0 })
+            .saturating_sub(if show_bottom_hint { 1 } else { 0 });
+
         // Render from oldest to newest (reverse the reversed list).
         entries.reverse();
-        let mut row_cursor = bottom_y.saturating_sub(used);
+        let clamped_used = used.min(content_height);
+        let mut row_cursor = content_y + content_height - clamped_used;
 
         let sep_style = Style::default().fg(crate::history::rgb(genesis_ui::colors::UI_DIM));
 
         for entry in &entries {
+            if row_cursor >= content_y + content_height {
+                break;
+            }
+            let avail = (content_y + content_height).saturating_sub(row_cursor);
+            let h = entry.height.min(avail);
             let cell_area = Rect {
                 x: area.x,
                 y: row_cursor,
                 width: area.width,
-                height: entry.height,
+                height: h,
             };
             match &entry.visual {
                 VisualEntry::Cell(cell) => cell.render(cell_area, buf),
@@ -674,7 +692,7 @@ impl ChatWidget {
             }
             row_cursor += entry.height;
 
-            if entry.separator_after {
+            if entry.separator_after && row_cursor < content_y + content_height {
                 render_turn_separator(area.x, row_cursor, area.width, sep_style, buf);
                 row_cursor += 1;
             }
@@ -682,28 +700,12 @@ impl ChatWidget {
 
         // Render a separator between the last committed cell and the
         // active streaming cell, if needed.
-        if active_sep {
+        if active_sep && row_cursor < content_y + content_height {
             render_turn_separator(area.x, row_cursor, area.width, sep_style, buf);
         }
 
-        // ── Overflow indicator ────────────────────────────────────────
-        let dim_style = Style::default().fg(crate::history::rgb(genesis_ui::colors::UI_DIM));
-
-        // Show scrolled-up indicator at the bottom when content is below.
-        if self.scroll_locked && below_count > 0 {
-            let hint = " \u{2193} scrolled up \u{00b7} PgDn/End to return".to_string();
-            let hint_line = Line::from(Span::styled(hint, dim_style));
-            let hint_area = Rect {
-                x: area.x,
-                y: area.y + area.height - 1,
-                width: area.width,
-                height: 1,
-            };
-            Paragraph::new(hint_line).render(hint_area, buf);
-        }
-
-        // Show overflow indicator at the top when messages are clipped above.
-        if skipped_message_count > 0 {
+        // ── Overflow indicators ───────────────────────────────────────
+        if show_top_hint {
             let hint = if self.scroll_locked {
                 format!(
                     " \u{2191} {} more \u{00b7} PgUp to scroll",
@@ -719,6 +721,17 @@ impl ChatWidget {
             let hint_area = Rect {
                 x: area.x,
                 y: area.y,
+                width: area.width,
+                height: 1,
+            };
+            Paragraph::new(hint_line).render(hint_area, buf);
+        }
+        if show_bottom_hint {
+            let hint = " \u{2193} scrolled up \u{00b7} PgDn/End to return".to_string();
+            let hint_line = Line::from(Span::styled(hint, dim_style));
+            let hint_area = Rect {
+                x: area.x,
+                y: area.y + area.height - 1,
                 width: area.width,
                 height: 1,
             };


### PR DESCRIPTION
## Summary
- **Scroll hint overwrite fix**: Overflow indicators (top/bottom) now render in reserved rows that don't overlap message content. Previously the "↑ N more" hint overwrote the topmost visible message.
- **AgentCell cache preservation**: Manual `Clone` impl preserves `cached_lines` OnceCell contents. The derived `Clone` returned an empty OnceCell, causing markdown to be re-parsed from scratch on every clone — quadratic cost in long conversations.
- **Terminal cleanup guard**: Added `TerminalGuard` RAII struct that calls `terminal::restore()` on drop. Ensures terminal is cleaned up even if `run_tui` returns early via `?` operators (previously would leave terminal in raw mode with hidden cursor).

## Test plan
- [ ] Scroll up in a long conversation — top hint should NOT overwrite the first visible message
- [ ] Verify scroll indicators appear in their own reserved rows
- [ ] Long conversation performance should be improved (no re-parsing on cell clone)
- [ ] Kill the process during TUI init — terminal should be properly restored