### PR TITLE
fix(tui): fix list items running together on single line

### DIFF
--- a/crates/genesis-tui/src/render/markdown.rs
+++ b/crates/genesis-tui/src/render/markdown.rs
@@ -264,7 +264,13 @@ impl MarkdownWriter {
                 // between items), pulldown-cmark does NOT wrap each item in
                 // a Paragraph, so we must end the line here to prevent items
                 // from running together on one line.
-                self.finish_line();
+                //
+                // Guard: for "loose" lists, End(Paragraph) already flushed
+                // current_spans. Calling finish_line() on empty spans would
+                // produce a spurious blank line after each item.
+                if !self.current_spans.is_empty() {
+                    self.finish_line();
+                }
             }
 
             // ── Code blocks ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
**Root cause found:** Tight lists (the default for LLM output — no blank lines between items) in CommonMark don't wrap each item in a `<p>` tag. pulldown-cmark skips `Start/End(Paragraph)` events for tight list items, going directly `Start(Item) → Text → End(Item)`. Since `End(TagEnd::Item)` was a no-op (comment said "flushed by inner Paragraph end"), `finish_line()` was never called between items.

**Result:** All bullet points and numbered list items were concatenated onto a single long line that wrapped, producing sloppy output like:
```
• Context window = ...• Stored memory = ...• Memory retrieval = ...
```
and
```
1. first item2. second item3. third item
```

**Fix:** `End(TagEnd::Item)` now calls `finish_line()` to ensure each list item starts on a new line.

**Tests:** Added `multi_list_items_each_on_own_line` and `ordered_list_items_each_on_own_line` tests that reproduce and verify the fix.

## Test plan
- [ ] LLM responses with bullet lists should show each item on its own line
- [ ] Numbered lists should show each number on its own line
- [ ] Nested lists should still work correctly
- [ ] Loose lists (with blank lines) should not produce double blank lines