### PR TITLE
refactor(core): deduplicate agent loop tool pipeline, decompose build_agent_loop

### DIFF
--- a/crates/genesis-core/src/agent_loop/mod.rs
+++ b/crates/genesis-core/src/agent_loop/mod.rs
@@ -1139,6 +1139,7 @@ impl AgentLoop {
     ///
     /// Returns `Some(question)` when a tool requests user clarification,
     /// signalling the caller to pause the agent loop.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn process_tool_results<F>(
         &mut self,
         session_id: &str,

--- a/crates/genesis-core/src/agent_loop/mod.rs
+++ b/crates/genesis-core/src/agent_loop/mod.rs
@@ -79,9 +79,6 @@ pub struct AgentLoop {
     /// Tools discovered via `find_tools` during this session. These are added
     /// to the core set for subsequent LLM requests.
     pub(crate) discovered_tools: HashSet<String>,
-    /// Whether a stuck-loop nudge has been sent during this user turn.
-    /// Cleared at the start of each new turn so the agent gets a fresh chance.
-    pub(crate) nudge_sent: bool,
 }
 
 impl AgentLoop {
@@ -152,7 +149,6 @@ impl AgentLoop {
             cache_misses: 0,
             compiled_guardrails,
             discovered_tools: HashSet::new(),
-            nudge_sent: false,
         }
     }
 
@@ -547,7 +543,6 @@ impl AgentLoop {
         // Reset stuck-loop state at the start of each new user turn so
         // stale failure counts from a previous turn don't cause false positives.
         self.tool_failure_counts.clear();
-        self.nudge_sent = false;
         self.tools.clear_recalled_memory_ids();
 
         // Record turn-level span attributes via tracing events rather than
@@ -1126,7 +1121,6 @@ impl AgentLoop {
             self.tool_failure_counts.remove(tool);
         }
 
-        self.nudge_sent = true;
         let tools_list = stuck_tools.join(", ");
         let nudge = format!(
             "[Stuck loop detected] The tool(s) {tools_list} have failed multiple times in a row. \
@@ -1697,10 +1691,6 @@ tools = [{tools_list}]
             initial_len,
             "no nudge below threshold"
         );
-        assert!(
-            !agent.nudge_sent,
-            "nudge_sent should be false below threshold"
-        );
 
         // Simulate 5 failures — should trigger at default threshold
         agent.tool_failure_counts.insert("web_search".to_owned(), 5);
@@ -1713,7 +1703,6 @@ tools = [{tools_list}]
         let last = agent.messages().last().unwrap();
         assert!(last.content_text().unwrap().contains("Stuck loop"));
         assert!(last.content_text().unwrap().contains("web_search"));
-        assert!(agent.nudge_sent, "nudge_sent should be true after nudge");
 
         // Counter should be cleared, so next check shouldn't nudge again
         agent.maybe_inject_stuck_nudge();
@@ -1743,7 +1732,6 @@ tools = [{tools_list}]
             initial_len + 1,
             "nudge injected at custom threshold"
         );
-        assert!(agent.nudge_sent);
     }
 
     #[test]
@@ -1766,22 +1754,16 @@ tools = [{tools_list}]
         // Simulate a stuck-loop nudge was sent in a previous turn
         agent.tool_failure_counts.insert("web_search".to_owned(), 5);
         agent.maybe_inject_stuck_nudge();
-        assert!(agent.nudge_sent);
         // Add some leftover failure counts that weren't cleared by the nudge
         agent.tool_failure_counts.insert("read_file".to_owned(), 2);
         assert!(!agent.tool_failure_counts.is_empty());
 
         // Simulate what run_turn_with_images does at the start of a new turn
         agent.tool_failure_counts.clear();
-        agent.nudge_sent = false;
 
         assert!(
             agent.tool_failure_counts.is_empty(),
             "failure counts should be cleared on new turn"
-        );
-        assert!(
-            !agent.nudge_sent,
-            "nudge_sent should be cleared on new turn"
         );
     }
 

--- a/crates/genesis-core/src/agent_loop/mod.rs
+++ b/crates/genesis-core/src/agent_loop/mod.rs
@@ -32,6 +32,7 @@ use genesis_lua::hooks::PreHookOutcome;
 use genesis_lua::LuaRuntime;
 
 use tools::execute_tool_calls_parallel;
+pub(crate) use tools::is_tool_error;
 use types::{format_blocked_reasons, MEMORY_NUDGE, SKILL_CREATION_THRESHOLD};
 
 /// The core agent loop that wires provider (LLM) and tool execution together.
@@ -1206,6 +1207,110 @@ impl AgentLoop {
              (4) asking the user for clarification."
         );
         let _ = self.push_message_with_lua_hooks(&hook_session, ChatMessage::system(&nudge));
+    }
+
+    /// Unified tool-result processing pipeline.
+    ///
+    /// This replaces three copy-pasted loops (blocking, streaming-success,
+    /// streaming-fallback) with a single method. All hooks, discovery, failure
+    /// tracking, trajectory recording, and event emission happen here.
+    ///
+    /// Returns `Some(question)` when a tool requests user clarification,
+    /// signalling the caller to pause the agent loop.
+    pub(crate) fn process_tool_results<F>(
+        &mut self,
+        session_id: &str,
+        effective_tool_calls: &[ToolCallEntry],
+        veto_reasons: Vec<Option<String>>,
+        executed_results: Vec<(String, bool)>,
+        tool_elapsed_ms: u64,
+        is_streaming: bool,
+        mut on_event: F,
+    ) -> Option<String>
+    where
+        F: FnMut(StreamEvent<'_>),
+    {
+        let mut executed_results = executed_results.into_iter();
+        let mut clarification = None;
+        for (tc, veto_reason) in effective_tool_calls.iter().zip(veto_reasons.into_iter()) {
+            let lua_vetoed = veto_reason.is_some();
+            let (mut result, requires_input) = match veto_reason {
+                Some(reason) => (
+                    format!("Error: tool call blocked by Lua hook: {reason}"),
+                    false,
+                ),
+                None => executed_results
+                    .next()
+                    .expect("executed tool results should align with allowed calls"),
+            };
+            result = sanitize::sanitize_credentials(&result);
+            // When find_tools returns results and core set filtering is active,
+            // extract discovered tool names and add them to the active set.
+            if self.config.core_tools.is_some()
+                && tc.function.name == "find_tools"
+                && !tools::is_tool_error(&result)
+                && !tools::is_find_tools_empty(&result)
+            {
+                for line in result.lines() {
+                    let trimmed = line.trim();
+                    // find_tools output format: "  **tool_name** — description"
+                    if let Some(rest) = trimmed.strip_prefix("**") {
+                        if let Some(name_end) = rest.find("**") {
+                            self.discover_tool(&rest[..name_end]);
+                        }
+                    }
+                }
+            }
+
+            let success = !tools::is_tool_error(&result);
+            if success && self.config.core_tools.is_some() {
+                // Auto-discover tools called outside the core set.
+                self.discover_tool(&tc.function.name);
+            }
+            let result = self.run_lua_post_tool_call(&tc.function.name, &result);
+            if !success {
+                let count = self
+                    .tool_failure_counts
+                    .entry(tc.function.name.clone())
+                    .or_insert(0);
+                *count += 1;
+            } else {
+                self.tool_failure_counts.remove(&tc.function.name);
+            }
+            self.hooks
+                .on_tool_call_end(session_id, &tc.function.name, success, tool_elapsed_ms);
+            on_event(StreamEvent::ToolCallEnd {
+                name: &tc.function.name,
+                call_id: &tc.id,
+                duration_ms: tool_elapsed_ms,
+                success,
+            });
+            self.fire_shell_hooks(
+                HookEvent::PostToolCall,
+                serde_json::json!({
+                    "session_id": session_id,
+                    "tool_name": tc.function.name,
+                    "tool_call_id": tc.id,
+                    "success": success,
+                    "result": result,
+                    "requires_input": requires_input,
+                    "streaming": is_streaming,
+                    "duration_ms": tool_elapsed_ms,
+                    "lua_vetoed": lua_vetoed,
+                }),
+            );
+            let result = self
+                .push_message_with_lua_hooks(session_id, ChatMessage::tool_result(&tc.id, result))
+                .and_then(|message| message.content_text().map(str::to_owned))
+                .unwrap_or_default();
+            self.trajectory
+                .record_tool_result(&tc.function.name, &result);
+            if requires_input {
+                on_event(StreamEvent::ClarificationNeeded { question: &result });
+                clarification = Some(result.clone());
+            }
+        }
+        clarification
     }
 
     /// Save the trajectory to disk if a trajectory directory is configured.

--- a/crates/genesis-core/src/agent_loop/mod.rs
+++ b/crates/genesis-core/src/agent_loop/mod.rs
@@ -1139,6 +1139,13 @@ impl AgentLoop {
     ///
     /// Returns `Some(question)` when a tool requests user clarification,
     /// signalling the caller to pause the agent loop.
+    ///
+    /// # Arguments
+    ///
+    /// * `executed_results` — must contain exactly one entry per `None` in
+    ///   `veto_reasons` (i.e. one result per non-vetoed tool call).
+    /// * `tool_elapsed_ms` — wall-clock duration of the entire parallel batch,
+    ///   not per-tool timing. All tools in the batch report this same value.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn process_tool_results<F>(
         &mut self,
@@ -1153,6 +1160,11 @@ impl AgentLoop {
     where
         F: FnMut(StreamEvent<'_>),
     {
+        debug_assert_eq!(
+            veto_reasons.iter().filter(|v| v.is_none()).count(),
+            executed_results.len(),
+            "executed_results must have one entry per non-vetoed tool call"
+        );
         let mut executed_results = executed_results.into_iter();
         let mut clarification = None;
         for (tc, veto_reason) in effective_tool_calls.iter().zip(veto_reasons.into_iter()) {

--- a/crates/genesis-core/src/agent_loop/mod.rs
+++ b/crates/genesis-core/src/agent_loop/mod.rs
@@ -983,87 +983,15 @@ impl AgentLoop {
                     };
                     let tool_elapsed_ms = tool_start.elapsed().as_millis() as u64;
 
-                    let mut executed_results = executed_results.into_iter();
-                    let mut clarification = None;
-                    for (tc, veto_reason) in
-                        effective_tool_calls.iter().zip(veto_reasons.into_iter())
-                    {
-                        let lua_vetoed = veto_reason.is_some();
-                        let (mut result, requires_input) = match veto_reason {
-                            Some(reason) => (
-                                format!("Error: tool call blocked by Lua hook: {reason}"),
-                                false,
-                            ),
-                            None => executed_results
-                                .next()
-                                .expect("executed tool results should align with allowed calls"),
-                        };
-                        result = sanitize::sanitize_credentials(&result);
-                        // When find_tools returns results and core set filtering is active,
-                        // extract discovered tool names and add them to the active set.
-                        if self.config.core_tools.is_some()
-                            && tc.function.name == "find_tools"
-                            && !result.starts_with("Error:")
-                            && !result.starts_with("No tools")
-                        {
-                            for line in result.lines() {
-                                let trimmed = line.trim();
-                                // find_tools output format: "  **tool_name** — description"
-                                if let Some(rest) = trimmed.strip_prefix("**") {
-                                    if let Some(name_end) = rest.find("**") {
-                                        self.discover_tool(&rest[..name_end]);
-                                    }
-                                }
-                            }
-                        }
-
-                        let success = !result.starts_with("Error:");
-                        if success && self.config.core_tools.is_some() {
-                            // Auto-discover tools called outside the core set.
-                            self.discover_tool(&tc.function.name);
-                        }
-                        let result = self.run_lua_post_tool_call(&tc.function.name, &result);
-                        if !success {
-                            let count = self
-                                .tool_failure_counts
-                                .entry(tc.function.name.clone())
-                                .or_insert(0);
-                            *count += 1;
-                        } else {
-                            self.tool_failure_counts.remove(&tc.function.name);
-                        }
-                        self.hooks.on_tool_call_end(
-                            &hook_session,
-                            &tc.function.name,
-                            success,
-                            tool_elapsed_ms,
-                        );
-                        self.fire_shell_hooks(
-                            HookEvent::PostToolCall,
-                            serde_json::json!({
-                                "session_id": hook_session,
-                                "tool_name": tc.function.name,
-                                "tool_call_id": tc.id,
-                                "success": success,
-                                "result": result,
-                                "requires_input": requires_input,
-                                "duration_ms": tool_elapsed_ms,
-                                "lua_vetoed": lua_vetoed,
-                            }),
-                        );
-                        let result = self
-                            .push_message_with_lua_hooks(
-                                &hook_session,
-                                ChatMessage::tool_result(&tc.id, result),
-                            )
-                            .and_then(|message| message.content_text().map(str::to_owned))
-                            .unwrap_or_default();
-                        self.trajectory
-                            .record_tool_result(&tc.function.name, &result);
-                        if requires_input {
-                            clarification = Some(result.clone());
-                        }
-                    }
+                    let clarification = self.process_tool_results(
+                        &hook_session,
+                        &effective_tool_calls,
+                        veto_reasons,
+                        executed_results,
+                        tool_elapsed_ms,
+                        false,
+                        |_| {},
+                    );
 
                     // Inject stuck-loop nudge if any tool failed too many times
                     self.maybe_inject_stuck_nudge();

--- a/crates/genesis-core/src/agent_loop/streaming.rs
+++ b/crates/genesis-core/src/agent_loop/streaming.rs
@@ -101,7 +101,6 @@ impl AgentLoop {
         // Reset stuck-loop state at the start of each new user turn so
         // stale failure counts from a previous turn don't cause false positives.
         self.tool_failure_counts.clear();
-        self.nudge_sent = false;
         self.tools.clear_recalled_memory_ids();
 
         let hook_session = self.session_id_str().to_owned();

--- a/crates/genesis-core/src/agent_loop/streaming.rs
+++ b/crates/genesis-core/src/agent_loop/streaming.rs
@@ -11,7 +11,6 @@ use super::tools::{execute_tool_calls_parallel, summarize_args};
 use super::types::{format_blocked_reasons, StreamEvent};
 use super::{AgentError, AgentLoop, AgentResult};
 use crate::hooks::HookEvent;
-use crate::sanitize;
 
 pub(crate) struct StreamUpdate {
     pub(crate) contents: Vec<String>,
@@ -628,82 +627,15 @@ impl AgentLoop {
                             let tool_exec_duration = tool_exec_start.elapsed();
                             let tool_exec_duration_ms = tool_exec_duration.as_millis() as u64;
 
-                            let mut clarification = None;
-                            let mut executed_results = executed_results.into_iter();
-                            for (tc, veto_reason) in tool_calls.iter().zip(veto_reasons.into_iter())
-                            {
-                                let lua_vetoed = veto_reason.is_some();
-                                let (mut result, requires_input) = match veto_reason {
-                                    Some(reason) => (
-                                        format!("Error: tool call blocked by Lua hook: {reason}"),
-                                        false,
-                                    ),
-                                    None => executed_results.next().expect(
-                                        "executed tool results should align with allowed calls",
-                                    ),
-                                };
-                                result = sanitize::sanitize_credentials(&result);
-                                if self.config.core_tools.is_some()
-                                    && tc.function.name == "find_tools"
-                                    && !result.starts_with("Error:")
-                                    && !result.starts_with("No tools")
-                                {
-                                    for line in result.lines() {
-                                        let trimmed = line.trim();
-                                        if let Some(rest) = trimmed.strip_prefix("**") {
-                                            if let Some(name_end) = rest.find("**") {
-                                                self.discover_tool(&rest[..name_end]);
-                                            }
-                                        }
-                                    }
-                                }
-                                let tool_success = !result.starts_with("Error:");
-                                let result =
-                                    self.run_lua_post_tool_call(&tc.function.name, &result);
-                                on_event(StreamEvent::ToolCallEnd {
-                                    name: &tc.function.name,
-                                    call_id: &tc.id,
-                                    duration_ms: tool_exec_duration_ms,
-                                    success: tool_success,
-                                });
-                                if !tool_success {
-                                    let count = self
-                                        .tool_failure_counts
-                                        .entry(tc.function.name.clone())
-                                        .or_insert(0);
-                                    *count += 1;
-                                } else {
-                                    self.tool_failure_counts.remove(&tc.function.name);
-                                }
-                                self.fire_shell_hooks(
-                                    HookEvent::PostToolCall,
-                                    serde_json::json!({
-                                        "session_id": hook_session,
-                                        "tool_name": tc.function.name,
-                                        "tool_call_id": tc.id,
-                                        "success": tool_success,
-                                        "result": result,
-                                        "requires_input": requires_input,
-                                        "streaming": false,
-                                        "lua_vetoed": lua_vetoed,
-                                    }),
-                                );
-                                let result = self
-                                    .push_message_with_lua_hooks(
-                                        &hook_session,
-                                        ChatMessage::tool_result(&tc.id, result),
-                                    )
-                                    .and_then(|message| message.content_text().map(str::to_owned))
-                                    .unwrap_or_default();
-                                self.trajectory
-                                    .record_tool_result(&tc.function.name, &result);
-                                if requires_input {
-                                    on_event(StreamEvent::ClarificationNeeded {
-                                        question: &result,
-                                    });
-                                    clarification = Some(result.clone());
-                                }
-                            }
+                            let clarification = self.process_tool_results(
+                                &hook_session,
+                                &tool_calls,
+                                veto_reasons,
+                                executed_results,
+                                tool_exec_duration_ms,
+                                false,
+                                &mut on_event,
+                            );
 
                             self.maybe_inject_stuck_nudge();
 

--- a/crates/genesis-core/src/agent_loop/streaming.rs
+++ b/crates/genesis-core/src/agent_loop/streaming.rs
@@ -460,86 +460,15 @@ impl AgentLoop {
                         let tool_exec_duration = tool_exec_start.elapsed();
 
                         let tool_exec_duration_ms = tool_exec_duration.as_millis() as u64;
-                        let mut clarification = None;
-                        let mut executed_results = executed_results.into_iter();
-                        for (tc, veto_reason) in
-                            streamed_tool_calls.iter().zip(veto_reasons.into_iter())
-                        {
-                            let lua_vetoed = veto_reason.is_some();
-                            let (mut result, requires_input) = match veto_reason {
-                                Some(reason) => (
-                                    format!("Error: tool call blocked by Lua hook: {reason}"),
-                                    false,
-                                ),
-                                None => executed_results.next().expect(
-                                    "executed tool results should align with allowed calls",
-                                ),
-                            };
-                            result = sanitize::sanitize_credentials(&result);
-                            // Extract discovered tool names from find_tools results
-                            // (only when core set filtering is active).
-                            if self.config.core_tools.is_some()
-                                && tc.function.name == "find_tools"
-                                && !result.starts_with("Error:")
-                                && !result.starts_with("No tools")
-                            {
-                                for line in result.lines() {
-                                    let trimmed = line.trim();
-                                    if let Some(rest) = trimmed.strip_prefix("**") {
-                                        if let Some(name_end) = rest.find("**") {
-                                            self.discover_tool(&rest[..name_end]);
-                                        }
-                                    }
-                                }
-                            }
-                            let tool_success = !result.starts_with("Error:");
-                            let result = self.run_lua_post_tool_call(&tc.function.name, &result);
-                            on_event(StreamEvent::ToolCallEnd {
-                                name: &tc.function.name,
-                                call_id: &tc.id,
-                                duration_ms: tool_exec_duration_ms,
-                                success: tool_success,
-                            });
-                            if !tool_success {
-                                let count = self
-                                    .tool_failure_counts
-                                    .entry(tc.function.name.clone())
-                                    .or_insert(0);
-                                *count += 1;
-                            } else {
-                                self.tool_failure_counts.remove(&tc.function.name);
-                                // Auto-discover tools called outside core set.
-                                if self.config.core_tools.is_some() {
-                                    self.discover_tool(&tc.function.name);
-                                }
-                            }
-                            self.fire_shell_hooks(
-                                HookEvent::PostToolCall,
-                                serde_json::json!({
-                                    "session_id": hook_session,
-                                    "tool_name": tc.function.name,
-                                    "tool_call_id": tc.id,
-                                    "success": tool_success,
-                                    "result": result,
-                                    "requires_input": requires_input,
-                                    "streaming": true,
-                                    "lua_vetoed": lua_vetoed,
-                                }),
-                            );
-                            let result = self
-                                .push_message_with_lua_hooks(
-                                    &hook_session,
-                                    ChatMessage::tool_result(&tc.id, result),
-                                )
-                                .and_then(|message| message.content_text().map(str::to_owned))
-                                .unwrap_or_default();
-                            self.trajectory
-                                .record_tool_result(&tc.function.name, &result);
-                            if requires_input {
-                                on_event(StreamEvent::ClarificationNeeded { question: &result });
-                                clarification = Some(result.clone());
-                            }
-                        }
+                        let clarification = self.process_tool_results(
+                            &hook_session,
+                            &streamed_tool_calls,
+                            veto_reasons,
+                            executed_results,
+                            tool_exec_duration_ms,
+                            true,
+                            &mut on_event,
+                        );
 
                         self.maybe_inject_stuck_nudge();
 

--- a/crates/genesis-core/src/agent_loop/tools.rs
+++ b/crates/genesis-core/src/agent_loop/tools.rs
@@ -9,6 +9,21 @@ use tracing::{debug, info, info_span, warn};
 use super::{AgentError, SubagentSpawner};
 use crate::ToolRuntime;
 
+/// Check whether a tool result string represents an error.
+///
+/// This is the single source of truth for the `"Error:"` convention used
+/// throughout the agent loop, trajectory scorer, and auto-tagger.
+/// Case-insensitive to handle tools that return `"error:"` lowercase.
+pub(crate) fn is_tool_error(content: &str) -> bool {
+    content.starts_with("Error:") || content.starts_with("error:")
+}
+
+/// Check whether a `find_tools` result indicates no matches.
+/// Used to avoid treating empty results as successful discovery.
+pub(crate) fn is_find_tools_empty(content: &str) -> bool {
+    content.starts_with("No tools")
+}
+
 /// Produce a short summary string (max ~40 chars) from a tool call's JSON
 /// arguments. Tries to show the first key-value pair; falls back to truncating
 /// the raw string.

--- a/crates/genesis-core/src/agent_loop/tools.rs
+++ b/crates/genesis-core/src/agent_loop/tools.rs
@@ -13,7 +13,7 @@ use crate::ToolRuntime;
 ///
 /// This is the single source of truth for the `"Error:"` convention used
 /// throughout the agent loop, trajectory scorer, and auto-tagger.
-/// Case-insensitive to handle tools that return `"error:"` lowercase.
+/// Handles both `"Error:"` (title-case) and `"error:"` (lowercase) prefixes.
 pub(crate) fn is_tool_error(content: &str) -> bool {
     content.starts_with("Error:") || content.starts_with("error:")
 }

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -773,6 +773,135 @@ impl<'a> SessionExecutionService<'a> {
         SessionStore::new(&self.loaded.config.storage.database_path)
     }
 
+    /// Build a fully-wired `ToolRuntime` for a single agent loop invocation.
+    ///
+    /// Attaches MCP, approval handler, terminal/sandbox backend, working
+    /// directory, Lua runtime, embedding provider, keyword enricher,
+    /// auto-consolidation threshold, cache watcher, and tool filter.
+    async fn wire_tool_runtime(
+        &self,
+        execution_context: &crate::ExecutionContext,
+        lua_runtime: &Option<Arc<LuaRuntime>>,
+    ) -> Result<ToolRuntime, SessionExecutionError> {
+        let mut tool_runtime = build_default_tool_runtime(execution_context);
+
+        // Attach MCP manager if we connected any servers at service creation
+        if let Some(mcp) = &self.mcp {
+            tool_runtime.set_mcp(Arc::clone(mcp));
+        }
+
+        // Attach interactive approval handler if configured
+        if let Some(handler) = &self.approval_handler {
+            tool_runtime.set_approval_handler(Arc::clone(handler));
+        }
+
+        // Set terminal backend if configured
+        if let Some(terminal) = &self.loaded.config.runtime.terminal {
+            tool_runtime.set_terminal_backend(terminal_config_to_backend(terminal));
+
+            // Wire up lifecycle-managed sandbox execution (persists across turns)
+            let components = self
+                .sandbox
+                .get_or_init(|| create_sandbox_components(self.loaded));
+            if let Some(c) = components {
+                let mut config = c.base_config.clone();
+                config.task_id = execution_context.plan.session_id.clone();
+                let executor: Arc<dyn genesis_tools::SandboxExecutor> =
+                    Arc::new(SandboxExecutorImpl {
+                        manager: c.manager.clone(),
+                        backend: c.backend.clone(),
+                        config,
+                    });
+                tool_runtime.set_sandbox_manager(executor);
+            }
+        }
+
+        // Set default working directory (worktree isolation)
+        if let Some(ref dir) = self.default_working_dir {
+            tool_runtime.set_default_working_dir(dir.clone());
+        }
+
+        // Attach Lua plugin runtime to tool runtime
+        if let Some(runtime) = lua_runtime {
+            tool_runtime.set_lua_runtime(Arc::clone(runtime));
+        }
+
+        // Wire embedding provider for auto-embed in memory tools
+        if let Some(ref config) = self.loaded.config.embedding {
+            match crate::embedding::EmbeddingProvider::from_config(config) {
+                Ok(provider) => {
+                    let model = provider.model().to_owned();
+                    let bridge: Arc<dyn genesis_tools::EmbeddingService> =
+                        Arc::new(EmbeddingServiceBridge {
+                            provider: Arc::new(provider),
+                            model,
+                        });
+                    tool_runtime.set_embedding_service(bridge);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to initialise embedding provider; memory dedup disabled");
+                }
+            }
+        }
+
+        // Wire LLM keyword enricher for richer memory keyword extraction
+        if self.loaded.config.memory.enrich_keywords {
+            match genesis_provider::client_from_config(
+                &self.loaded.config.provider.backend,
+                &self.loaded.config.provider.model,
+                self.loaded.config.provider.base_url.as_deref(),
+                self.loaded.config.provider.api_key_env.as_deref(),
+            )
+            .await
+            {
+                Ok(client) => {
+                    let enricher: Arc<dyn genesis_tools::KeywordEnricher> =
+                        Arc::new(KeywordEnricherBridge { client });
+                    tool_runtime.set_keyword_enricher(enricher);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to initialise keyword enricher; using simple extraction");
+                }
+            }
+        }
+
+        // Wire auto-consolidation threshold from memory config
+        tool_runtime.set_auto_consolidation_threshold(
+            self.loaded.config.memory.auto_consolidation_threshold,
+        );
+
+        // Start filesystem watcher for tool result cache.
+        // Uses the working directory (or worktree dir) as the watch root.
+        {
+            let watch_dir = self
+                .default_working_dir
+                .as_deref()
+                .map(std::path::Path::new)
+                .unwrap_or(std::path::Path::new("."));
+            tool_runtime.start_cache_watcher(watch_dir);
+        }
+
+        // Apply tool filter (allowlist/denylist)
+        if let Some(ref filter) = self.loaded.config.runtime.tool_filter {
+            let mut allowed: std::collections::HashSet<String> = if filter.allow.is_empty() {
+                tool_runtime
+                    .definitions_async()
+                    .await
+                    .into_iter()
+                    .map(|d| d.name)
+                    .collect()
+            } else {
+                filter.allow.iter().cloned().collect()
+            };
+            for denied in &filter.deny {
+                allowed.remove(denied);
+            }
+            tool_runtime.retain(&allowed);
+        }
+
+        Ok(tool_runtime)
+    }
+
     /// Build all provider clients (primary, tool-routing, fallback) for a
     /// single agent loop invocation.
     async fn build_provider_clients(&self) -> Result<ProviderClients, SessionExecutionError> {
@@ -863,43 +992,6 @@ impl<'a> SessionExecutionService<'a> {
     ) -> Result<AgentLoop, SessionExecutionError> {
         let execution_context =
             build_execution_context_from_loaded(self.loaded, session_id, platform);
-        let mut tool_runtime = build_default_tool_runtime(&execution_context);
-
-        // Attach MCP manager if we connected any servers at service creation
-        if let Some(mcp) = &self.mcp {
-            tool_runtime.set_mcp(Arc::clone(mcp));
-        }
-
-        // Attach interactive approval handler if configured
-        if let Some(handler) = &self.approval_handler {
-            tool_runtime.set_approval_handler(Arc::clone(handler));
-        }
-
-        // Set terminal backend if configured
-        if let Some(terminal) = &self.loaded.config.runtime.terminal {
-            tool_runtime.set_terminal_backend(terminal_config_to_backend(terminal));
-
-            // Wire up lifecycle-managed sandbox execution (persists across turns)
-            let components = self
-                .sandbox
-                .get_or_init(|| create_sandbox_components(self.loaded));
-            if let Some(c) = components {
-                let mut config = c.base_config.clone();
-                config.task_id = execution_context.plan.session_id.clone();
-                let executor: Arc<dyn genesis_tools::SandboxExecutor> =
-                    Arc::new(SandboxExecutorImpl {
-                        manager: c.manager.clone(),
-                        backend: c.backend.clone(),
-                        config,
-                    });
-                tool_runtime.set_sandbox_manager(executor);
-            }
-        }
-
-        // Set default working directory (worktree isolation)
-        if let Some(ref dir) = self.default_working_dir {
-            tool_runtime.set_default_working_dir(dir.clone());
-        }
 
         // Warm the Lua plugin runtime once per session so plugin state survives
         // across turns and later middleware can reuse the cached runtime.
@@ -907,82 +999,10 @@ impl<'a> SessionExecutionService<'a> {
             &execution_context.plan.session_id,
             execution_context.plan.platform.clone(),
         );
-        if let Some(runtime) = &lua_runtime {
-            tool_runtime.set_lua_runtime(Arc::clone(runtime));
-        }
 
-        // Wire embedding provider for auto-embed in memory tools
-        if let Some(ref config) = self.loaded.config.embedding {
-            match crate::embedding::EmbeddingProvider::from_config(config) {
-                Ok(provider) => {
-                    let model = provider.model().to_owned();
-                    let bridge: Arc<dyn genesis_tools::EmbeddingService> =
-                        Arc::new(EmbeddingServiceBridge {
-                            provider: Arc::new(provider),
-                            model,
-                        });
-                    tool_runtime.set_embedding_service(bridge);
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to initialise embedding provider; memory dedup disabled");
-                }
-            }
-        }
-
-        // Wire LLM keyword enricher for richer memory keyword extraction
-        if self.loaded.config.memory.enrich_keywords {
-            match genesis_provider::client_from_config(
-                &self.loaded.config.provider.backend,
-                &self.loaded.config.provider.model,
-                self.loaded.config.provider.base_url.as_deref(),
-                self.loaded.config.provider.api_key_env.as_deref(),
-            )
-            .await
-            {
-                Ok(client) => {
-                    let enricher: Arc<dyn genesis_tools::KeywordEnricher> =
-                        Arc::new(KeywordEnricherBridge { client });
-                    tool_runtime.set_keyword_enricher(enricher);
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "failed to initialise keyword enricher; using simple extraction");
-                }
-            }
-        }
-
-        // Wire auto-consolidation threshold from memory config
-        tool_runtime.set_auto_consolidation_threshold(
-            self.loaded.config.memory.auto_consolidation_threshold,
-        );
-
-        // Start filesystem watcher for tool result cache.
-        // Uses the working directory (or worktree dir) as the watch root.
-        {
-            let watch_dir = self
-                .default_working_dir
-                .as_deref()
-                .map(std::path::Path::new)
-                .unwrap_or(std::path::Path::new("."));
-            tool_runtime.start_cache_watcher(watch_dir);
-        }
-
-        // Apply tool filter (allowlist/denylist)
-        if let Some(ref filter) = self.loaded.config.runtime.tool_filter {
-            let mut allowed: std::collections::HashSet<String> = if filter.allow.is_empty() {
-                tool_runtime
-                    .definitions_async()
-                    .await
-                    .into_iter()
-                    .map(|d| d.name)
-                    .collect()
-            } else {
-                filter.allow.iter().cloned().collect()
-            };
-            for denied in &filter.deny {
-                allowed.remove(denied);
-            }
-            tool_runtime.retain(&allowed);
-        }
+        let tool_runtime = self
+            .wire_tool_runtime(&execution_context, &lua_runtime)
+            .await?;
 
         // Load skills, user model, project context, and relevant memories
         let db_path = &self.loaded.config.storage.database_path;

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -33,6 +33,16 @@ struct SandboxComponents {
     base_config: SandboxConfig,
 }
 
+/// Provider clients built for a single agent loop invocation.
+///
+/// Groups the primary LLM client, optional tool-routing client, and
+/// optional fallback clients so they can be constructed in one place.
+struct ProviderClients {
+    primary: genesis_provider::ChatClient,
+    tool_client: Option<genesis_provider::ChatClient>,
+    fallbacks: Vec<(genesis_provider::ChatClient, std::time::Duration)>,
+}
+
 /// Bridges the async `SandboxManager` into the sync `SandboxExecutor` trait.
 struct SandboxExecutorImpl {
     manager: Arc<SandboxManager>,
@@ -763,6 +773,87 @@ impl<'a> SessionExecutionService<'a> {
         SessionStore::new(&self.loaded.config.storage.database_path)
     }
 
+    /// Build all provider clients (primary, tool-routing, fallback) for a
+    /// single agent loop invocation.
+    async fn build_provider_clients(&self) -> Result<ProviderClients, SessionExecutionError> {
+        let (backend, model) = self.effective_provider_selection();
+        let cb_cfg = self.loaded.config.provider.circuit_breaker.as_ref();
+        let primary = genesis_provider::client_from_config_with_circuit_breaker(
+            backend,
+            model,
+            self.loaded.config.provider.base_url.as_deref(),
+            self.loaded.config.provider.api_key_env.as_deref(),
+            cb_cfg.map(|c| c.failure_threshold),
+            cb_cfg.map(|c| c.cooldown_secs),
+        )
+        .await?;
+        debug!(
+            provider_backend = %backend,
+            model = %model,
+            "built primary provider client"
+        );
+
+        // Optional tool-routing client
+        let tool_client = if let Some(tp) = &self.loaded.config.tool_provider {
+            let tp_cb = tp.circuit_breaker.as_ref();
+            let client = genesis_provider::client_from_config_with_circuit_breaker(
+                &tp.backend,
+                &tp.model,
+                tp.base_url.as_deref(),
+                tp.api_key_env.as_deref(),
+                tp_cb.map(|c| c.failure_threshold),
+                tp_cb.map(|c| c.cooldown_secs),
+            )
+            .await?;
+            debug!(
+                tool_provider_backend = %tp.backend,
+                tool_model = %tp.model,
+                "multi-provider routing enabled"
+            );
+            Some(client)
+        } else {
+            None
+        };
+
+        // Optional fallback clients for automatic failover
+        let fallbacks = if self.loaded.config.fallback_providers.is_empty() {
+            Vec::new()
+        } else {
+            use std::time::Duration;
+
+            let default_timeout = Duration::from_secs(30);
+            let mut fallbacks = Vec::new();
+            for fp in &self.loaded.config.fallback_providers {
+                let fb_cb = fp.circuit_breaker.as_ref();
+                let fb_client = genesis_provider::client_from_config_with_circuit_breaker(
+                    &fp.backend,
+                    &fp.model,
+                    fp.base_url.as_deref(),
+                    fp.api_key_env.as_deref(),
+                    fb_cb.map(|c| c.failure_threshold),
+                    fb_cb.map(|c| c.cooldown_secs),
+                )
+                .await?;
+                let timeout = fp
+                    .timeout_secs
+                    .map(Duration::from_secs)
+                    .unwrap_or(default_timeout);
+                fallbacks.push((fb_client, timeout));
+            }
+            debug!(
+                fallback_count = self.loaded.config.fallback_providers.len(),
+                "provider failover enabled"
+            );
+            fallbacks
+        };
+
+        Ok(ProviderClients {
+            primary,
+            tool_client,
+            fallbacks,
+        })
+    }
+
     async fn build_agent_loop(
         &self,
         session_id: String,
@@ -969,22 +1060,7 @@ impl<'a> SessionExecutionService<'a> {
             prompt_builder = prompt_builder.memories(m);
         }
         let system_prompt = prompt_builder.build();
-        let (backend, model) = self.effective_provider_selection();
-        let cb_cfg = self.loaded.config.provider.circuit_breaker.as_ref();
-        let client = genesis_provider::client_from_config_with_circuit_breaker(
-            backend,
-            model,
-            self.loaded.config.provider.base_url.as_deref(),
-            self.loaded.config.provider.api_key_env.as_deref(),
-            cb_cfg.map(|c| c.failure_threshold),
-            cb_cfg.map(|c| c.cooldown_secs),
-        )
-        .await?;
-        debug!(
-            provider_backend = %backend,
-            model = %model,
-            "built agent loop dependencies"
-        );
+        let clients = self.build_provider_clients().await?;
 
         let hook_runner = crate::hooks::HookRunner::default();
         let hooks: Arc<dyn crate::agent_loop::AgentHooks> =
@@ -1012,7 +1088,7 @@ impl<'a> SessionExecutionService<'a> {
 
         let subagent_tool_runtime = Arc::new(tool_runtime.clone());
         let mut agent = AgentLoop::with_history(
-            client,
+            clients.primary,
             tool_runtime,
             AgentLoopConfig {
                 system_prompt: Some(system_prompt),
@@ -1051,54 +1127,11 @@ impl<'a> SessionExecutionService<'a> {
             agent.set_lua_runtime(runtime);
         }
 
-        // Set up tool provider routing if configured
-        if let Some(tp) = &self.loaded.config.tool_provider {
-            let tp_cb = tp.circuit_breaker.as_ref();
-            let tool_client = genesis_provider::client_from_config_with_circuit_breaker(
-                &tp.backend,
-                &tp.model,
-                tp.base_url.as_deref(),
-                tp.api_key_env.as_deref(),
-                tp_cb.map(|c| c.failure_threshold),
-                tp_cb.map(|c| c.cooldown_secs),
-            )
-            .await?;
+        if let Some(tool_client) = clients.tool_client {
             agent.set_tool_client(tool_client);
-            debug!(
-                tool_provider_backend = %tp.backend,
-                tool_model = %tp.model,
-                "multi-provider routing enabled"
-            );
         }
-
-        // Set up fallback providers for automatic failover (sequential, config order).
-        if !self.loaded.config.fallback_providers.is_empty() {
-            use std::time::Duration;
-
-            let default_timeout = Duration::from_secs(30);
-            let mut fallbacks = Vec::new();
-            for fp in &self.loaded.config.fallback_providers {
-                let fb_cb = fp.circuit_breaker.as_ref();
-                let fb_client = genesis_provider::client_from_config_with_circuit_breaker(
-                    &fp.backend,
-                    &fp.model,
-                    fp.base_url.as_deref(),
-                    fp.api_key_env.as_deref(),
-                    fb_cb.map(|c| c.failure_threshold),
-                    fb_cb.map(|c| c.cooldown_secs),
-                )
-                .await?;
-                let timeout = fp
-                    .timeout_secs
-                    .map(Duration::from_secs)
-                    .unwrap_or(default_timeout);
-                fallbacks.push((fb_client, timeout));
-            }
-            agent.set_fallback_clients(fallbacks);
-            debug!(
-                fallback_count = self.loaded.config.fallback_providers.len(),
-                "provider failover enabled"
-            );
+        if !clients.fallbacks.is_empty() {
+            agent.set_fallback_clients(clients.fallbacks);
         }
 
         // Attach subagent spawner so agent can spawn parallel workstreams

--- a/crates/genesis-core/src/execution.rs
+++ b/crates/genesis-core/src/execution.rs
@@ -96,6 +96,55 @@ fn plugins_enabled(loaded: &LoadedConfig, overrides: PluginRuntimeOverrides) -> 
         .unwrap_or(loaded.config.plugins.enabled && !env_flag("GENESIS_NO_PLUGINS"))
 }
 
+/// Build the standard `config_values` map for a `LuaRuntimeConfig`.
+///
+/// Shared between `SessionExecutionService::lua_runtime_config` and
+/// `ExecutionSubagentSpawner::build_lua_runtime` to eliminate duplication.
+fn build_lua_config_values(
+    loaded: &LoadedConfig,
+    profile: &str,
+    backend: &str,
+    model: &str,
+    platform: &str,
+    plugins_enabled: bool,
+    personality: Option<&str>,
+) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+    values.insert("profile".to_owned(), profile.to_owned());
+    values.insert("provider_backend".to_owned(), backend.to_owned());
+    values.insert("provider_model".to_owned(), model.to_owned());
+    values.insert("delivery_platform".to_owned(), platform.to_owned());
+    values.insert("plugins_enabled".to_owned(), plugins_enabled.to_string());
+    values.insert(
+        "plugin_hook_timeout_ms".to_owned(),
+        loaded.config.plugins.hook_timeout_ms.to_string(),
+    );
+    values.insert(
+        "plugin_tool_timeout_ms".to_owned(),
+        loaded.config.plugins.tool_timeout_ms.to_string(),
+    );
+    values.insert(
+        "plugin_auto_disable_after".to_owned(),
+        loaded.config.plugins.auto_disable_after.to_string(),
+    );
+    values.insert(
+        "data_dir".to_owned(),
+        loaded.paths.data_dir.to_string_lossy().into_owned(),
+    );
+    values.insert(
+        "database_path".to_owned(),
+        loaded.paths.database_path.to_string_lossy().into_owned(),
+    );
+    values.insert(
+        "plugin_dir".to_owned(),
+        loaded.paths.plugin_dir.to_string_lossy().into_owned(),
+    );
+    if let Some(personality) = personality {
+        values.insert("personality".to_owned(), personality.to_owned());
+    }
+    values
+}
+
 /// Bridges the async `EmbeddingProvider` into the sync `EmbeddingService` trait.
 struct EmbeddingServiceBridge {
     provider: Arc<crate::embedding::EmbeddingProvider>,
@@ -449,55 +498,15 @@ impl<'a> SessionExecutionService<'a> {
     ) -> LuaRuntimeConfig {
         let cache_key = self.lua_runtime_cache_key(session_id, platform);
         let personality = cache_key.personality.clone();
-        let mut config_values = BTreeMap::new();
-        config_values.insert("profile".to_owned(), self.loaded.config.profile.clone());
-        config_values.insert(
-            "provider_backend".to_owned(),
-            cache_key.provider_backend.clone(),
+        let config_values = build_lua_config_values(
+            self.loaded,
+            &self.loaded.config.profile,
+            &cache_key.provider_backend,
+            &cache_key.provider_model,
+            &cache_key.delivery_platform,
+            self.plugins_enabled(),
+            personality.as_deref(),
         );
-        config_values.insert(
-            "provider_model".to_owned(),
-            cache_key.provider_model.clone(),
-        );
-        config_values.insert(
-            "delivery_platform".to_owned(),
-            cache_key.delivery_platform.clone(),
-        );
-        config_values.insert(
-            "plugins_enabled".to_owned(),
-            self.plugins_enabled().to_string(),
-        );
-        config_values.insert(
-            "plugin_hook_timeout_ms".to_owned(),
-            self.loaded.config.plugins.hook_timeout_ms.to_string(),
-        );
-        config_values.insert(
-            "plugin_tool_timeout_ms".to_owned(),
-            self.loaded.config.plugins.tool_timeout_ms.to_string(),
-        );
-        config_values.insert(
-            "plugin_auto_disable_after".to_owned(),
-            self.loaded.config.plugins.auto_disable_after.to_string(),
-        );
-        config_values.insert(
-            "data_dir".to_owned(),
-            self.loaded.paths.data_dir.to_string_lossy().into_owned(),
-        );
-        config_values.insert(
-            "database_path".to_owned(),
-            self.loaded
-                .paths
-                .database_path
-                .to_string_lossy()
-                .into_owned(),
-        );
-        config_values.insert(
-            "plugin_dir".to_owned(),
-            self.loaded.paths.plugin_dir.to_string_lossy().into_owned(),
-        );
-        if let Some(ref personality) = personality {
-            config_values.insert("personality".to_owned(), personality.clone());
-        }
 
         LuaRuntimeConfig {
             plugin_dir: self.loaded.paths.plugin_dir.clone(),
@@ -1502,7 +1511,8 @@ struct ExecutionSubagentSpawner {
 
 impl ExecutionSubagentSpawner {
     fn build_lua_runtime(&self, child_session_id: &str) -> Option<Arc<LuaRuntime>> {
-        if !plugins_enabled(self.loaded.as_ref(), self.plugin_runtime_overrides) {
+        let is_enabled = plugins_enabled(self.loaded.as_ref(), self.plugin_runtime_overrides);
+        if !is_enabled {
             return None;
         }
 
@@ -1514,42 +1524,14 @@ impl ExecutionSubagentSpawner {
             ),
         };
 
-        let mut config_values = BTreeMap::new();
-        config_values.insert("profile".to_owned(), self.loaded.config.profile.clone());
-        config_values.insert("provider_backend".to_owned(), backend.to_owned());
-        config_values.insert("provider_model".to_owned(), model.to_owned());
-        config_values.insert("delivery_platform".to_owned(), "cli".to_owned());
-        config_values.insert(
-            "plugins_enabled".to_owned(),
-            plugins_enabled(self.loaded.as_ref(), self.plugin_runtime_overrides).to_string(),
-        );
-        config_values.insert(
-            "plugin_hook_timeout_ms".to_owned(),
-            self.loaded.config.plugins.hook_timeout_ms.to_string(),
-        );
-        config_values.insert(
-            "plugin_tool_timeout_ms".to_owned(),
-            self.loaded.config.plugins.tool_timeout_ms.to_string(),
-        );
-        config_values.insert(
-            "plugin_auto_disable_after".to_owned(),
-            self.loaded.config.plugins.auto_disable_after.to_string(),
-        );
-        config_values.insert(
-            "data_dir".to_owned(),
-            self.loaded.paths.data_dir.to_string_lossy().into_owned(),
-        );
-        config_values.insert(
-            "database_path".to_owned(),
-            self.loaded
-                .paths
-                .database_path
-                .to_string_lossy()
-                .into_owned(),
-        );
-        config_values.insert(
-            "plugin_dir".to_owned(),
-            self.loaded.paths.plugin_dir.to_string_lossy().into_owned(),
+        let config_values = build_lua_config_values(
+            &self.loaded,
+            &self.loaded.config.profile,
+            backend,
+            model,
+            "cli",
+            is_enabled,
+            None,
         );
 
         let config = LuaRuntimeConfig {

--- a/crates/genesis-core/src/quality.rs
+++ b/crates/genesis-core/src/quality.rs
@@ -145,7 +145,7 @@ fn score_signal_to_noise(trajectory: &Trajectory, issues: &mut Vec<String>) -> f
             empty_steps += 1;
         }
         if let Some(result) = &step.tool_result {
-            if result.starts_with("Error:") || result.starts_with("error:") {
+            if crate::agent_loop::is_tool_error(result) {
                 error_steps += 1;
             }
         }
@@ -240,7 +240,7 @@ fn score_efficiency(trajectory: &Trajectory, issues: &mut Vec<String>) -> f64 {
             s.action_type == ActionType::ToolResult
                 && s.tool_result
                     .as_ref()
-                    .is_some_and(|r| r.starts_with("Error:") || r.starts_with("error:"))
+                    .is_some_and(|r| crate::agent_loop::is_tool_error(r))
         })
         .count();
 

--- a/crates/genesis-core/src/tagger.rs
+++ b/crates/genesis-core/src/tagger.rs
@@ -228,7 +228,7 @@ fn tag_by_content(trajectory: &Trajectory, tags: &mut HashSet<String>) {
         .filter(|s| {
             s.tool_result
                 .as_ref()
-                .is_some_and(|r| r.starts_with("Error:") || r.starts_with("error:"))
+                .is_some_and(|r| crate::agent_loop::is_tool_error(r))
         })
         .count();
 

--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -396,6 +396,10 @@ impl App {
                         let _ = self
                             .app_tx
                             .send(AppEvent::CopyToClipboard(text.to_string()));
+                        self.status_bar
+                            .show_transient_warning("\u{2713} Copied to clipboard");
+                    } else {
+                        self.status_bar.show_transient_warning("Nothing to copy");
                     }
                     self.frame_requester.schedule_frame();
                 }

--- a/crates/genesis-tui/src/app.rs
+++ b/crates/genesis-tui/src/app.rs
@@ -97,6 +97,9 @@ pub struct App {
     pub context_window_size: usize,
     /// Last known viewport width (used for transcript overlay).
     pub viewport_width: u16,
+    /// Whether mouse capture is active (true = scroll mode, false = select mode).
+    /// Toggled via Shift+M to allow terminal-native text selection.
+    pub mouse_captured: bool,
     /// Active tool approval overlay (shown when a tool needs user approval).
     pub approval: Option<crate::widgets::approval_overlay::ApprovalOverlay>,
     /// Channel to send approval responses back to the tool execution thread.
@@ -631,6 +634,25 @@ impl App {
             return;
         }
 
+        // Alt+M — toggle mouse capture (scroll mode vs select mode).
+        // When disabled, the terminal handles mouse events natively, allowing
+        // text selection in Alacritty, tmux, etc.
+        if key.code == KeyCode::Char('m') && key.modifiers.contains(KeyModifiers::ALT) {
+            self.mouse_captured = !self.mouse_captured;
+            if self.mouse_captured {
+                let _ =
+                    crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture);
+                self.status_bar.show_transient_warning("Mouse: scroll mode");
+            } else {
+                let _ =
+                    crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture);
+                self.status_bar
+                    .show_transient_warning("Mouse: select mode (Alt+M to restore scroll)");
+            }
+            self.frame_requester.schedule_frame();
+            return;
+        }
+
         // Ctrl+L — clear chat (same as /clear but via keyboard).
         if key.code == KeyCode::Char('l') && key.modifiers.contains(KeyModifiers::CONTROL) {
             self.chat = ChatWidget::new();
@@ -1038,6 +1060,7 @@ mod tests {
             streaming_chars: 0,
             context_window_size: 128_000,
             viewport_width: 80,
+            mouse_captured: true,
             approval: None,
             approval_response: None,
             approval_queue: std::collections::VecDeque::new(),

--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -362,6 +362,23 @@ impl ToolCell {
     /// Extract the first line of the output, truncated to `max_chars` characters.
     ///
     /// Returns `None` if there is no output or the first line is blank.
+    /// First non-blank line of output, truncated. Used as a brief preview
+    /// in Grouped mode for successful tools.
+    fn output_preview(&self, max_chars: usize) -> Option<String> {
+        let output = self.output.as_deref()?;
+        let first_line = output.lines().find(|l| !l.trim().is_empty())?;
+        let trimmed = first_line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if trimmed.chars().count() > max_chars {
+            let s: String = trimmed.chars().take(max_chars).collect();
+            Some(format!("{s}…"))
+        } else {
+            Some(trimmed.to_owned())
+        }
+    }
+
     fn error_context(&self, max_chars: usize) -> Option<String> {
         let output = self.output.as_deref()?;
         let first_line = output.lines().find(|l| !l.trim().is_empty())?;
@@ -431,7 +448,7 @@ impl ToolCell {
 
         lines.push(status_line);
 
-        // On failure, show a brief error reason (first line of output) if available.
+        // On failure, show a brief error reason; on success, show output preview.
         if !self.success {
             if let Some(reason) = self.error_context(60) {
                 let error_line = Line::from(vec![
@@ -444,6 +461,13 @@ impl ToolCell {
                 ]);
                 lines.push(error_line);
             }
+        } else if let Some(preview) = self.output_preview(55) {
+            let preview_line = Line::from(vec![
+                Span::styled("  │ ↳ ", Style::default().fg(UI_DIM)),
+                Span::styled(preview, Style::default().fg(Color::Rgb(120, 120, 120))),
+                Span::styled(" │", Style::default().fg(UI_DIM)),
+            ]);
+            lines.push(preview_line);
         }
 
         lines.push(bottom);
@@ -861,13 +885,26 @@ mod tests {
     }
 
     #[test]
-    fn grouped_success_with_output_no_error_context_line() {
+    fn grouped_success_with_output_shows_preview() {
         let cell = make_cell(true)
             .with_display_mode(ToolDisplayMode::Grouped)
             .with_output("some output");
         let lines = cell.to_scrollback_lines(80);
-        // success: error context is not shown even if there is output
-        assert_eq!(lines.len(), 4, "grouped success should remain 4 lines");
+        // Grouped success with output: top + content + status + preview + bottom = 5
+        assert_eq!(
+            lines.len(),
+            5,
+            "grouped success with output should be 5 lines (includes preview)"
+        );
+        let all_text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            all_text.contains("some output"),
+            "should show output preview: {all_text:?}"
+        );
     }
 
     #[test]
@@ -1011,11 +1048,11 @@ diff --git a/src/main.rs b/src/main.rs
             .with_display_mode(ToolDisplayMode::Grouped)
             .with_output("wrote 42 bytes to foo.txt");
         let lines = cell.to_scrollback_lines(80);
-        // Plain output should not expand — grouped mode uses per-category content only
+        // Grouped: top + content + status + output_preview + bottom = 5 lines
         assert_eq!(
             lines.len(),
-            4,
-            "grouped with plain output should be 4 lines"
+            5,
+            "grouped with plain output should be 5 lines (includes preview)"
         );
     }
 

--- a/crates/genesis-tui/src/history/tool_cell.rs
+++ b/crates/genesis-tui/src/history/tool_cell.rs
@@ -101,6 +101,17 @@ fn tool_category(name: &str) -> ToolCategory {
 /// Extract a file path from an args summary string.
 ///
 /// The summary typically looks like `path: "src/main.rs"` or just `src/main.rs`.
+/// Truncate a tool name to `max` characters with ellipsis if too long.
+/// MCP tool names can be very long (e.g. `mcp__plugin_playwright__browser_navigate`).
+fn truncate_tool_name(name: &str, max: usize) -> String {
+    if name.chars().count() <= max {
+        name.to_owned()
+    } else {
+        let truncated: String = name.chars().take(max - 1).collect();
+        format!("{truncated}\u{2026}") // …
+    }
+}
+
 fn extract_path(args_summary: &str) -> String {
     // Try to extract a quoted path first.
     if let Some(start) = args_summary.find('"') {
@@ -419,10 +430,12 @@ impl ToolCell {
         let (status_str, status_color) = self.status_str();
 
         // Top border: `  ┌─ tool_name ──...──┐`
+        // Truncate long tool names (MCP tools can be very long).
+        let display_name = truncate_tool_name(&self.tool_name, 40);
         let name_color = tool_color(&self.tool_name);
         let top = Line::from(vec![
             Span::styled("  ┌─ ", Style::default().fg(UI_DIM)),
-            Span::styled(self.tool_name.clone(), Style::default().fg(name_color)),
+            Span::styled(display_name.clone(), Style::default().fg(name_color)),
             Span::styled(" ─┐", Style::default().fg(UI_DIM)),
         ]);
 
@@ -439,7 +452,7 @@ impl ToolCell {
         ]);
 
         // Bottom border: `  └─ … ─┘` matching the top border width.
-        let fill_width = self.tool_name.width() + 2; // "─ " + name + " ─"
+        let fill_width = display_name.width() + 2; // "─ " + name + " ─"
         let bottom_fill = "─".repeat(fill_width);
         let bottom = Line::from(vec![Span::styled(
             format!("  └{}┘", bottom_fill),

--- a/crates/genesis-tui/src/lib.rs
+++ b/crates/genesis-tui/src/lib.rs
@@ -246,6 +246,7 @@ pub async fn run_tui(
         streaming_chars: 0,
         context_window_size,
         viewport_width: viewport_area.width,
+        mouse_captured: true,
         approval: None,
         approval_response: None,
         approval_queue: std::collections::VecDeque::new(),

--- a/crates/genesis-tui/src/render/markdown.rs
+++ b/crates/genesis-tui/src/render/markdown.rs
@@ -307,7 +307,8 @@ impl MarkdownWriter {
             Event::End(TagEnd::CodeBlock) => {
                 if let Some((lang, code)) = self.code_block.take() {
                     // Emit language label line if the fence specified a language.
-                    if !lang.is_empty() {
+                    let has_label = !lang.is_empty();
+                    if has_label {
                         self.emit_code_lang_label(&lang);
                     }
 
@@ -321,6 +322,16 @@ impl MarkdownWriter {
                         }
                     } else {
                         self.lines.extend(highlighted);
+                    }
+
+                    // Bottom separator to visually close the code block.
+                    if has_label {
+                        let mut bottom_spans = Vec::new();
+                        if self.blockquote_depth > 0 {
+                            bottom_spans.extend(blockquote_prefix(self.blockquote_depth));
+                        }
+                        bottom_spans.push(Span::styled("─".repeat(60), Style::default().fg(DIM)));
+                        self.lines.push(Line::from(bottom_spans));
                     }
                 }
             }
@@ -848,11 +859,13 @@ mod tests {
         let md = "```rust\nlet x = 42;\n```";
         let lines = markdown_to_lines(md);
         assert!(
-            !lines.is_empty(),
-            "code fence should produce at least one line"
+            lines.len() >= 3,
+            "code fence should produce label + code + separator, got {}",
+            lines.len()
         );
-        // Skip the first line (language label) — only code lines have CODE_BG.
-        for line in lines.iter().skip(1) {
+        // Skip the first line (language label) and last line (bottom separator) —
+        // only the code lines between them have CODE_BG.
+        for line in lines.iter().skip(1).take(lines.len() - 2) {
             for span in &line.spans {
                 assert_eq!(
                     span.style.bg,

--- a/crates/genesis-tui/src/widgets/chat_widget.rs
+++ b/crates/genesis-tui/src/widgets/chat_widget.rs
@@ -338,9 +338,9 @@ impl ChatWidget {
 
     /// Return styled lines for in-progress tool calls in the active cell.
     ///
-    /// Shows a single summary line for tool calls being executed, so the
-    /// user sees activity in the chat area during tool execution (not just
-    /// in the status bar).
+    /// Completed tools are collapsed into a compact summary line to avoid
+    /// filling the viewport when many tools run in a single turn. Only
+    /// currently-running tools are shown individually.
     fn active_tool_lines(&self) -> Vec<Line<'static>> {
         let cell = match &self.active_cell {
             Some(c) if !c.tool_calls.is_empty() => c,
@@ -349,29 +349,59 @@ impl ChatWidget {
         let dim = Style::default().fg(self.theme_dim);
         let accent = Style::default().fg(self.theme_accent);
         let ok_color = Style::default().fg(ratatui::style::Color::Rgb(100, 200, 100));
+        let fail_color = Style::default().fg(ratatui::style::Color::Rgb(200, 100, 100));
         let prefix_indent = "     "; // matches "eve> " width
 
-        let mut lines = Vec::new();
+        // Count completed vs running tools.
+        let mut done_ok = 0usize;
+        let mut done_fail = 0usize;
+        let mut total_dur = std::time::Duration::ZERO;
+        let mut running: Vec<&ActiveToolCall> = Vec::new();
+
         for tc in &cell.tool_calls {
-            let (icon, icon_style) = match tc.success {
-                Some(true) => ("\u{2713} ", ok_color), // ✓
-                Some(false) => (
-                    "\u{2717} ",
-                    Style::default().fg(ratatui::style::Color::Rgb(200, 100, 100)),
-                ),
-                None => ("\u{2022} ", accent), // • (running)
+            match tc.success {
+                Some(true) => {
+                    done_ok += 1;
+                    total_dur += tc.duration.unwrap_or_default();
+                }
+                Some(false) => {
+                    done_fail += 1;
+                    total_dur += tc.duration.unwrap_or_default();
+                }
+                None => running.push(tc),
+            }
+        }
+
+        let mut lines = Vec::new();
+
+        // Compact summary for completed tools (1 line max).
+        let done_total = done_ok + done_fail;
+        if done_total > 0 {
+            let dur_str = format!("{:.1}s", total_dur.as_secs_f64());
+            let (status, status_style) = if done_fail > 0 {
+                (format!("{done_fail} failed"), fail_color)
+            } else {
+                ("all ok".to_owned(), ok_color)
             };
-            let dur = tc
-                .duration
-                .map(|d| format!(" {:.1}s", d.as_secs_f64()))
-                .unwrap_or_default();
             lines.push(Line::from(vec![
                 Span::raw(prefix_indent.to_owned()),
-                Span::styled(icon.to_owned(), icon_style),
-                Span::styled(tc.tool_name.clone(), dim),
-                Span::styled(dur, dim),
+                Span::styled("\u{25b8} ", ok_color), // ▸
+                Span::styled(format!("{done_total} tool calls"), dim),
+                Span::styled(format!(" ({dur_str}, "), dim),
+                Span::styled(status, status_style),
+                Span::styled(")", dim),
             ]));
         }
+
+        // Individual lines for running tools.
+        for tc in running {
+            lines.push(Line::from(vec![
+                Span::raw(prefix_indent.to_owned()),
+                Span::styled("\u{2022} ", accent), // •
+                Span::styled(tc.tool_name.clone(), dim),
+            ]));
+        }
+
         lines
     }
 

--- a/crates/genesis-tui/src/widgets/command_popup.rs
+++ b/crates/genesis-tui/src/widgets/command_popup.rs
@@ -339,7 +339,7 @@ impl CommandPopup {
             let row_y = popup_y + 1 + row_idx as u16;
 
             // Build the row content as a Line and render it.
-            let line = build_item_line(cmd, is_selected, inner_width);
+            let line = build_item_line(cmd, is_selected, inner_width, &self.query);
             let mut x = popup_x + 1;
             for span in &line.spans {
                 let style = span.style;
@@ -386,7 +386,13 @@ impl Default for CommandPopup {
 ///
 /// Layout: `  /name      description…`
 /// Selected row has a coloured background and the `>` indicator.
-fn build_item_line(cmd: &CommandDef, is_selected: bool, inner_width: usize) -> Line<'static> {
+/// Matching query characters in the name are highlighted with bold.
+fn build_item_line(
+    cmd: &CommandDef,
+    is_selected: bool,
+    inner_width: usize,
+    query: &str,
+) -> Line<'static> {
     // Indicator: "> " for selected, "  " otherwise.
     let indicator = if is_selected { "> " } else { "  " };
 
@@ -398,19 +404,25 @@ fn build_item_line(cmd: &CommandDef, is_selected: bool, inner_width: usize) -> L
         Style::default().fg(INDICATOR_FG)
     };
 
-    let name = cmd.name;
-    // Fixed name column width. render() clamps popup_width >= 20, so
-    // inner_width is always >= 18 — no need for narrow-terminal shrinking.
     let name_col_width = 14usize;
-    let name_padded = format!("{:<width$}", name, width = name_col_width);
 
-    let name_style = if is_selected {
+    let name_base = if is_selected {
         Style::default()
             .fg(SELECTED_TEXT_FG)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(NAME_FG)
     };
+    let name_match = if is_selected {
+        name_base
+    } else {
+        Style::default()
+            .fg(SELECTED_TEXT_FG)
+            .add_modifier(Modifier::BOLD)
+    };
+
+    // Build name spans with match highlighting.
+    let name_spans = highlight_matches(cmd.name, query, name_col_width, name_base, name_match);
 
     let desc_style = if is_selected {
         Style::default().fg(SELECTED_TEXT_FG)
@@ -423,11 +435,86 @@ fn build_item_line(cmd: &CommandDef, is_selected: bool, inner_width: usize) -> L
     let desc_width = inner_width.saturating_sub(used);
     let desc = truncate_str(cmd.description, desc_width);
 
-    Line::from(vec![
-        Span::styled(indicator.to_owned(), indicator_style),
-        Span::styled(name_padded, name_style),
-        Span::styled(desc, desc_style),
-    ])
+    let mut spans = vec![Span::styled(indicator.to_owned(), indicator_style)];
+    spans.extend(name_spans);
+    spans.push(Span::styled(desc, desc_style));
+    Line::from(spans)
+}
+
+/// Highlight characters in `name` that match the `query` subsequence.
+/// Returns spans padded to `col_width`.
+fn highlight_matches(
+    name: &str,
+    query: &str,
+    col_width: usize,
+    base_style: Style,
+    match_style: Style,
+) -> Vec<Span<'static>> {
+    if query.is_empty() {
+        return vec![Span::styled(
+            format!("{:<width$}", name, width = col_width),
+            base_style,
+        )];
+    }
+
+    let name_lower = name.to_lowercase();
+    let query_lower = query.to_lowercase();
+
+    // Find match positions (greedy subsequence).
+    let mut match_positions = Vec::new();
+    let mut qi = 0;
+    let query_chars: Vec<char> = query_lower.chars().collect();
+    for (i, ch) in name_lower.chars().enumerate() {
+        if qi < query_chars.len() && ch == query_chars[qi] {
+            match_positions.push(i);
+            qi += 1;
+        }
+    }
+
+    let match_set: std::collections::HashSet<usize> = match_positions.into_iter().collect();
+    let mut spans = Vec::new();
+    let mut current = String::new();
+    let mut current_is_match = false;
+
+    for (i, ch) in name.chars().enumerate() {
+        let is_match = match_set.contains(&i);
+        if is_match != current_is_match && !current.is_empty() {
+            let style = if current_is_match {
+                match_style
+            } else {
+                base_style
+            };
+            spans.push(Span::styled(std::mem::take(&mut current), style));
+        }
+        current.push(ch);
+        current_is_match = is_match;
+    }
+
+    // Pad to column width.
+    let name_len = name.chars().count();
+    if name_len < col_width {
+        let padding = col_width - name_len;
+        if !current_is_match {
+            current.extend(std::iter::repeat_n(' ', padding));
+        } else {
+            // Flush current match span, then add padding as base.
+            if !current.is_empty() {
+                spans.push(Span::styled(std::mem::take(&mut current), match_style));
+            }
+            current = " ".repeat(padding);
+            current_is_match = false;
+        }
+    }
+    if !current.is_empty() {
+        let style = if current_is_match {
+            match_style
+        } else {
+            base_style
+        };
+        spans.push(Span::styled(current, style));
+    }
+
+    spans
 }
 
 /// Truncate a string to at most `max_chars` Unicode scalar values.

--- a/crates/genesis-tui/src/widgets/help_overlay.rs
+++ b/crates/genesis-tui/src/widgets/help_overlay.rs
@@ -105,6 +105,7 @@ impl HelpOverlay {
             ("Shift+Down", "Scroll chat down (1 line)"),
             ("Ctrl+End", "Jump to bottom of chat"),
             ("Up/Down", "Navigate input history / lines"),
+            ("Alt+M", "Toggle mouse: scroll ↔ select text"),
             ("Esc", "Close overlay / dismiss popup"),
         ];
 

--- a/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
+++ b/crates/genesis-tui/src/widgets/snapshots/genesis_tui__widgets__help_overlay__tests__snapshot_help_overlay.snap
@@ -36,6 +36,7 @@ expression: buffer_to_string(&buf)
   Shift+Down      Scroll chat down (1 line)                 
   Ctrl+End        Jump to bottom of chat                    
   Up/Down         Navigate input history / lines            
+  Alt+M           Toggle mouse: scroll ↔ select text        
   Esc             Close overlay / dismiss popup             
                                                             
   Slash Commands                                            
@@ -55,5 +56,4 @@ expression: buffer_to_string(&buf)
   Overlay Navigation                                        
   ─────────────────                                         
   j / Down        Scroll down one line                      
-  k / Up          Scroll up one line                        
-  Ctrl+D          Scroll down half page
+  k / Up          Scroll up one line

--- a/crates/genesis-tui/src/widgets/status_bar.rs
+++ b/crates/genesis-tui/src/widgets/status_bar.rs
@@ -529,8 +529,10 @@ impl StatusBarWidget {
             Color::Rgb(255, 100, 100) // red — critical
         } else if self.context_percent >= 75 {
             Color::Rgb(255, 200, 80) // yellow — warning
+        } else if self.context_percent <= 50 {
+            Color::Rgb(100, 200, 100) // green — healthy
         } else {
-            self.palette.dim
+            self.palette.dim // neutral (51-74%)
         };
         spans.push(Span::styled(ctx, Style::default().fg(ctx_color).bg(bg)));
 


### PR DESCRIPTION
## Summary

- **Unified tool result processing**: Extracted `process_tool_results()` method that replaces 3 copy-pasted ~80-line tool-result loops (blocking, streaming, streaming-fallback) with a single shared pipeline
- **Centralized error detection**: Added `is_tool_error()` / `is_find_tools_empty()` helpers replacing 9 scattered `starts_with("Error:")` string checks across agent loop, quality scorer, and tagger
- **Decomposed `build_agent_loop`**: Extracted `build_lua_config_values()`, `build_provider_clients()`, and `wire_tool_runtime()` — reducing the method from ~365 lines to ~120 lines

### Bug fixes

- **`hooks.on_tool_call_end()` missing in streaming paths** — the `AgentHooks` lifecycle callback was only firing in the blocking path, completely absent from both streaming code paths
- **`discover_tool()` missing in streaming-fallback** — successfully called tools outside the core set weren't being auto-discovered when the streaming path fell back to blocking
- **Dead `nudge_sent` field** — was set to `true` but never read as a guard (stuck-loop nudge was already correctly gated by `tool_failure_counts` reset)

### Stats

5 files changed, 335 insertions, 424 deletions (-89 net)

## Test plan

- [x] `cargo test -p genesis-core` — 768 tests passing
- [x] `cargo clippy -p genesis-core -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Verify streaming chat works end-to-end (tool calls, stuck-loop nudge, clarification)
- [ ] Verify blocking chat works end-to-end