### PR TITLE
feat(tui): wire theme into chat widget — cursor, separators, and indicators

### DIFF
--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -373,6 +373,7 @@ impl App {
                     let next = names[(idx + 1) % names.len()];
                     self.active_theme = crate::theme::resolve_theme(next);
                     self.status_bar.set_theme(&*self.active_theme);
+                    self.chat.set_theme(&*self.active_theme);
                     // Persist to config (best-effort, ignore errors).
                     let _ = genesis_config::set_theme(next);
                     self.frame_requester.schedule_frame();

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -261,8 +261,9 @@ pub async fn run_tui(
         active_theme: crate::theme::resolve_theme(&config.tui.theme),
     };
 
-    // Apply the initial theme to the status bar.
+    // Apply the initial theme to themed widgets.
     app.status_bar.set_theme(&*app.active_theme);
+    app.chat.set_theme(&*app.active_theme);
 
     // If an initial prompt was provided, skip the welcome screen and submit
     // the prompt as the first user message once the event loop starts.

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -70,6 +70,10 @@ pub struct ChatWidget {
     /// A tool group is identified by the index of its first cell in `committed_cells`.
     /// Groups not present in this set are rendered as a single collapsed summary line.
     pub expanded_tool_groups: HashSet<usize>,
+    /// Theme-derived accent color (for cursor, active indicators).
+    theme_accent: ratatui::style::Color,
+    /// Theme-derived dim color (for separators, hints).
+    theme_dim: ratatui::style::Color,
     /// Number of rows scrolled back from the bottom (0 = pinned to bottom).
     scroll_offset: usize,
     /// True when the user has scrolled up and auto-scroll is disabled.
@@ -86,9 +90,19 @@ impl ChatWidget {
             input: InputWidget::new(),
             active_cell_cache: None,
             expanded_tool_groups: HashSet::new(),
+            theme_accent: crate::history::rgb(genesis_ui::colors::EVE_LAVENDER),
+            theme_dim: crate::history::rgb(genesis_ui::colors::UI_DIM),
             scroll_offset: 0,
             scroll_locked: false,
         }
+    }
+
+    // ── Theme ─────────────────────────────────────────────────────────────
+
+    /// Update theme-derived colors for the chat view.
+    pub fn set_theme(&mut self, theme: &dyn crate::theme::Theme) {
+        self.theme_accent = theme.primary();
+        self.theme_dim = theme.text_dim();
     }
 
     // ── Scroll ────────────────────────────────────────────────────────────
@@ -433,8 +447,7 @@ impl ChatWidget {
             let mut lines = self.active_cell_cache.as_ref().unwrap().lines.clone();
 
             // Append a block cursor to the last line to indicate streaming.
-            let cursor_style =
-                Style::default().fg(crate::history::rgb(genesis_ui::colors::EVE_LAVENDER));
+            let cursor_style = Style::default().fg(self.theme_accent);
             if let Some(last_line) = lines.last_mut() {
                 last_line.spans.push(Span::styled("\u{258D}", cursor_style));
             }
@@ -655,7 +668,7 @@ impl ChatWidget {
 
         // ── Determine hint rows ────────────────────────────────────────
         // Reserve rows for overflow hints so they don't overwrite content.
-        let dim_style = Style::default().fg(crate::history::rgb(genesis_ui::colors::UI_DIM));
+        let dim_style = Style::default().fg(self.theme_dim);
         let show_top_hint = skipped_message_count > 0;
         let show_bottom_hint = self.scroll_locked && below_count > 0;
 
@@ -672,7 +685,7 @@ impl ChatWidget {
         let clamped_used = used.min(content_height);
         let mut row_cursor = content_y + content_height - clamped_used;
 
-        let sep_style = Style::default().fg(crate::history::rgb(genesis_ui::colors::UI_DIM));
+        let sep_style = Style::default().fg(self.theme_dim);
 
         for entry in &entries {
             if row_cursor >= content_y + content_height {


### PR DESCRIPTION
## Summary
Phase 2 of theme wiring — the chat widget now responds to `/theme` cycling:

- Streaming cursor color (block cursor during agent response)
- Turn separators between user and agent messages
- Scroll/overflow indicator text (top and bottom hints)

Combined with Phase 1 (status bar, PR #386), switching themes now visibly changes
both the status bar and the chat area.

## Test plan
- [ ] Run `/theme` — streaming cursor, separators, and scroll hints should change color
- [ ] Verify all 4 themes produce distinct appearances in the chat area
- [ ] Scroll indicators should use the theme's dim color, not hardcoded Eve dim