### PR TITLE
fix(tui): per-block prefix, scroll, block splitting, tool UX, and polish

### DIFF
--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -82,6 +82,9 @@ pub struct App {
     pub overlay: Option<ActiveOverlay>,
     /// Last known viewport height (used to pass visible_rows to the overlay).
     pub viewport_height: u16,
+    /// Last computed message area height (viewport minus status bar, input, separator).
+    /// Updated each frame for accurate scroll clamping.
+    pub message_area_height: u16,
     /// Slash command popup (shown when input starts with `/`).
     pub command_popup: CommandPopup,
     /// Interactive clarification picker (shown when agent asks a question with choices).
@@ -167,7 +170,7 @@ impl App {
                         self.chat.scroll_up(
                             delta as usize,
                             self.viewport_width,
-                            self.viewport_height,
+                            self.message_area_height,
                         );
                     } else if delta < 0 {
                         self.chat.scroll_down((-delta) as usize);
@@ -640,14 +643,14 @@ impl App {
         // ── Chat scroll-back ──────────────────────────────────────
         match key.code {
             KeyCode::PageUp => {
-                let half = (self.viewport_height / 2).max(1) as usize;
+                let half = (self.message_area_height / 2).max(1) as usize;
                 self.chat
-                    .scroll_up(half, self.viewport_width, self.viewport_height);
+                    .scroll_up(half, self.viewport_width, self.message_area_height);
                 self.frame_requester.schedule_frame();
                 return;
             }
             KeyCode::PageDown => {
-                let half = (self.viewport_height / 2).max(1) as usize;
+                let half = (self.message_area_height / 2).max(1) as usize;
                 self.chat.scroll_down(half);
                 self.frame_requester.schedule_frame();
                 return;
@@ -664,7 +667,7 @@ impl App {
             match key.code {
                 KeyCode::Up => {
                     self.chat
-                        .scroll_up(1, self.viewport_width, self.viewport_height);
+                        .scroll_up(1, self.viewport_width, self.message_area_height);
                     self.frame_requester.schedule_frame();
                     return;
                 }
@@ -1028,6 +1031,7 @@ mod tests {
             status_bar: StatusBarWidget::new("test".to_string(), "main".to_string()),
             overlay: None,
             viewport_height: 24,
+            message_area_height: 19, // 24 - status(1) - input(3) - separator(1)
             command_popup: CommandPopup::new(),
             clarification: ClarificationWidget::new(),
             clear_after_welcome: false,

--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -164,7 +164,11 @@ impl App {
                     self.frame_requester.schedule_frame();
                 } else if matches!(self.screen, AppScreen::Chat) {
                     if delta > 0 {
-                        self.chat.scroll_up(delta as usize, self.viewport_width);
+                        self.chat.scroll_up(
+                            delta as usize,
+                            self.viewport_width,
+                            self.viewport_height,
+                        );
                     } else if delta < 0 {
                         self.chat.scroll_down((-delta) as usize);
                     }
@@ -637,7 +641,8 @@ impl App {
         match key.code {
             KeyCode::PageUp => {
                 let half = (self.viewport_height / 2).max(1) as usize;
-                self.chat.scroll_up(half, self.viewport_width);
+                self.chat
+                    .scroll_up(half, self.viewport_width, self.viewport_height);
                 self.frame_requester.schedule_frame();
                 return;
             }
@@ -658,7 +663,8 @@ impl App {
         if key.modifiers.contains(KeyModifiers::SHIFT) {
             match key.code {
                 KeyCode::Up => {
-                    self.chat.scroll_up(1, self.viewport_width);
+                    self.chat
+                        .scroll_up(1, self.viewport_width, self.viewport_height);
                     self.frame_requester.schedule_frame();
                     return;
                 }

--- a/crates/genesis-tui/src/history/agent_cell.rs
+++ b/crates/genesis-tui/src/history/agent_cell.rs
@@ -24,6 +24,9 @@ const PREFIX: &str = "eve> ";
 pub struct AgentCell {
     /// The raw response text (private — use `text()` accessor).
     text: String,
+    /// When true, this cell is a continuation of a prior agent block in the
+    /// same turn — rendered with indent instead of the `eve> ` prefix.
+    continuation: bool,
     /// Lazily-computed styled lines (avoids re-parsing markdown in both
     /// `height()` and `to_scrollback_lines()`).
     cached_lines: OnceCell<Vec<Line<'static>>>,
@@ -42,6 +45,7 @@ impl Clone for AgentCell {
         }
         Self {
             text: self.text.clone(),
+            continuation: self.continuation,
             cached_lines,
             cached_height: self.cached_height.clone(),
         }
@@ -50,9 +54,24 @@ impl Clone for AgentCell {
 
 impl AgentCell {
     /// Construct a new `AgentCell` with the given response text.
+    ///
+    /// This is the first block of an agent turn — rendered with the `eve> ` prefix.
     pub fn new(text: impl Into<String>) -> Self {
         Self {
             text: text.into(),
+            continuation: false,
+            cached_lines: OnceCell::new(),
+            cached_height: Cell::new(None),
+        }
+    }
+
+    /// Construct a continuation `AgentCell` — a subsequent block in the same turn.
+    ///
+    /// Rendered with matching-width indent instead of the `eve> ` prefix.
+    pub fn new_continuation(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            continuation: true,
             cached_lines: OnceCell::new(),
             cached_height: Cell::new(None),
         }
@@ -65,8 +84,13 @@ impl AgentCell {
 
     /// Return the cached (or lazily computed) styled lines.
     fn lines(&self) -> &Vec<Line<'static>> {
-        self.cached_lines
-            .get_or_init(|| prefix_markdown_lines(&self.text))
+        self.cached_lines.get_or_init(|| {
+            if self.continuation {
+                continuation_markdown_lines(&self.text)
+            } else {
+                prefix_markdown_lines(&self.text)
+            }
+        })
     }
 
     /// Render the cell into the given buffer area.
@@ -101,10 +125,31 @@ impl AgentCell {
 }
 
 /// Parse `text` as markdown and prepend the `eve> ` prefix/indent.
+///
+/// The first line gets the coloured `eve> ` prefix; continuation lines
+/// get a matching-width space indent.
 pub(crate) fn prefix_markdown_lines(text: &str) -> Vec<Line<'static>> {
+    format_markdown_lines_inner(text, false)
+}
+
+/// Parse `text` as markdown with indent only (no `eve> ` prefix).
+///
+/// Used for continuation blocks within the same agent turn — all lines
+/// get the matching-width space indent so they align with the first block.
+pub(crate) fn continuation_markdown_lines(text: &str) -> Vec<Line<'static>> {
+    format_markdown_lines_inner(text, true)
+}
+
+/// Shared implementation: render markdown with either `eve> ` prefix or
+/// indent-only on the first line.
+fn format_markdown_lines_inner(text: &str, continuation: bool) -> Vec<Line<'static>> {
     let md_lines = markdown_to_lines(text);
 
     if md_lines.is_empty() {
+        if continuation {
+            // Continuation of empty text — produce nothing visible.
+            return vec![];
+        }
         // Even for empty text, produce one line with just the prefix so the
         // cell is visible.
         return vec![Line::from(Span::styled(
@@ -122,7 +167,7 @@ pub(crate) fn prefix_markdown_lines(text: &str) -> Vec<Line<'static>> {
         .enumerate()
         .map(|(i, line)| {
             let mut spans = Vec::with_capacity(1 + line.spans.len());
-            if i == 0 {
+            if i == 0 && !continuation {
                 spans.push(Span::styled(PREFIX.to_owned(), prefix_style));
             } else {
                 spans.push(Span::raw(indent.clone()));

--- a/crates/genesis-tui/src/history/agent_cell.rs
+++ b/crates/genesis-tui/src/history/agent_cell.rs
@@ -109,7 +109,14 @@ impl AgentCell {
             }
         }
         let usable_width = width.max(1);
-        let h = wrapped_row_count(&self.to_scrollback_lines(usable_width), usable_width).max(1);
+        let lines = self.to_scrollback_lines(usable_width);
+        // Empty continuation cells (no visible lines) should occupy 0 rows,
+        // but cells with the eve> prefix always occupy at least 1 row.
+        let h = if lines.is_empty() {
+            0
+        } else {
+            wrapped_row_count(&lines, usable_width).max(1)
+        };
         self.cached_height.set(Some((width, h)));
         h
     }

--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -541,7 +541,7 @@ impl ToolCell {
 
 /// Render a collapsed tool group as a single styled [`Line`].
 ///
-/// Format: `  ▸ N tool calls (Xs, all ok)` or `  ▸ N tool calls (Xs, M failed)`
+/// Format: `  ▸ N tool calls: name1, name2, … (Xs, all ok)`
 pub fn tool_group_summary_line(cells: &[&ToolCell]) -> Line<'static> {
     let count = cells.len();
     let total_dur: Duration = cells.iter().map(|c| c.duration).sum();
@@ -554,12 +554,30 @@ pub fn tool_group_summary_line(cells: &[&ToolCell]) -> Line<'static> {
         (format!("{fail_count} failed"), COLOR_FAIL)
     };
 
+    // Collect unique tool names in call order, truncated to fit.
+    let mut names: Vec<&str> = Vec::new();
+    for c in cells {
+        if !names.contains(&c.tool_name.as_str()) {
+            names.push(&c.tool_name);
+        }
+    }
+    // Show up to 3 unique names, then "…".
+    let names_str = if names.len() <= 3 {
+        names.join(", ")
+    } else {
+        format!("{}, +{} more", names[..2].join(", "), names.len() - 2)
+    };
+
     Line::from(vec![
         Span::styled("  ", Style::default().fg(UI_DIM)),
         Span::styled("▸ ", Style::default().fg(Color::Rgb(180, 167, 214))),
         Span::styled(
             format!("{count} tool calls"),
             Style::default().fg(Color::Rgb(168, 168, 168)),
+        ),
+        Span::styled(
+            format!(": {names_str}"),
+            Style::default().fg(Color::Rgb(140, 140, 140)),
         ),
         Span::styled(format!(" ({dur_str}, "), Style::default().fg(UI_DIM)),
         Span::styled(status, Style::default().fg(status_color)),
@@ -1252,6 +1270,13 @@ diff --git a/src/main.rs b/src/main.rs
             "should show total duration: {text:?}"
         );
         assert!(text.contains("all ok"), "should show all ok: {text:?}");
+        // Tool names should be listed in the summary.
+        assert!(text.contains("shell"), "should show tool name: {text:?}");
+        assert!(
+            text.contains("read_file"),
+            "should show tool name: {text:?}"
+        );
+        assert!(text.contains("grep"), "should show tool name: {text:?}");
     }
 
     #[test]

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -678,7 +678,7 @@ fn render_frame(
         app.effects.on_resize();
 
         // Reclamp scroll offset for the new width.
-        app.chat.reclamp_scroll(area.width);
+        app.chat.reclamp_scroll(area.width, area.height);
 
         // Rebuild the transcript overlay if open.
         if let Some(app::ActiveOverlay::Transcript(_)) = &app.overlay {

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -844,8 +844,14 @@ fn render_frame(
                 }
 
                 if input_area.height >= 2 && input_area.width >= 2 {
-                    // Input panel border.
-                    let border_style = Style::default().fg(app.active_theme.border());
+                    // Input panel border — accent when idle (accepting input),
+                    // dim when a turn is running.
+                    let border_color = if app.turn_running {
+                        app.active_theme.text_dim()
+                    } else {
+                        app.active_theme.border()
+                    };
+                    let border_style = Style::default().fg(border_color);
                     crate::render::draw_box(input_area, buf, border_style, None);
 
                     let inner = Rect {

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -239,6 +239,7 @@ pub async fn run_tui(
         status_bar,
         overlay: None,
         viewport_height: viewport_area.height,
+        message_area_height: viewport_area.height.saturating_sub(5), // status + input + separator
         command_popup: crate::widgets::command_popup::CommandPopup::new(),
         clarification: crate::widgets::clarification::ClarificationWidget::new(),
         clear_after_welcome: false,
@@ -678,7 +679,7 @@ fn render_frame(
         app.effects.on_resize();
 
         // Reclamp scroll offset for the new width.
-        app.chat.reclamp_scroll(area.width, area.height);
+        app.chat.reclamp_scroll(area.width, app.message_area_height);
 
         // Rebuild the transcript overlay if open.
         if let Some(app::ActiveOverlay::Transcript(_)) = &app.overlay {
@@ -793,6 +794,9 @@ fn render_frame(
                     width: area.width,
                     height: chat_area_height,
                 };
+
+                // Store computed message area height for scroll clamping.
+                app.message_area_height = message_area_height;
 
                 if message_area_height > 0 {
                     app.chat.render_messages(message_area, buf);

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -673,12 +673,16 @@ fn render_frame(
         let area = term.viewport_area();
         app.viewport_width = area.width;
         app.viewport_height = area.height;
+        // Approximate the new message area height (status + input + separator ≈ 5 rows).
+        // The exact value is computed during render, but this estimate is sufficient
+        // for scroll clamping on resize.
+        app.message_area_height = area.height.saturating_sub(5);
 
         // Cancel all running effects — they hold stale coordinates from
         // the pre-resize viewport.
         app.effects.on_resize();
 
-        // Reclamp scroll offset for the new width.
+        // Reclamp scroll offset for the new dimensions.
         app.chat.reclamp_scroll(area.width, app.message_area_height);
 
         // Rebuild the transcript overlay if open.

--- a/crates/genesis-tui/src/streaming_blocks.rs
+++ b/crates/genesis-tui/src/streaming_blocks.rs
@@ -22,6 +22,10 @@ pub struct StreamingBlockCollector {
     fence_marker: Option<String>,
     /// Number of lines accumulated in the current block.
     line_count: usize,
+    /// Whether the current block contains list items or blockquotes.
+    /// When true, the 20-line auto-split is disabled to avoid breaking
+    /// mid-structure (list items/blockquotes lose their context in new cells).
+    in_structured_block: bool,
     /// Deferred block waiting to be returned on the next `push_line` call.
     /// Used when a single `push_line` would need to emit two blocks (e.g.
     /// a paragraph followed by a heading on the same call).
@@ -42,6 +46,7 @@ impl StreamingBlockCollector {
             in_code_fence: false,
             fence_marker: None,
             line_count: 0,
+            in_structured_block: false,
             pending_emit: None,
         }
     }
@@ -126,13 +131,23 @@ impl StreamingBlockCollector {
             return None;
         }
 
+        // Detect list items and blockquotes — these are "structured" blocks
+        // that should not be split mid-way by the auto-emit threshold.
+        if is_list_item(stripped) || stripped.starts_with('>') {
+            self.in_structured_block = true;
+        }
+
         // Regular text line — accumulate.
         self.buffer.push_str(line);
         self.line_count += 1;
 
         // Auto-emit after accumulating enough lines to keep cells small.
-        // This prevents any single paragraph from growing too large.
-        if self.line_count >= 20 {
+        // Skip this when inside a structured block (list/blockquote) to
+        // avoid splitting mid-structure — the block will emit on the next
+        // blank line or when a different block type starts. Use a higher
+        // safety limit (80 lines) to prevent unbounded growth.
+        let limit = if self.in_structured_block { 80 } else { 20 };
+        if self.line_count >= limit {
             return self.emit();
         }
 
@@ -174,6 +189,7 @@ impl StreamingBlockCollector {
         self.in_code_fence = false;
         self.fence_marker = None;
         self.line_count = 0;
+        self.in_structured_block = false;
         self.pending_emit = None;
     }
 
@@ -183,8 +199,32 @@ impl StreamingBlockCollector {
             return None;
         }
         self.line_count = 0;
+        self.in_structured_block = false;
         Some(std::mem::take(&mut self.buffer))
     }
+}
+
+/// Detect a markdown list item prefix (e.g. `- `, `* `, `+ `, `1. `).
+fn is_list_item(stripped: &str) -> bool {
+    // Unordered: - , * , +  (followed by space)
+    if stripped.len() >= 2 {
+        let first = stripped.as_bytes()[0];
+        if (first == b'-' || first == b'*' || first == b'+') && stripped.as_bytes()[1] == b' ' {
+            return true;
+        }
+    }
+    // Ordered: N. or N) followed by space (e.g. "1. ", "10) ")
+    if let Some(dot_pos) = stripped.find(". ") {
+        if dot_pos <= 9 && stripped[..dot_pos].bytes().all(|b| b.is_ascii_digit()) {
+            return true;
+        }
+    }
+    if let Some(paren_pos) = stripped.find(") ") {
+        if paren_pos <= 9 && stripped[..paren_pos].bytes().all(|b| b.is_ascii_digit()) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Detect a code fence opening marker (``` or ~~~).
@@ -300,6 +340,7 @@ mod tests {
         c.reset();
         assert!(!c.in_code_fence);
         assert!(c.buffer.is_empty());
+        assert!(!c.in_structured_block);
     }
 
     #[test]
@@ -333,6 +374,85 @@ mod tests {
         let block = c.push_line("~~~\n");
         assert!(block.is_some());
         assert!(block.unwrap().contains("code"));
+    }
+
+    #[test]
+    fn list_items_not_split_at_20_lines() {
+        let mut c = StreamingBlockCollector::new();
+        // Push 25 list items — should NOT auto-emit at 20.
+        for i in 0..25 {
+            assert!(
+                c.push_line(&format!("- item {i}\n")).is_none(),
+                "list should not auto-emit at line {}",
+                i + 1
+            );
+        }
+        // Blank line terminates the list block.
+        let block = c.push_line("\n");
+        assert!(block.is_some(), "list should emit on blank line");
+        let text = block.unwrap();
+        assert!(text.contains("- item 0"), "should contain first item");
+        assert!(text.contains("- item 24"), "should contain last item");
+    }
+
+    #[test]
+    fn blockquote_not_split_at_20_lines() {
+        let mut c = StreamingBlockCollector::new();
+        for i in 0..25 {
+            assert!(
+                c.push_line(&format!("> quote line {i}\n")).is_none(),
+                "blockquote should not auto-emit at line {}",
+                i + 1
+            );
+        }
+        let block = c.push_line("\n");
+        assert!(block.is_some());
+        let text = block.unwrap();
+        assert!(text.contains("> quote line 0"));
+        assert!(text.contains("> quote line 24"));
+    }
+
+    #[test]
+    fn ordered_list_not_split_at_20_lines() {
+        let mut c = StreamingBlockCollector::new();
+        for i in 1..=25 {
+            assert!(
+                c.push_line(&format!("{i}. item\n")).is_none(),
+                "ordered list should not auto-emit at line {i}"
+            );
+        }
+        let block = c.finalize();
+        assert!(block.is_some());
+        let text = block.unwrap();
+        assert!(text.contains("1. item"));
+        assert!(text.contains("25. item"));
+    }
+
+    #[test]
+    fn plain_paragraph_still_splits_at_20_lines() {
+        let mut c = StreamingBlockCollector::new();
+        for i in 0..19 {
+            assert!(
+                c.push_line(&format!("plain line {i}\n")).is_none(),
+                "should not emit before 20 lines"
+            );
+        }
+        let block = c.push_line("plain line 19\n");
+        assert!(block.is_some(), "plain text should auto-emit at 20 lines");
+    }
+
+    #[test]
+    fn structured_block_has_safety_limit() {
+        // Even structured blocks have an 80-line safety limit.
+        let mut c = StreamingBlockCollector::new();
+        for i in 0..79 {
+            assert!(
+                c.push_line(&format!("- item {i}\n")).is_none(),
+                "should not emit before 80 lines for structured block"
+            );
+        }
+        let block = c.push_line("- item 79\n");
+        assert!(block.is_some(), "should emit at 80-line safety limit");
     }
 
     #[test]

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -155,9 +155,15 @@ impl ChatWidget {
     /// The offset is clamped so the oldest content can reach the top of
     /// the viewport but never scrolls further (no blank screen). When
     /// total content fits within the viewport, returns 0.
+    ///
+    /// Accounts for hint rows: when scrolled, the renderer reserves 1 row
+    /// for "↑ N more" (top) and 1 row for "↓ scrolled up" (bottom), so
+    /// only `viewport_height - 2` rows show actual content.
     fn scroll_max(&mut self, viewport_width: u16, viewport_height: u16) -> usize {
         let total = self.committed_content_height(viewport_width);
-        total.saturating_sub(viewport_height as usize)
+        // Reserve 2 rows for hints when scrolled.
+        let visible = (viewport_height as usize).saturating_sub(2);
+        total.saturating_sub(visible)
     }
 
     /// Scroll the chat view up by `rows` rows, clamped so the oldest

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -984,13 +984,38 @@ impl ChatWidget {
             prev_is_user = Some(cur_is_user);
         }
 
-        // Count message cells (User/Agent) that were clipped above.
-        let skipped_message_count = self
-            .committed_cells
-            .iter()
-            .take(self.committed_cells.len().saturating_sub(cells_collected))
-            .filter(|c| matches!(c, HistoryCell::User(_) | HistoryCell::Agent(_)))
-            .count();
+        // Count conversation *turns* (not individual blocks) clipped above.
+        // With per-block-cell architecture, one agent response may span
+        // multiple AgentCell entries. Collapse consecutive Agent cells into
+        // one turn so the hint says "↑ 2 more" for 2 turns, not "↑ 12 more"
+        // for 12 paragraph blocks.
+        let skipped_message_count = {
+            let skipped = self
+                .committed_cells
+                .iter()
+                .take(self.committed_cells.len().saturating_sub(cells_collected));
+            let mut turns = 0usize;
+            let mut prev_is_agent = false;
+            for cell in skipped {
+                match cell {
+                    HistoryCell::User(_) => {
+                        turns += 1;
+                        prev_is_agent = false;
+                    }
+                    HistoryCell::Agent(_) => {
+                        if !prev_is_agent {
+                            turns += 1;
+                        }
+                        prev_is_agent = true;
+                    }
+                    HistoryCell::Tool(_) => {
+                        // Tools are part of the agent turn, don't count separately.
+                        prev_is_agent = false;
+                    }
+                }
+            }
+            turns
+        };
 
         // Also account for a separator between the last committed cell
         // and the active cell, if the active cell was rendered above.

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -150,20 +150,24 @@ impl ChatWidget {
 
     // ── Scroll ────────────────────────────────────────────────────────────
 
-    /// Compute the maximum allowed scroll offset for the current content
-    /// at the given viewport width. Only counts committed cells (not the
-    /// active streaming cell) because `render_messages` hides the active
-    /// cell when the user has scrolled up.
-    fn scroll_max(&mut self, viewport_width: u16) -> usize {
-        self.committed_content_height(viewport_width)
+    /// Compute the maximum allowed scroll offset for the current content.
+    ///
+    /// The offset is clamped so the oldest content can reach the top of
+    /// the viewport but never scrolls further (no blank screen). When
+    /// total content fits within the viewport, returns 0.
+    fn scroll_max(&mut self, viewport_width: u16, viewport_height: u16) -> usize {
+        let total = self.committed_content_height(viewport_width);
+        total.saturating_sub(viewport_height as usize)
     }
 
-    /// Scroll the chat view up by `rows` rows, clamped to the visible
-    /// content height so the offset never grows unbounded.
-    pub fn scroll_up(&mut self, rows: usize, viewport_width: u16) {
-        let max = self.scroll_max(viewport_width);
+    /// Scroll the chat view up by `rows` rows, clamped so the oldest
+    /// content can reach the top but you can't scroll into blank space.
+    pub fn scroll_up(&mut self, rows: usize, viewport_width: u16, viewport_height: u16) {
+        let max = self.scroll_max(viewport_width, viewport_height);
         self.scroll_offset = self.scroll_offset.saturating_add(rows).min(max);
-        self.scroll_locked = true;
+        if self.scroll_offset > 0 {
+            self.scroll_locked = true;
+        }
     }
 
     /// Scroll the chat view down by `rows` rows. Re-enables auto-scroll
@@ -191,11 +195,11 @@ impl ChatWidget {
     /// When the terminal width changes, wrapped content takes a different
     /// number of rows. If the old offset now exceeds the new maximum,
     /// this brings it back in range (or snaps to bottom if it would be 0).
-    pub fn reclamp_scroll(&mut self, viewport_width: u16) {
+    pub fn reclamp_scroll(&mut self, viewport_width: u16, viewport_height: u16) {
         if !self.scroll_locked {
             return;
         }
-        let max = self.scroll_max(viewport_width);
+        let max = self.scroll_max(viewport_width, viewport_height);
         if self.scroll_offset > max {
             self.scroll_offset = max;
         }
@@ -869,6 +873,13 @@ impl ChatWidget {
         let mut cells_collected = 0usize;
         let num_cells = self.committed_cells.len();
 
+        // When the user has scrolled up, collect extra cells beyond the
+        // viewport so that after skipping the newest entries (scroll offset),
+        // older cells fill the freed space. Without this, scrolling up
+        // would show empty space instead of earlier messages.
+        let scroll_extra = u16::try_from(self.scroll_offset).unwrap_or(u16::MAX);
+        let collection_budget = remaining_rows.saturating_add(scroll_extra);
+
         let mut i = num_cells;
         while i > 0 {
             i -= 1;
@@ -898,7 +909,7 @@ impl ChatWidget {
                         let cur_is_user = false;
                         let needs_sep = prev_is_user.is_some_and(|prev| prev != cur_is_user);
                         let cost = h + if needs_sep { 1 } else { 0 };
-                        if used + cost > remaining_rows {
+                        if used + cost > collection_budget {
                             break;
                         }
 
@@ -933,7 +944,7 @@ impl ChatWidget {
             // height budget.
             let needs_sep = prev_is_user.is_some_and(|prev| prev != cur_is_user);
             let cost = h + if needs_sep { 1 } else { 0 };
-            if used + cost > remaining_rows {
+            if used + cost > collection_budget {
                 // If this is the FIRST cell we're trying to add and it's
                 // taller than the viewport, add it anyway — it will be
                 // clipped to the viewport height during rendering (showing
@@ -944,7 +955,7 @@ impl ChatWidget {
                     // appear (if entries is empty and this cell didn't fit,
                     // there are older messages above → skipped_message_count > 0).
                     let hint_reserve: u16 = 1;
-                    let clamped_h = remaining_rows
+                    let clamped_h = collection_budget
                         .saturating_sub(if needs_sep { 1 } else { 0 })
                         .saturating_sub(hint_reserve);
                     if clamped_h > 0 {
@@ -1584,6 +1595,57 @@ mod tests {
         assert!(
             !has_indicator,
             "should not show overflow indicator when all messages fit"
+        );
+    }
+
+    #[test]
+    fn scroll_up_reveals_user_message_after_long_response() {
+        let mut cw = ChatWidget::new();
+        cw.add_user_message("my original question".to_string());
+        cw.start_turn();
+        // Create a long response with many blocks (paragraphs separated by blank lines).
+        for i in 0..20 {
+            cw.append_text(&format!("paragraph {i} content\n\n"));
+        }
+        // Drain all streaming buffer ticks to commit blocks.
+        while cw.tick_streaming() {}
+        cw.complete_turn();
+
+        // Use a small viewport that can't fit all blocks.
+        let area = Rect::new(0, 0, 60, 10);
+
+        // Helper to extract all text from a buffer.
+        let buf_text = |buf: &Buffer| -> String {
+            let mut text = String::new();
+            for row in 0..area.height {
+                for col in 0..area.width {
+                    if let Some(c) = buf.cell((col, row)) {
+                        text.push_str(c.symbol());
+                    }
+                }
+            }
+            text
+        };
+
+        let mut buf = Buffer::empty(area);
+        cw.render_messages(area, &mut buf);
+
+        // Initially, user message is clipped (too many agent blocks).
+        assert!(
+            !buf_text(&buf).contains("my original question"),
+            "user message should be clipped initially"
+        );
+
+        // Scroll up far enough to reach the user message.
+        for _ in 0..50 {
+            cw.scroll_up(1, area.width, area.height);
+        }
+
+        let mut buf2 = Buffer::empty(area);
+        cw.render_messages(area, &mut buf2);
+        assert!(
+            buf_text(&buf2).contains("my original question"),
+            "scrolling up should reveal the user's message"
         );
     }
 

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use crate::history::agent_cell::{prefix_markdown_lines, AgentCell};
+use crate::history::agent_cell::{continuation_markdown_lines, prefix_markdown_lines, AgentCell};
 use crate::history::cell::HistoryCell;
 use crate::history::tool_cell::{tool_group_summary_line, ToolCell, ToolDisplayMode};
 use crate::history::user_cell::UserCell;
@@ -41,6 +41,10 @@ pub struct ActiveCell {
     /// and emits complete blocks for committing as `HistoryCell` entries.
     pub block_collector: StreamingBlockCollector,
     pub tool_calls: Vec<ActiveToolCall>,
+    /// Whether the first text block of this turn has been committed.
+    /// Used to decide whether subsequent blocks are continuations (indent
+    /// only, no `eve> ` prefix).
+    pub first_block_committed: bool,
 }
 
 /// Cache for the active cell's rendered markdown lines.
@@ -226,6 +230,7 @@ impl ChatWidget {
         self.active_cell = Some(ActiveCell {
             block_collector: StreamingBlockCollector::new(),
             tool_calls: Vec::new(),
+            first_block_committed: false,
         });
         self.active_cell_cache = None;
         self.streaming_buffer.reset();
@@ -270,8 +275,19 @@ impl ChatWidget {
                 }
             }
             for block in emitted_blocks {
-                self.committed_cells
-                    .push(HistoryCell::Agent(AgentCell::new(block)));
+                let is_continuation = self
+                    .active_cell
+                    .as_ref()
+                    .is_some_and(|c| c.first_block_committed);
+                let agent_cell = if is_continuation {
+                    AgentCell::new_continuation(block)
+                } else {
+                    if let Some(ac) = &mut self.active_cell {
+                        ac.first_block_committed = true;
+                    }
+                    AgentCell::new(block)
+                };
+                self.committed_cells.push(HistoryCell::Agent(agent_cell));
                 self.bump_revision();
             }
             return true;
@@ -355,17 +371,29 @@ impl ChatWidget {
             if let Some(cell) = &mut self.active_cell {
                 for line in SplitKeepNewlines::new(&remaining) {
                     if let Some(block) = cell.block_collector.push_line(line) {
-                        self.committed_cells
-                            .push(HistoryCell::Agent(AgentCell::new(block)));
+                        let agent_cell = if cell.first_block_committed {
+                            AgentCell::new_continuation(block)
+                        } else {
+                            cell.first_block_committed = true;
+                            AgentCell::new(block)
+                        };
+                        self.committed_cells.push(HistoryCell::Agent(agent_cell));
                     }
                 }
             }
         }
         // Flush any remaining partial block in the collector.
         if let Some(cell) = &mut self.active_cell {
-            if let Some(block) = cell.block_collector.finalize() {
-                self.committed_cells
-                    .push(HistoryCell::Agent(AgentCell::new(block)));
+            let agent_cell_opt = cell.block_collector.finalize().map(|block| {
+                if cell.first_block_committed {
+                    AgentCell::new_continuation(block)
+                } else {
+                    cell.first_block_committed = true;
+                    AgentCell::new(block)
+                }
+            });
+            if let Some(agent_cell) = agent_cell_opt {
+                self.committed_cells.push(HistoryCell::Agent(agent_cell));
             }
         }
 
@@ -577,15 +605,19 @@ impl ChatWidget {
                 }
                 // Reuse the active cell cache when possible to avoid redundant
                 // markdown re-parsing.
+                let is_cont = self
+                    .active_cell
+                    .as_ref()
+                    .is_some_and(|c| c.first_block_committed);
                 let h = if let Some(cache) = self.active_cell_cache.as_ref() {
                     if cache.parsed_len == preview.len() && cache.parsed_width == width {
                         wrapped_row_count(&cache.lines, width).max(1)
                     } else {
-                        let lines = crate::history::agent_cell::prefix_markdown_lines(&preview);
+                        let lines = active_cell_lines(&preview, width, is_cont);
                         wrapped_row_count(&lines, width).max(1)
                     }
                 } else {
-                    let lines = crate::history::agent_cell::prefix_markdown_lines(&preview);
+                    let lines = active_cell_lines(&preview, width, is_cont);
                     wrapped_row_count(&lines, width).max(1)
                 };
                 total = total.saturating_add(h);
@@ -723,7 +755,12 @@ impl ChatWidget {
                 .as_ref()
                 .is_none_or(|c| c.parsed_len != text_len || c.parsed_width != width);
             if needs_reparse {
-                let lines = active_cell_lines(active_preview.as_ref().unwrap(), width);
+                let is_continuation = self
+                    .active_cell
+                    .as_ref()
+                    .is_some_and(|c| c.first_block_committed);
+                let lines =
+                    active_cell_lines(active_preview.as_ref().unwrap(), width, is_continuation);
                 self.active_cell_cache = Some(ActiveCellCache {
                     parsed_len: text_len,
                     parsed_width: width,
@@ -1110,8 +1147,12 @@ impl Default for ChatWidget {
 ///
 /// Uses the same `eve> ` prefix/indent pattern as [`AgentCell`], with
 /// markdown formatting applied so styles appear live as the agent types.
-fn active_cell_lines(text: &str, _width: u16) -> Vec<Line<'static>> {
-    prefix_markdown_lines(text)
+fn active_cell_lines(text: &str, _width: u16, is_continuation: bool) -> Vec<Line<'static>> {
+    if is_continuation {
+        continuation_markdown_lines(text)
+    } else {
+        prefix_markdown_lines(text)
+    }
 }
 
 /// Iterator that splits a string at newline boundaries, keeping the trailing

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -330,6 +330,45 @@ impl ChatWidget {
         }
     }
 
+    /// Return styled lines for in-progress tool calls in the active cell.
+    ///
+    /// Shows a single summary line for tool calls being executed, so the
+    /// user sees activity in the chat area during tool execution (not just
+    /// in the status bar).
+    fn active_tool_lines(&self) -> Vec<Line<'static>> {
+        let cell = match &self.active_cell {
+            Some(c) if !c.tool_calls.is_empty() => c,
+            _ => return Vec::new(),
+        };
+        let dim = Style::default().fg(self.theme_dim);
+        let accent = Style::default().fg(self.theme_accent);
+        let ok_color = Style::default().fg(ratatui::style::Color::Rgb(100, 200, 100));
+        let prefix_indent = "     "; // matches "eve> " width
+
+        let mut lines = Vec::new();
+        for tc in &cell.tool_calls {
+            let (icon, icon_style) = match tc.success {
+                Some(true) => ("\u{2713} ", ok_color), // ✓
+                Some(false) => (
+                    "\u{2717} ",
+                    Style::default().fg(ratatui::style::Color::Rgb(200, 100, 100)),
+                ),
+                None => ("\u{2022} ", accent), // • (running)
+            };
+            let dur = tc
+                .duration
+                .map(|d| format!(" {:.1}s", d.as_secs_f64()))
+                .unwrap_or_default();
+            lines.push(Line::from(vec![
+                Span::raw(prefix_indent.to_owned()),
+                Span::styled(icon.to_owned(), icon_style),
+                Span::styled(tc.tool_name.clone(), dim),
+                Span::styled(dur, dim),
+            ]));
+        }
+        lines
+    }
+
     /// Record a tool call starting in the active cell.
     ///
     /// If no turn is active, this is a no-op.
@@ -835,6 +874,30 @@ impl ChatWidget {
 
                 active_cell_rows = visible_rows;
                 remaining_rows -= visible_rows;
+            }
+        }
+
+        // ── In-progress tool call indicators ─────────────────────────
+        // Show active tool calls below committed cells but above the
+        // streaming text, so users see tool activity in the chat area.
+        if !self.scroll_locked {
+            let tool_lines = self.active_tool_lines();
+            let tool_rows = tool_lines.len() as u16;
+            if tool_rows > 0 && remaining_rows > 0 {
+                let usable = tool_rows.min(remaining_rows);
+                let tool_y = bottom_y - active_cell_rows - usable;
+                let tool_area = Rect {
+                    x: area.x,
+                    y: tool_y,
+                    width: area.width,
+                    height: usable,
+                };
+                // Only show the last `usable` lines if there are more tools than rows.
+                let skip = tool_lines.len().saturating_sub(usable as usize);
+                let visible_lines: Vec<Line<'_>> = tool_lines.into_iter().skip(skip).collect();
+                Paragraph::new(visible_lines).render(tool_area, buf);
+                active_cell_rows += usable;
+                remaining_rows -= usable;
             }
         }
 

--- a/crates/genesis-tui/src/widgets/command_popup.rs
+++ b/crates/genesis-tui/src/widgets/command_popup.rs
@@ -161,15 +161,36 @@ impl CommandPopup {
     }
 
     /// Recompute `filtered` and clamp `selected`.
+    ///
+    /// Uses subsequence (fuzzy) matching: query characters must appear in
+    /// order but need not be contiguous. Exact prefix matches sort first,
+    /// then substring matches, then fuzzy matches.
     fn refilter(&mut self) {
         let q = self.query.to_lowercase();
-        self.filtered = self
-            .commands
-            .iter()
-            .enumerate()
-            .filter(|(_, cmd)| cmd.name.to_lowercase().contains(&q))
-            .map(|(i, _)| i)
-            .collect();
+        if q.is_empty() {
+            self.filtered = (0..self.commands.len()).collect();
+        } else {
+            // Score: 0 = prefix, 1 = substring, 2 = fuzzy subsequence
+            let mut scored: Vec<(usize, u8)> = self
+                .commands
+                .iter()
+                .enumerate()
+                .filter_map(|(i, cmd)| {
+                    let name = cmd.name.to_lowercase();
+                    if name.starts_with(&q) {
+                        Some((i, 0))
+                    } else if name.contains(&q) {
+                        Some((i, 1))
+                    } else if fuzzy_subsequence(&name, &q) {
+                        Some((i, 2))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            scored.sort_by_key(|&(_, score)| score);
+            self.filtered = scored.into_iter().map(|(i, _)| i).collect();
+        }
         // Clamp selection so it stays in bounds.
         if self.filtered.is_empty() {
             self.selected = 0;
@@ -424,6 +445,17 @@ fn truncate_str(s: &str, max_chars: usize) -> String {
         let truncated: String = s.chars().take(max_chars - 1).collect();
         format!("{}…", truncated)
     }
+}
+
+/// Check whether `query` is a subsequence of `haystack` (all chars appear in order).
+fn fuzzy_subsequence(haystack: &str, query: &str) -> bool {
+    let mut haystack_chars = haystack.chars();
+    for qc in query.chars() {
+        if !haystack_chars.any(|hc| hc == qc) {
+            return false;
+        }
+    }
+    true
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────

--- a/crates/genesis-tui/src/widgets/help_overlay.rs
+++ b/crates/genesis-tui/src/widgets/help_overlay.rs
@@ -93,6 +93,7 @@ impl HelpOverlay {
             ("Ctrl+Right", "Move cursor to next word"),
             ("Home/Ctrl+A", "Move cursor to start of line"),
             ("End/Ctrl+E", "Move cursor to end of line"),
+            ("Ctrl+B/F", "Move cursor left/right (Emacs)"),
             ("Ctrl+K", "Delete to end of line (fill kill buffer)"),
             ("Ctrl+U", "Delete to start of line (fill kill buffer)"),
             ("Ctrl+W", "Delete word backward (fill kill buffer)"),

--- a/crates/genesis-tui/src/widgets/input_widget.rs
+++ b/crates/genesis-tui/src/widgets/input_widget.rs
@@ -324,8 +324,8 @@ impl InputWidget {
             }
 
             // ── Up/Down: line navigation when multi-line, history when single-line
-            // Ctrl+P — previous (Emacs)
-            (KeyCode::Char('p'), KeyModifiers::CONTROL) | (KeyCode::Up, _) => {
+            // (Ctrl+P/N are NOT aliased here — Ctrl+P is the command palette.)
+            (KeyCode::Up, _) => {
                 if self.is_multiline() {
                     self.move_cursor_up();
                 } else {
@@ -334,8 +334,7 @@ impl InputWidget {
                 InputAction::None
             }
 
-            // Ctrl+N — next (Emacs)
-            (KeyCode::Char('n'), KeyModifiers::CONTROL) | (KeyCode::Down, _) => {
+            (KeyCode::Down, _) => {
                 if self.is_multiline() {
                     self.move_cursor_down();
                 } else {

--- a/crates/genesis-tui/src/widgets/input_widget.rs
+++ b/crates/genesis-tui/src/widgets/input_widget.rs
@@ -282,12 +282,14 @@ impl InputWidget {
                 InputAction::None
             }
 
-            (KeyCode::Left, _) => {
+            // Ctrl+B — backward char (Emacs)
+            (KeyCode::Char('b'), KeyModifiers::CONTROL) | (KeyCode::Left, _) => {
                 self.move_cursor_left();
                 InputAction::None
             }
 
-            (KeyCode::Right, _) => {
+            // Ctrl+F — forward char (Emacs)
+            (KeyCode::Char('f'), KeyModifiers::CONTROL) | (KeyCode::Right, _) => {
                 self.move_cursor_right();
                 InputAction::None
             }
@@ -322,7 +324,8 @@ impl InputWidget {
             }
 
             // ── Up/Down: line navigation when multi-line, history when single-line
-            (KeyCode::Up, _) => {
+            // Ctrl+P — previous (Emacs)
+            (KeyCode::Char('p'), KeyModifiers::CONTROL) | (KeyCode::Up, _) => {
                 if self.is_multiline() {
                     self.move_cursor_up();
                 } else {
@@ -331,7 +334,8 @@ impl InputWidget {
                 InputAction::None
             }
 
-            (KeyCode::Down, _) => {
+            // Ctrl+N — next (Emacs)
+            (KeyCode::Char('n'), KeyModifiers::CONTROL) | (KeyCode::Down, _) => {
                 if self.is_multiline() {
                     self.move_cursor_down();
                 } else {

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
@@ -24,6 +24,7 @@ expression: buffer_to_string(&buf)
   Ctrl+Right      Move cursor to next word                  
   Home/Ctrl+A     Move cursor to start of line              
   End/Ctrl+E      Move cursor to end of line                
+  Ctrl+B/F        Move cursor left/right (Emacs)            
   Ctrl+K          Delete to end of line (fill kill buffer)  
   Ctrl+U          Delete to start of line (fill kill buffer)
   Ctrl+W          Delete word backward (fill kill buffer)   
@@ -55,5 +56,4 @@ expression: buffer_to_string(&buf)
   ─────────────────                                         
   j / Down        Scroll down one line                      
   k / Up          Scroll up one line                        
-  Ctrl+D          Scroll down half page                     
-  Ctrl+U          Scroll up half page
+  Ctrl+D          Scroll down half page

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_streaming_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_streaming_status_bar.snap
@@ -2,4 +2,4 @@
 source: crates/genesis-tui/src/widgets/status_bar.rs
 expression: spans_text
 ---
-◆ [Act] gpt-4o · 42%   streaming 256 tok   ⎇ main
+◆ [Act] gpt-4o · 42%   streaming 256 tok  · esc to interrupt  ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_streaming_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_streaming_status_bar.snap
@@ -2,4 +2,4 @@
 source: crates/genesis-tui/src/widgets/status_bar.rs
 expression: spans_text
 ---
-◆ [Act] gpt-4o · 42%   streaming 256 tok  · esc to interrupt  ⎇ main
+◆ [Act] gpt-4o · 42%   streaming 256 tok  · ctrl+c to interrupt  ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_thinking_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_thinking_status_bar.snap
@@ -2,4 +2,4 @@
 source: crates/genesis-tui/src/widgets/status_bar.rs
 expression: spans_text
 ---
-◆ [Act] gpt-4o · 42%   (~'.')~ thinking  · esc to interrupt  ⎇ main
+◆ [Act] gpt-4o · 42%   (~'.')~ thinking  · ctrl+c to interrupt  ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_thinking_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_thinking_status_bar.snap
@@ -2,4 +2,4 @@
 source: crates/genesis-tui/src/widgets/status_bar.rs
 expression: spans_text
 ---
-◆ [Act] gpt-4o · 42%   (~'.')~ thinking   ⎇ main
+◆ [Act] gpt-4o · 42%   (~'.')~ thinking  · esc to interrupt  ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_tool_running_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_tool_running_status_bar.snap
@@ -2,4 +2,4 @@
 source: crates/genesis-tui/src/widgets/status_bar.rs
 expression: spans_text
 ---
-◆ [Act] gpt-4o · 42%   shell_exec  · esc to interrupt  ⎇ main
+◆ [Act] gpt-4o · 42%   shell_exec  · ctrl+c to interrupt  ⎇ main

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_tool_running_status_bar.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__status_bar__tests__snapshot_tool_running_status_bar.snap
@@ -2,4 +2,4 @@
 source: crates/genesis-tui/src/widgets/status_bar.rs
 expression: spans_text
 ---
-◆ [Act] gpt-4o · 42%   shell_exec   ⎇ main
+◆ [Act] gpt-4o · 42%   shell_exec  · esc to interrupt  ⎇ main

--- a/crates/genesis-tui/src/widgets/status_bar.rs
+++ b/crates/genesis-tui/src/widgets/status_bar.rs
@@ -569,18 +569,34 @@ impl StatusBarWidget {
                     SHIMMER_HIGHLIGHT,
                     bg,
                 ));
+                spans.push(Span::styled(
+                    " \u{00b7} esc to interrupt",
+                    Style::default().fg(DIM_TEXT).bg(bg),
+                ));
                 spans
             }
 
             StatusState::ToolRunning { tool_name } => {
                 let elapsed = self.format_elapsed();
-                let text = format!(" {} {}", tool_name, elapsed);
-                shimmer_spans(&text, self.shimmer_phase, DIM_TEXT, SHIMMER_HIGHLIGHT, bg)
+                let text = format!(" {} {elapsed}", tool_name);
+                let mut spans =
+                    shimmer_spans(&text, self.shimmer_phase, DIM_TEXT, SHIMMER_HIGHLIGHT, bg);
+                spans.push(Span::styled(
+                    " \u{00b7} esc to interrupt",
+                    Style::default().fg(DIM_TEXT).bg(bg),
+                ));
+                spans
             }
 
             StatusState::Streaming { tokens } => {
                 let text = format!(" streaming {} tok ", tokens);
-                shimmer_spans(&text, self.shimmer_phase, DIM_TEXT, SHIMMER_HIGHLIGHT, bg)
+                let mut spans =
+                    shimmer_spans(&text, self.shimmer_phase, DIM_TEXT, SHIMMER_HIGHLIGHT, bg);
+                spans.push(Span::styled(
+                    " \u{00b7} esc to interrupt",
+                    Style::default().fg(DIM_TEXT).bg(bg),
+                ));
+                spans
             }
         }
     }

--- a/crates/genesis-tui/src/widgets/status_bar.rs
+++ b/crates/genesis-tui/src/widgets/status_bar.rs
@@ -570,7 +570,7 @@ impl StatusBarWidget {
                     bg,
                 ));
                 spans.push(Span::styled(
-                    " \u{00b7} esc to interrupt",
+                    " \u{00b7} ctrl+c to interrupt",
                     Style::default().fg(DIM_TEXT).bg(bg),
                 ));
                 spans
@@ -582,7 +582,7 @@ impl StatusBarWidget {
                 let mut spans =
                     shimmer_spans(&text, self.shimmer_phase, DIM_TEXT, SHIMMER_HIGHLIGHT, bg);
                 spans.push(Span::styled(
-                    " \u{00b7} esc to interrupt",
+                    " \u{00b7} ctrl+c to interrupt",
                     Style::default().fg(DIM_TEXT).bg(bg),
                 ));
                 spans
@@ -593,7 +593,7 @@ impl StatusBarWidget {
                 let mut spans =
                     shimmer_spans(&text, self.shimmer_phase, DIM_TEXT, SHIMMER_HIGHLIGHT, bg);
                 spans.push(Span::styled(
-                    " \u{00b7} esc to interrupt",
+                    " \u{00b7} ctrl+c to interrupt",
                     Style::default().fg(DIM_TEXT).bg(bg),
                 ));
                 spans


### PR DESCRIPTION
## Summary

Ten TUI fixes across rendering, scrolling, block splitting, status bar, and UX polish:

### Rendering
1. **eve> prefix spam** — Only first block of agent turn shows `eve>` prefix; subsequent blocks use matching-width indent
2. **Empty continuation cell height** — Returns 0 instead of 1 for empty continuation cells

### Scrolling
3. **Can't scroll to see original input** — Collection budget includes scroll offset; `scroll_max` capped at `total - viewport_height`
4. **Scroll uses message area height** — Accurate clamping using actual message pane height, not full viewport
5. **Resize reclamp uses fresh dimensions** — Recomputes message_area_height before reclamping

### Block Splitting
6. **Lists/blockquotes preserved** — Auto-split detects list items and blockquotes, raises limit to 80 lines for structured blocks

### Status Bar
7. **"ctrl+c to interrupt" hint** — Shows during Thinking/ToolRunning/Streaming states with the correct shortcut

### UX Polish
8. **Overflow hint counts turns, not blocks** — "↑ 2 more" means 2 conversation turns, not 12 paragraph cells
9. **Tool names in collapsed summary** — Shows `▸ 3 tool calls: shell, read_file, grep (1.0s, all ok)` instead of hiding tool names
10. **(Auth, separate PR #418)** — Auto-reimport tokens from Codex CLI on refresh failure

## Test plan
- [x] 509 genesis-tui tests pass (6 new)
- [x] Clippy clean, full workspace builds
- [ ] Visual: `eve>` once per response
- [ ] Visual: PgUp reveals user's original message
- [ ] Visual: Collapsed tool groups show tool names
- [ ] Visual: "↑ N more" counts turns correctly