### PR TITLE
feat(tui): code block separators, tool output preview, context colors

### DIFF
--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -396,6 +396,10 @@ impl App {
                         let _ = self
                             .app_tx
                             .send(AppEvent::CopyToClipboard(text.to_string()));
+                        self.status_bar
+                            .show_transient_warning("\u{2713} Copied to clipboard");
+                    } else {
+                        self.status_bar.show_transient_warning("Nothing to copy");
                     }
                     self.frame_requester.schedule_frame();
                 }

--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -97,6 +97,9 @@ pub struct App {
     pub context_window_size: usize,
     /// Last known viewport width (used for transcript overlay).
     pub viewport_width: u16,
+    /// Whether mouse capture is active (true = scroll mode, false = select mode).
+    /// Toggled via Shift+M to allow terminal-native text selection.
+    pub mouse_captured: bool,
     /// Active tool approval overlay (shown when a tool needs user approval).
     pub approval: Option<crate::widgets::approval_overlay::ApprovalOverlay>,
     /// Channel to send approval responses back to the tool execution thread.
@@ -631,6 +634,25 @@ impl App {
             return;
         }
 
+        // Alt+M — toggle mouse capture (scroll mode vs select mode).
+        // When disabled, the terminal handles mouse events natively, allowing
+        // text selection in Alacritty, tmux, etc.
+        if key.code == KeyCode::Char('m') && key.modifiers.contains(KeyModifiers::ALT) {
+            self.mouse_captured = !self.mouse_captured;
+            if self.mouse_captured {
+                let _ =
+                    crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture);
+                self.status_bar.show_transient_warning("Mouse: scroll mode");
+            } else {
+                let _ =
+                    crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
+                self.status_bar
+                    .show_transient_warning("Mouse: select mode (Alt+M to restore scroll)");
+            }
+            self.frame_requester.schedule_frame();
+            return;
+        }
+
         // Ctrl+L — clear chat (same as /clear but via keyboard).
         if key.code == KeyCode::Char('l') && key.modifiers.contains(KeyModifiers::CONTROL) {
             self.chat = ChatWidget::new();
@@ -1038,6 +1060,7 @@ mod tests {
             streaming_chars: 0,
             context_window_size: 128_000,
             viewport_width: 80,
+            mouse_captured: true,
             approval: None,
             approval_response: None,
             approval_queue: std::collections::VecDeque::new(),

--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -362,6 +362,23 @@ impl ToolCell {
     /// Extract the first line of the output, truncated to `max_chars` characters.
     ///
     /// Returns `None` if there is no output or the first line is blank.
+    /// First non-blank line of output, truncated. Used as a brief preview
+    /// in Grouped mode for successful tools.
+    fn output_preview(&self, max_chars: usize) -> Option<String> {
+        let output = self.output.as_deref()?;
+        let first_line = output.lines().find(|l| !l.trim().is_empty())?;
+        let trimmed = first_line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if trimmed.chars().count() > max_chars {
+            let s: String = trimmed.chars().take(max_chars).collect();
+            Some(format!("{s}…"))
+        } else {
+            Some(trimmed.to_owned())
+        }
+    }
+
     fn error_context(&self, max_chars: usize) -> Option<String> {
         let output = self.output.as_deref()?;
         let first_line = output.lines().find(|l| !l.trim().is_empty())?;
@@ -431,7 +448,7 @@ impl ToolCell {
 
         lines.push(status_line);
 
-        // On failure, show a brief error reason (first line of output) if available.
+        // On failure, show a brief error reason; on success, show output preview.
         if !self.success {
             if let Some(reason) = self.error_context(60) {
                 let error_line = Line::from(vec![
@@ -444,6 +461,13 @@ impl ToolCell {
                 ]);
                 lines.push(error_line);
             }
+        } else if let Some(preview) = self.output_preview(55) {
+            let preview_line = Line::from(vec![
+                Span::styled("  │ ↳ ", Style::default().fg(UI_DIM)),
+                Span::styled(preview, Style::default().fg(Color::Rgb(120, 120, 120))),
+                Span::styled(" │", Style::default().fg(UI_DIM)),
+            ]);
+            lines.push(preview_line);
         }
 
         lines.push(bottom);
@@ -861,13 +885,26 @@ mod tests {
     }
 
     #[test]
-    fn grouped_success_with_output_no_error_context_line() {
+    fn grouped_success_with_output_shows_preview() {
         let cell = make_cell(true)
             .with_display_mode(ToolDisplayMode::Grouped)
             .with_output("some output");
         let lines = cell.to_scrollback_lines(80);
-        // success: error context is not shown even if there is output
-        assert_eq!(lines.len(), 4, "grouped success should remain 4 lines");
+        // Grouped success with output: top + content + status + preview + bottom = 5
+        assert_eq!(
+            lines.len(),
+            5,
+            "grouped success with output should be 5 lines (includes preview)"
+        );
+        let all_text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            all_text.contains("some output"),
+            "should show output preview: {all_text:?}"
+        );
     }
 
     #[test]
@@ -1011,11 +1048,11 @@ diff --git a/src/main.rs b/src/main.rs
             .with_display_mode(ToolDisplayMode::Grouped)
             .with_output("wrote 42 bytes to foo.txt");
         let lines = cell.to_scrollback_lines(80);
-        // Plain output should not expand — grouped mode uses per-category content only
+        // Grouped: top + content + status + output_preview + bottom = 5 lines
         assert_eq!(
             lines.len(),
-            4,
-            "grouped with plain output should be 4 lines"
+            5,
+            "grouped with plain output should be 5 lines (includes preview)"
         );
     }
 

--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -101,6 +101,17 @@ fn tool_category(name: &str) -> ToolCategory {
 /// Extract a file path from an args summary string.
 ///
 /// The summary typically looks like `path: "src/main.rs"` or just `src/main.rs`.
+/// Truncate a tool name to `max` characters with ellipsis if too long.
+/// MCP tool names can be very long (e.g. `mcp__plugin_playwright__browser_navigate`).
+fn truncate_tool_name(name: &str, max: usize) -> String {
+    if name.chars().count() <= max {
+        name.to_owned()
+    } else {
+        let truncated: String = name.chars().take(max - 1).collect();
+        format!("{truncated}\u{2026}") // …
+    }
+}
+
 fn extract_path(args_summary: &str) -> String {
     // Try to extract a quoted path first.
     if let Some(start) = args_summary.find('"') {
@@ -419,10 +430,12 @@ impl ToolCell {
         let (status_str, status_color) = self.status_str();
 
         // Top border: `  ┌─ tool_name ──...──┐`
+        // Truncate long tool names (MCP tools can be very long).
+        let display_name = truncate_tool_name(&self.tool_name, 40);
         let name_color = tool_color(&self.tool_name);
         let top = Line::from(vec![
             Span::styled("  ┌─ ", Style::default().fg(UI_DIM)),
-            Span::styled(self.tool_name.clone(), Style::default().fg(name_color)),
+            Span::styled(display_name.clone(), Style::default().fg(name_color)),
             Span::styled(" ─┐", Style::default().fg(UI_DIM)),
         ]);
 
@@ -439,7 +452,7 @@ impl ToolCell {
         ]);
 
         // Bottom border: `  └─ … ─┘` matching the top border width.
-        let fill_width = self.tool_name.width() + 2; // "─ " + name + " ─"
+        let fill_width = display_name.width() + 2; // "─ " + name + " ─"
         let bottom_fill = "─".repeat(fill_width);
         let bottom = Line::from(vec![Span::styled(
             format!("  └{}┘", bottom_fill),

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -246,6 +246,7 @@ pub async fn run_tui(
         streaming_chars: 0,
         context_window_size,
         viewport_width: viewport_area.width,
+        mouse_captured: true,
         approval: None,
         approval_response: None,
         approval_queue: std::collections::VecDeque::new(),

--- a/crates/genesis-tui/src/render/markdown.rs
+++ b/crates/genesis-tui/src/render/markdown.rs
@@ -307,7 +307,8 @@ impl MarkdownWriter {
             Event::End(TagEnd::CodeBlock) => {
                 if let Some((lang, code)) = self.code_block.take() {
                     // Emit language label line if the fence specified a language.
-                    if !lang.is_empty() {
+                    let has_label = !lang.is_empty();
+                    if has_label {
                         self.emit_code_lang_label(&lang);
                     }
 
@@ -321,6 +322,16 @@ impl MarkdownWriter {
                         }
                     } else {
                         self.lines.extend(highlighted);
+                    }
+
+                    // Bottom separator to visually close the code block.
+                    if has_label {
+                        let mut bottom_spans = Vec::new();
+                        if self.blockquote_depth > 0 {
+                            bottom_spans.extend(blockquote_prefix(self.blockquote_depth));
+                        }
+                        bottom_spans.push(Span::styled("─".repeat(60), Style::default().fg(DIM)));
+                        self.lines.push(Line::from(bottom_spans));
                     }
                 }
             }
@@ -848,11 +859,13 @@ mod tests {
         let md = "```rust\nlet x = 42;\n```";
         let lines = markdown_to_lines(md);
         assert!(
-            !lines.is_empty(),
-            "code fence should produce at least one line"
+            lines.len() >= 3,
+            "code fence should produce label + code + separator, got {}",
+            lines.len()
         );
-        // Skip the first line (language label) — only code lines have CODE_BG.
-        for line in lines.iter().skip(1) {
+        // Skip the first line (language label) and last line (bottom separator) —
+        // only the code lines between them have CODE_BG.
+        for line in lines.iter().skip(1).take(lines.len() - 2) {
             for span in &line.spans {
                 assert_eq!(
                     span.style.bg,

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -338,9 +338,9 @@ impl ChatWidget {
 
     /// Return styled lines for in-progress tool calls in the active cell.
     ///
-    /// Shows a single summary line for tool calls being executed, so the
-    /// user sees activity in the chat area during tool execution (not just
-    /// in the status bar).
+    /// Completed tools are collapsed into a compact summary line to avoid
+    /// filling the viewport when many tools run in a single turn. Only
+    /// currently-running tools are shown individually.
     fn active_tool_lines(&self) -> Vec<Line<'static>> {
         let cell = match &self.active_cell {
             Some(c) if !c.tool_calls.is_empty() => c,
@@ -349,29 +349,59 @@ impl ChatWidget {
         let dim = Style::default().fg(self.theme_dim);
         let accent = Style::default().fg(self.theme_accent);
         let ok_color = Style::default().fg(ratatui::style::Color::Rgb(100, 200, 100));
+        let fail_color = Style::default().fg(ratatui::style::Color::Rgb(200, 100, 100));
         let prefix_indent = "     "; // matches "eve> " width
 
-        let mut lines = Vec::new();
+        // Count completed vs running tools.
+        let mut done_ok = 0usize;
+        let mut done_fail = 0usize;
+        let mut total_dur = std::time::Duration::ZERO;
+        let mut running: Vec<&ActiveToolCall> = Vec::new();
+
         for tc in &cell.tool_calls {
-            let (icon, icon_style) = match tc.success {
-                Some(true) => ("\u{2713} ", ok_color), // ✓
-                Some(false) => (
-                    "\u{2717} ",
-                    Style::default().fg(ratatui::style::Color::Rgb(200, 100, 100)),
-                ),
-                None => ("\u{2022} ", accent), // • (running)
+            match tc.success {
+                Some(true) => {
+                    done_ok += 1;
+                    total_dur += tc.duration.unwrap_or_default();
+                }
+                Some(false) => {
+                    done_fail += 1;
+                    total_dur += tc.duration.unwrap_or_default();
+                }
+                None => running.push(tc),
+            }
+        }
+
+        let mut lines = Vec::new();
+
+        // Compact summary for completed tools (1 line max).
+        let done_total = done_ok + done_fail;
+        if done_total > 0 {
+            let dur_str = format!("{:.1}s", total_dur.as_secs_f64());
+            let (status, status_style) = if done_fail > 0 {
+                (format!("{done_fail} failed"), fail_color)
+            } else {
+                ("all ok".to_owned(), ok_color)
             };
-            let dur = tc
-                .duration
-                .map(|d| format!(" {:.1}s", d.as_secs_f64()))
-                .unwrap_or_default();
             lines.push(Line::from(vec![
                 Span::raw(prefix_indent.to_owned()),
-                Span::styled(icon.to_owned(), icon_style),
-                Span::styled(tc.tool_name.clone(), dim),
-                Span::styled(dur, dim),
+                Span::styled("\u{25b8} ", ok_color), // ▸
+                Span::styled(format!("{done_total} tool calls"), dim),
+                Span::styled(format!(" ({dur_str}, "), dim),
+                Span::styled(status, status_style),
+                Span::styled(")", dim),
             ]));
         }
+
+        // Individual lines for running tools.
+        for tc in running {
+            lines.push(Line::from(vec![
+                Span::raw(prefix_indent.to_owned()),
+                Span::styled("\u{2022} ", accent), // •
+                Span::styled(tc.tool_name.clone(), dim),
+            ]));
+        }
+
         lines
     }
 

--- a/crates/genesis-tui/src/widgets/command_popup.rs
+++ b/crates/genesis-tui/src/widgets/command_popup.rs
@@ -339,7 +339,7 @@ impl CommandPopup {
             let row_y = popup_y + 1 + row_idx as u16;
 
             // Build the row content as a Line and render it.
-            let line = build_item_line(cmd, is_selected, inner_width);
+            let line = build_item_line(cmd, is_selected, inner_width, &self.query);
             let mut x = popup_x + 1;
             for span in &line.spans {
                 let style = span.style;
@@ -386,7 +386,13 @@ impl Default for CommandPopup {
 ///
 /// Layout: `  /name      description…`
 /// Selected row has a coloured background and the `>` indicator.
-fn build_item_line(cmd: &CommandDef, is_selected: bool, inner_width: usize) -> Line<'static> {
+/// Matching query characters in the name are highlighted with bold.
+fn build_item_line(
+    cmd: &CommandDef,
+    is_selected: bool,
+    inner_width: usize,
+    query: &str,
+) -> Line<'static> {
     // Indicator: "> " for selected, "  " otherwise.
     let indicator = if is_selected { "> " } else { "  " };
 
@@ -398,19 +404,25 @@ fn build_item_line(cmd: &CommandDef, is_selected: bool, inner_width: usize) -> L
         Style::default().fg(INDICATOR_FG)
     };
 
-    let name = cmd.name;
-    // Fixed name column width. render() clamps popup_width >= 20, so
-    // inner_width is always >= 18 — no need for narrow-terminal shrinking.
     let name_col_width = 14usize;
-    let name_padded = format!("{:<width$}", name, width = name_col_width);
 
-    let name_style = if is_selected {
+    let name_base = if is_selected {
         Style::default()
             .fg(SELECTED_TEXT_FG)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(NAME_FG)
     };
+    let name_match = if is_selected {
+        name_base
+    } else {
+        Style::default()
+            .fg(SELECTED_TEXT_FG)
+            .add_modifier(Modifier::BOLD)
+    };
+
+    // Build name spans with match highlighting.
+    let name_spans = highlight_matches(cmd.name, query, name_col_width, name_base, name_match);
 
     let desc_style = if is_selected {
         Style::default().fg(SELECTED_TEXT_FG)
@@ -423,11 +435,86 @@ fn build_item_line(cmd: &CommandDef, is_selected: bool, inner_width: usize) -> L
     let desc_width = inner_width.saturating_sub(used);
     let desc = truncate_str(cmd.description, desc_width);
 
-    Line::from(vec![
-        Span::styled(indicator.to_owned(), indicator_style),
-        Span::styled(name_padded, name_style),
-        Span::styled(desc, desc_style),
-    ])
+    let mut spans = vec![Span::styled(indicator.to_owned(), indicator_style)];
+    spans.extend(name_spans);
+    spans.push(Span::styled(desc, desc_style));
+    Line::from(spans)
+}
+
+/// Highlight characters in `name` that match the `query` subsequence.
+/// Returns spans padded to `col_width`.
+fn highlight_matches(
+    name: &str,
+    query: &str,
+    col_width: usize,
+    base_style: Style,
+    match_style: Style,
+) -> Vec<Span<'static>> {
+    if query.is_empty() {
+        return vec![Span::styled(
+            format!("{:<width$}", name, width = col_width),
+            base_style,
+        )];
+    }
+
+    let name_lower = name.to_lowercase();
+    let query_lower = query.to_lowercase();
+
+    // Find match positions (greedy subsequence).
+    let mut match_positions = Vec::new();
+    let mut qi = 0;
+    let query_chars: Vec<char> = query_lower.chars().collect();
+    for (i, ch) in name_lower.chars().enumerate() {
+        if qi < query_chars.len() && ch == query_chars[qi] {
+            match_positions.push(i);
+            qi += 1;
+        }
+    }
+
+    let match_set: std::collections::HashSet<usize> = match_positions.into_iter().collect();
+    let mut spans = Vec::new();
+    let mut current = String::new();
+    let mut current_is_match = false;
+
+    for (i, ch) in name.chars().enumerate() {
+        let is_match = match_set.contains(&i);
+        if is_match != current_is_match && !current.is_empty() {
+            let style = if current_is_match {
+                match_style
+            } else {
+                base_style
+            };
+            spans.push(Span::styled(std::mem::take(&mut current), style));
+        }
+        current.push(ch);
+        current_is_match = is_match;
+    }
+
+    // Pad to column width.
+    let name_len = name.chars().count();
+    if name_len < col_width {
+        let padding = col_width - name_len;
+        if !current_is_match {
+            current.extend(std::iter::repeat_n(' ', padding));
+        } else {
+            // Flush current match span, then add padding as base.
+            if !current.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut current), match_style));
+            }
+            current = " ".repeat(padding);
+            current_is_match = false;
+        }
+    }
+    if !current.is_empty() {
+        let style = if current_is_match {
+            match_style
+        } else {
+            base_style
+        };
+        spans.push(Span::styled(current, style));
+    }
+
+    spans
 }
 
 /// Truncate a string to at most `max_chars` Unicode scalar values.

--- a/crates/genesis-tui/src/widgets/help_overlay.rs
+++ b/crates/genesis-tui/src/widgets/help_overlay.rs
@@ -105,6 +105,7 @@ impl HelpOverlay {
             ("Shift+Down", "Scroll chat down (1 line)"),
             ("Ctrl+End", "Jump to bottom of chat"),
             ("Up/Down", "Navigate input history / lines"),
+            ("Alt+M", "Toggle mouse: scroll ↔ select text"),
             ("Esc", "Close overlay / dismiss popup"),
         ];
 

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
@@ -36,6 +36,7 @@ expression: buffer_to_string(&buf)
   Shift+Down      Scroll chat down (1 line)                 
   Ctrl+End        Jump to bottom of chat                    
   Up/Down         Navigate input history / lines            
+  Alt+M           Toggle mouse: scroll ↔ select text        
   Esc             Close overlay / dismiss popup             
                                                             
   Slash Commands                                            
@@ -55,5 +56,4 @@ expression: buffer_to_string(&buf)
   Overlay Navigation                                        
   ─────────────────                                         
   j / Down        Scroll down one line                      
-  k / Up          Scroll up one line                        
-  Ctrl+D          Scroll down half page
+  k / Up          Scroll up one line

--- a/crates/genesis-tui/src/widgets/status_bar.rs
+++ b/crates/genesis-tui/src/widgets/status_bar.rs
@@ -529,8 +529,10 @@ impl StatusBarWidget {
             Color::Rgb(255, 100, 100) // red — critical
         } else if self.context_percent >= 75 {
             Color::Rgb(255, 200, 80) // yellow — warning
+        } else if self.context_percent <= 50 {
+            Color::Rgb(100, 200, 100) // green — healthy
         } else {
-            self.palette.dim
+            self.palette.dim // neutral (51-74%)
         };
         spans.push(Span::styled(ctx, Style::default().fg(ctx_color).bg(bg)));
 


### PR DESCRIPTION
## Summary

Eight TUI polish improvements in one PR:

### Visual Polish
1. **Code block bottom separator** — `───` line below fenced code blocks with language labels
2. **Tool output preview** — Grouped mode shows `↳ first line…` for successful tools
3. **Context % green indicator** — Green (≤50%), neutral (51-74%), yellow (75%+), red (90%+)
4. **Command popup match highlighting** — Matching characters shown in bold during fuzzy search

### UX Improvements
5. **Compact tool indicators** — Completed tools summarized as `▸ 28 tool calls (0.5s, all ok)`, only running tool shown individually. Fixes viewport flooding with 30+ tool lines.
6. **Alt+M mouse toggle** — Switch between scroll mode and select mode for text selection in Alacritty/tmux
7. **/copy visual feedback** — Status bar shows "✓ Copied to clipboard" or "Nothing to copy"
8. **Long tool name truncation** — MCP tool names capped at 40 chars with ellipsis in bordered cells

## Test plan
- [x] All 509 genesis-tui tests pass
- [x] Clippy clean
- [ ] Visual: code blocks have clean boundaries
- [ ] Visual: tool indicators stay compact with many tools
- [ ] Visual: Alt+M enables text selection
- [ ] Visual: /copy shows confirmation
- [ ] Visual: fuzzy search highlights matching chars